### PR TITLE
feat(moe): support the fused gate+up expert layout (Gemma 4 MoE)

### DIFF
--- a/core/include/bmoe/recipe.h
+++ b/core/include/bmoe/recipe.h
@@ -1,7 +1,7 @@
 // MoE architecture recipes.
 //
 // A recipe is the ONLY architecture-specific knowledge in the engine: the gguf tensor
-// name suffixes of a layer's three expert projections. Everything else — routing, the
+// name suffixes of a layer's expert weight tensors. Everything else — routing, the
 // number of experts, the per-expert byte stride — is discovered at runtime from the
 // tensors themselves. Supporting a new MoE family is therefore one table row plus a
 // byte-identity gate run, never a code change in the streaming path.
@@ -11,13 +11,18 @@
 
 namespace bmoe {
 
-// The three expert weight tensors of a MoE layer, named `blk.<il>.<suffix>.weight` in
-// the gguf. Each is a 3-D tensor whose dim-2 indexes the expert (ne[2] == n_expert).
+// The expert weight tensors of a MoE layer, named `blk.<il>.<suffix>.weight` in the gguf.
+// A recipe lists the per-layer expert tensors as a suffix table: the common split layout
+// names three ({gate, up, down} projections), while architectures that fuse gate+up into
+// one tensor name two ({gate_up, down}). Unused slots are nullptr. Each named tensor is
+// 3-D and its dim-2 indexes the expert (ne[2] == n_expert); the engine streams whatever
+// the recipe names and never needs to know which projection a given tensor carries — a
+// fused gate_up is just an expert tensor with a larger per-expert stride, discovered at
+// runtime like any other.
 struct MoeRecipe {
-    const char * arch;             // gguf general.architecture, e.g. "qwen3moe"
-    const char * gate_exps_suffix; // e.g. "ffn_gate_exps"
-    const char * up_exps_suffix;   // e.g. "ffn_up_exps"
-    const char * down_exps_suffix; // e.g. "ffn_down_exps"
+    static constexpr int max_exps = 3;
+    const char * arch;                  // gguf general.architecture, e.g. "qwen3moe"
+    const char * exps_suffix[max_exps]; // e.g. {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}
 };
 
 // Look up a recipe by gguf architecture string. Returns nullptr if the architecture is

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -134,13 +134,24 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
         for (LayerExperts & L : layers) {
             if (!L.bound) continue;
             ++n_bound;
-            for (int p = 0; p < 3; ++p) {
+            // Require exactly the projections the recipe names (a fused layout names fewer
+            // than max_exps); a slot the recipe declares but that capture never bound means
+            // the gguf's layout does not match the recipe — refuse rather than guess.
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                if (!recipe->exps_suffix[p]) continue; // slot unused by this architecture
                 ggml_tensor * t = L.proj[p].tensor;
-                if (!t) return fail("captured layer is missing a projection tensor");
+                if (!t)
+                    return fail(std::string("captured MoE layer is missing expert tensor '") + recipe->exps_suffix[p] +
+                                "'");
                 auto it = offs.off_by_name.find(t->name);
                 if (it == offs.off_by_name.end()) return fail(std::string("no gguf offset for tensor ") + t->name);
                 L.proj[p].file_off = it->second;
-                if (n_expert == 0) n_expert = (int) t->ne[2];
+                const int ne2 = (int) t->ne[2];
+                if (n_expert == 0)
+                    n_expert = ne2;
+                else if (ne2 != n_expert)
+                    return fail(std::string("inconsistent expert count: tensor ") + t->name + " has " +
+                                std::to_string(ne2) + ", expected " + std::to_string(n_expert));
             }
         }
         if (n_bound == 0) return fail("no MoE expert tensors captured — is this a MoE model?");

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -4,19 +4,26 @@
 
 namespace bmoe {
 
-// The registry. v1 ships Qwen3 MoE (Qwen3-30B-A3B and siblings). Most llama.cpp MoE
-// models are built by the same build_moe_ffn helper and expose the identical
+// The registry. Ships Qwen3 MoE (Qwen3-30B-A3B and siblings). Most llama.cpp MoE models
+// are built by the same build_moe_ffn helper and expose the identical
 // `ffn_{gate,up,down}_exps` naming, so adding one is usually a single row here — see
-// docs/adding-a-model.md. Models that pack gate+up into one tensor (a merged
-// `ffn_gate_up_exps`) need a distinct recipe shape and are intentionally not claimed
-// by these rows.
+// docs/adding-a-model.md. Models that fuse gate+up into one tensor (a merged
+// `ffn_gate_up_exps`) name two expert tensors instead of three; that is still one row,
+// with the fused suffix in the first slot and a nullptr tail.
 static const MoeRecipe k_recipes[] = {
-    {"qwen3moe", "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"},
-    {"qwen2moe", "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"},
+    {"qwen3moe", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
+    {"qwen2moe", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
     // llada-moe is a diffusion MoE; the expert layout is standard, so expert streaming
     // applies mechanically. Note that its diffusion inference does not have the n=1
     // routing sparsity autoregressive decode relies on — see docs/limitations.md.
-    {"llada-moe", "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"},
+    {"llada-moe", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
+    // gemma4 (Gemma 4 MoE, e.g. 26B-A4B) fuses gate+up into blk.<il>.ffn_gate_up_exps —
+    // to the streamer just an expert tensor with a 2x per-expert stride. The per-expert
+    // ffn_down_exps.scale, the router (ffn_gate_inp.{weight,scale}) and the always-on
+    // shared expert (the layer's dense ffn_{gate,up,down}) match no suffix and stay mmap-
+    // resident; the resident shared expert lowers the streamed fraction — see
+    // docs/limitations.md.
+    {"gemma4", {"ffn_gate_up_exps", "ffn_down_exps", nullptr}},
 };
 
 static const int k_n_recipes = (int) (sizeof(k_recipes) / sizeof(k_recipes[0]));

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -35,24 +35,30 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
 
     // Largest full-tensor byte size per projection, over all bound layers → shared-slot
-    // and bounce sizing.
-    size_t max_full[3] = {0, 0, 0};
+    // and bounce sizing. Absent projection slots (a fused layout uses fewer than max_exps
+    // expert tensors) keep nb2 == 0, so their max_full stays 0 and they are skipped below.
+    size_t max_full[MoeRecipe::max_exps] = {0, 0, 0};
     for (const LayerExperts & L : layers_) {
         if (!L.bound) continue;
-        for (int p = 0; p < 3; ++p) {
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
             const size_t full = (size_t) L.proj[p].nb2 * (size_t) n_expert_;
             max_full[p] = std::max(max_full[p], full);
         }
     }
-    if (max_full[0] == 0) {
+    size_t max_full_any = 0;
+    for (int p = 0; p < MoeRecipe::max_exps; ++p)
+        max_full_any = std::max(max_full_any, max_full[p]);
+    if (max_full_any == 0) {
         std::fprintf(stderr, "bmoe: no MoE layers were bound\n");
         return false;
     }
 
     if (cache_max_ == 0) {
-        // Three shared slots reused across layers (one layer computes at a time). Rebind
-        // every bound layer's expert tensors onto them; only routed slices are ever valid.
-        for (int p = 0; p < 3; ++p) {
+        // One shared slot per present projection, reused across layers (one layer computes
+        // at a time). Rebind every bound layer's expert tensors onto them; only routed
+        // slices are ever valid. Absent slots (max_full[p] == 0) get no buffer.
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            if (max_full[p] == 0) continue;
             slot_[p] = pio::alloc_aligned(align_, max_full[p]);
             if (!slot_[p]) {
                 std::fprintf(stderr, "bmoe: slot alloc %zu failed\n", max_full[p]);
@@ -62,8 +68,8 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         }
         for (LayerExperts & L : layers_) {
             if (!L.bound) continue;
-            for (int p = 0; p < 3; ++p)
-                L.proj[p].tensor->data = slot_[p];
+            for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                if (L.proj[p].tensor) L.proj[p].tensor->data = slot_[p];
         }
     } else {
         // LRU cache: one reserved (address-only) buffer per (layer, projection). Physical
@@ -71,14 +77,15 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         // each expert at its canonical offset e*nb2 inside tensor->data, so the buffers
         // live at fixed per-layer addresses; lazy commit keeps that affordable.
         page_ = pio::vm_page();
-        for (int p = 0; p < 3; ++p) {
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
             lbuf_[p].assign(n_layer_, nullptr);
             lbuf_sz_[p].assign(n_layer_, 0);
         }
         for (int il = 0; il < n_layer_; ++il) {
             LayerExperts & L = layers_[il];
             if (!L.bound) continue;
-            for (int p = 0; p < 3; ++p) {
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                if (!L.proj[p].tensor) continue; // absent slot in a fused layout
                 const size_t full = (size_t) L.proj[p].nb2 * (size_t) n_expert_;
                 lbuf_[p][il] = pio::vm_reserve(full);
                 if (!lbuf_[p][il]) {
@@ -102,7 +109,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     }
 
     // Read pool: a private fd + bounce per lane so concurrent preads never contend.
-    const size_t max_slice = std::max({max_full[0], max_full[1], max_full[2]}) / (size_t) n_expert_;
+    const size_t max_slice = max_full_any / (size_t) n_expert_;
     const size_t bounce_cap = max_slice + 2 * align_;
 
     pio::fd_t primary = pio::open_read(gguf_path.c_str(), o_direct_);
@@ -136,7 +143,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     }
 
     seen_.assign(n_expert_, 0);
-    jobs_.reserve((size_t) n_expert_ * 3);
+    jobs_.reserve((size_t) n_expert_ * MoeRecipe::max_exps);
     batch_gen_ = 0;
     next_idx_ = 0;
     done_cnt_ = 0;
@@ -251,13 +258,17 @@ void ExpertStreamSource::lru_push_front(int32_t id) {
 }
 size_t ExpertStreamSource::entry_bytes(int il) const {
     const LayerExperts & L = layers_[il];
-    return (size_t) L.proj[0].nb2 + L.proj[1].nb2 + L.proj[2].nb2;
+    size_t bytes = 0;
+    for (int p = 0; p < MoeRecipe::max_exps; ++p)
+        bytes += (size_t) L.proj[p].nb2; // absent slots contribute 0
+    return bytes;
 }
 void ExpertStreamSource::evict_tail() {
     const int32_t id = ctail_;
     const int il = id / n_expert_, e = id % n_expert_;
-    for (int p = 0; p < 3; ++p) {
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
         const uint64_t slice = layers_[il].proj[p].nb2;
+        if (slice == 0) continue; // absent slot in a fused layout
         char * s = (char *) lbuf_[p][il] + (uint64_t) e * slice;
         uintptr_t a0 = ((uintptr_t) s + page_ - 1) & ~(uintptr_t) (page_ - 1);
         uintptr_t a1 = ((uintptr_t) s + slice) & ~(uintptr_t) (page_ - 1);
@@ -277,8 +288,9 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
 
     auto stage = [&](int e) -> bool {
         if (cache_max_ == 0) {
-            for (int p = 0; p < 3; ++p) {
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
                 const uint64_t slice = L.proj[p].nb2;
+                if (slice == 0) continue; // absent slot in a fused layout
                 jobs_.push_back(
                     {(char *) slot_[p] + (uint64_t) e * slice, L.proj[p].file_off + (uint64_t) e * slice, slice});
             }
@@ -293,8 +305,9 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
             lru_push_front(id);
             return true;
         }
-        for (int p = 0; p < 3; ++p) {
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
             const uint64_t slice = L.proj[p].nb2;
+            if (slice == 0) continue; // absent slot in a fused layout
             char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
             uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
             uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
@@ -381,12 +394,12 @@ void ExpertStreamSource::shutdown() {
         if (t.joinable()) t.join();
     io_pool_.clear();
 
-    for (int p = 0; p < 3; ++p)
+    for (int p = 0; p < MoeRecipe::max_exps; ++p)
         if (slot_[p]) {
             pio::aligned_free(slot_[p]);
             slot_[p] = nullptr;
         }
-    for (int p = 0; p < 3; ++p) {
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
         for (int il = 0; il < (int) lbuf_[p].size(); ++il)
             if (lbuf_[p][il]) pio::vm_release(lbuf_[p][il], lbuf_sz_[p][il]);
         lbuf_[p].clear();

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -1,8 +1,8 @@
 // Flash-backed expert streaming with an optional LRU cache.
 //
 // Ported from the original research streamer. One layer computes at a time, so with the
-// cache off the three expert projections share three heap slots (full n_expert size)
-// that every layer's tensors are rebound onto: only the routed slices are ever filled,
+// cache off the expert tensors share up to three heap slots (full n_expert size) that
+// every layer's tensors are rebound onto: only the routed slices are ever filled,
 // re-read fresh each token. With the cache on, each (layer, projection) gets its own
 // reserved-but-uncommitted address range; a routed expert already resident is a hit (no
 // read), a miss is read once and kept, and the coldest entries are evicted (pages
@@ -16,6 +16,7 @@
 
 #include "bmoe/expert_source.h"
 #include "bmoe/config.h"
+#include "bmoe/recipe.h"
 #include "../io/platform_io.h"
 
 #include <atomic>
@@ -37,10 +38,12 @@ struct ExpertTensorRef {
     uint64_t nb2 = 0;               // bytes per expert (== tensor->nb[2])
 };
 
-// The three projections {gate, up, down} of one MoE layer.
+// The expert weight tensors of one MoE layer, one per recipe suffix slot. The split
+// layout fills all three ({gate, up, down}); a fused-gate_up layout fills two and leaves
+// the tail slot empty (tensor == nullptr). Unbound layers (dense, or non-MoE) stay false.
 struct LayerExperts {
     bool bound = false;
-    ExpertTensorRef proj[3];
+    ExpertTensorRef proj[MoeRecipe::max_exps];
 };
 
 class ExpertStreamSource final : public IExpertSource {
@@ -91,14 +94,14 @@ private:
     std::vector<LayerExperts> layers_;
 
     // shared-slot mode (cache off): one full-size slot per projection, reused by layers
-    void * slot_[3] = {nullptr, nullptr, nullptr};
-    size_t slot_sz_[3] = {0, 0, 0};
+    void * slot_[MoeRecipe::max_exps] = {nullptr, nullptr, nullptr};
+    size_t slot_sz_[MoeRecipe::max_exps] = {0, 0, 0};
 
     // LRU mode (cache on): per-(layer, projection) reserved buffers
     size_t cache_max_ = 0;
     size_t page_ = 4096;
-    std::vector<void *> lbuf_[3];
-    std::vector<size_t> lbuf_sz_[3];
+    std::vector<void *> lbuf_[MoeRecipe::max_exps];
+    std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];
     std::vector<uint8_t> cvalid_;
     std::vector<int32_t> cprev_, cnext_;
     std::vector<uint32_t> cstamp_;

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -11,17 +11,21 @@ RouterHook::RouterHook(const MoeRecipe & recipe, int n_layer) : recipe_(recipe),
     captured_.assign(n_layer_ > 0 ? n_layer_ : 0, LayerExperts{});
 }
 
-// Match a tensor name of the form "blk.<il>.<suffix>.weight" against the recipe's three
-// expert projections. Returns the projection index (0=gate,1=up,2=down) and layer, or -1.
+// Match a tensor name of the form "blk.<il>.<suffix>.weight" against the recipe's expert
+// tensor suffixes. Returns the slot index (its position in recipe.exps_suffix) and layer,
+// or -1. The exact ".weight" tail comparison is load-bearing: a companion tensor like
+// "ffn_down_exps.scale" prefix-matches its suffix but fails the tail strcmp, so per-expert
+// scales — and every other non-".weight" tensor — are left mmap-resident, not streamed.
 static int match_expert(const char * name, const MoeRecipe & r, int & il_out) {
     int il = -1;
     int consumed = 0;
     if (std::sscanf(name, "blk.%d.%n", &il, &consumed) != 1 || il < 0) return -1;
     const char * rest = name + consumed; // "<suffix>.weight"
-    const char * suffixes[3] = {r.gate_exps_suffix, r.up_exps_suffix, r.down_exps_suffix};
-    for (int p = 0; p < 3; ++p) {
-        const size_t sl = std::strlen(suffixes[p]);
-        if (std::strncmp(rest, suffixes[p], sl) == 0 && std::strcmp(rest + sl, ".weight") == 0) {
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+        const char * suffix = r.exps_suffix[p];
+        if (!suffix) continue; // unused slot (fewer than max_exps expert tensors)
+        const size_t sl = std::strlen(suffix);
+        if (std::strncmp(rest, suffix, sl) == 0 && std::strcmp(rest + sl, ".weight") == 0) {
             il_out = il;
             return p;
         }

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -48,7 +48,7 @@ private:
 
     // Stored by value, not by reference: the caller often constructs us from a temporary
     // (a `cond ? *ptr : MoeRecipe{}` ternary yields a prvalue even when ptr is non-null),
-    // which would leave a reference member dangling. The struct is just three string
+    // which would leave a reference member dangling. The struct is just a handful of string
     // literal pointers, so copying is cheap and keeps the suffixes valid for our lifetime.
     MoeRecipe recipe_;
     int n_layer_ = 0;

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -10,32 +10,42 @@ In `core/src/moe/arch_registry.cpp`:
 
 ```cpp
 static const MoeRecipe k_recipes[] = {
-    { "qwen3moe", "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps" },
-    { "your_arch", "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps" },  // <-- new
+    { "qwen3moe", { "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps" } },
+    { "your_arch", { "ffn_gate_exps", "ffn_up_exps", "ffn_down_exps" } },  // <-- new
 };
 ```
 
-`arch` is the gguf `general.architecture` string. The three suffixes are the tensor names
-without the `blk.<il>.` prefix and `.weight` suffix.
+`arch` is the gguf `general.architecture` string. `exps_suffix` lists the layer's expert
+weight tensors — the names without the `blk.<il>.` prefix and `.weight` suffix. The common
+split layout names three ({gate, up, down}); leave a trailing slot `nullptr` for layouts
+with fewer (see the fused case below). The engine discovers the expert count and per-expert
+stride at runtime, so a recipe is only these names.
 
 ## 2. Run the gates
 
-Generate a tiny model for your architecture (adapt `scripts/make-tiny-moe.py`) and run:
+Generate a tiny model for your architecture and run its gate:
 
 ```bash
+# scripts/make-tiny-moe.py --arch <arch> emits a synthetic model for that layout;
+# tests/CMakeLists.txt wires one generate-fixture + gate per arch it knows.
 cd build && ctest -R moe_gates --output-on-failure
 ```
 
-If G1 (streamed == resident) passes, the architecture streams losslessly.
+If G1 (streamed == resident) passes, the architecture streams losslessly. For a layout
+`make-tiny-moe.py` does not yet emit, either teach it that arch (preferred — permanent CI
+coverage) or validate the recipe against a real model, as was done for `llada-moe`.
 
 ## When one row is not enough
 
-Some models **pack gate and up into a single tensor** (`ffn_gate_up_exps`) instead of two.
-The current recipe shape assumes three separate projections, and the engine will refuse
-such a model rather than stream it incorrectly. Supporting the merged layout needs a
-distinct recipe variant and a small change in `expert_stream_source` to treat the packed
-tensor as two logical projections — contributions welcome.
+Some models **pack gate and up into a single tensor** (`ffn_gate_up_exps`) instead of two —
+`gemma4` (Gemma 4 MoE) is one. This is still a single row: put the fused suffix first and
+leave the tail `nullptr`, because to the streamer a fused `gate_up` is just an expert tensor
+with a larger per-expert stride, discovered at runtime like any other.
+
+```cpp
+    { "gemma4", { "ffn_gate_up_exps", "ffn_down_exps", nullptr } },
+```
 
 Models with **shared/always-on experts** (a dense expert applied to every token, as in
-DeepSeek and some Qwen variants) work, but the shared expert stays resident and reduces
-the streaming saving proportionally. Note it in the model's entry when you add one.
+`gemma4`, DeepSeek and some Qwen variants) work, but the shared expert stays resident and
+reduces the streaming saving proportionally. Note it in the model's entry when you add one.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -23,8 +23,10 @@ expert-selective streaming that stays lossless and requires no fork.
 - **CPU experts.** Streamed experts are computed on CPU; the rebind targets host memory.
   GPU offload of the streamed experts is not supported (the dense parts can still use the
   GPU). Decode is flash-I/O-bound anyway, so this is rarely the bottleneck.
-- **Three separate projections.** Models that pack gate+up into one expert tensor are not
-  yet supported (see [adding-a-model.md](adding-a-model.md)).
+- **Shared experts stay resident.** Architectures with an always-on shared expert (e.g.
+  `gemma4`) stream the routed experts but keep the shared expert — and any dense layers —
+  mmap-resident, so the streamed fraction (and the memory saving) is smaller than for a
+  purely routed model like `qwen3moe`.
 - **Repack must stay off.** Loading uses `use_extra_bufts=false`; you cannot combine
   streaming with weight repacking.
 - **Windows throughput.** The cache's reserve-then-commit-per-slice path is heavier on

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,8 +20,10 @@ large share of the I/O. Requires a routing predictor or speculative prefetch.
 
 ## More architectures
 
-Beyond `qwen3moe`: other `build_moe_ffn` models (one recipe row each), then the merged
-`ffn_gate_up_exps` layout and shared-expert models. See
+Beyond `qwen3moe`: other `build_moe_ffn` models are one recipe row each. The merged
+`ffn_gate_up_exps` layout and shared-expert models are supported too (`gemma4` / Gemma 4
+MoE exercises both). Remaining frontier: architectures whose routing node is not the shared
+`ffn_moe_topk` (e.g. custom gating), which the capture/stream hook would need to learn. See
 [adding-a-model.md](adding-a-model.md).
 
 ## Expert quantization on the fly

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -18,10 +18,11 @@ updated.
 We use both phases:
 
 **Capture phase** (one warm-up decode). `ask` is called for every node, so we scan each
-node's `src[]` for expert weight tensors (`blk.<il>.ffn_{gate,up,down}_exps.weight`) and
-record the live `ggml_tensor*`. We return false throughout — capture observes, it does not
-isolate. `ggml_tensor` is a public struct, so reading `->name`, `->ne`, `->nb` and writing
-`->data` is public API surface.
+node's `src[]` for expert weight tensors (`blk.<il>.<suffix>.weight`, where the suffixes
+come from the arch's recipe — `ffn_{gate,up,down}_exps` for the split layout, a fused
+`ffn_gate_up_exps` for others) and record the live `ggml_tensor*`. We return false
+throughout — capture observes, it does not isolate. `ggml_tensor` is a public struct, so
+reading `->name`, `->ne`, `->nb` and writing `->data` is public API surface.
 
 **Stream phase** (real generation). We return true only for `ffn_moe_topk-<il>`. The
 non-ask callback then hands us that node with the selected expert ids materialized; we
@@ -51,6 +52,14 @@ cd third_party/llama.cpp && git fetch && git checkout <newer-tag>
 cd ../.. && git add third_party/llama.cpp && scripts/build-host.sh
 cd build && ctest --output-on-failure     # gates must stay green
 ```
+
+Most bumps are exactly this: update, rebuild, gates green. The fragility is not the public
+API but the *internal naming conventions* the seam attaches to — the tensor suffixes and
+the `ffn_moe_topk` node name are how llama.cpp happens to build MoE graphs today, not a
+guaranteed contract, so upstream can rename or restructure them (Gemma 4's fused
+`ffn_gate_up_exps` is one such evolution we absorbed with a recipe row). The gates are the
+enforcement: a rename breaks byte-identity before merge instead of silently corrupting
+output. Each supported architecture adds one more gate to keep green across a bump.
 
 If a future release moves the two hooks (a stable expert-residency API, say) upstream,
 this seam shrinks further or disappears — `core/` does not change.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -12,8 +12,7 @@ data class AppSettings(
     val threads: Int = 4,        // compute threads (-t); 4 is the measured optimum
     val nPredict: Int = 48,
     val oDirect: Boolean = true, // bypass the page cache
-    val chatml: Boolean = true,  // wrap the prompt in a ChatML turn
-    val thinking: Boolean = true,// Qwen3 reasoning; off appends the /no_think soft switch
+    val thinking: Boolean = false,// Qwen3 reasoning; off appends the /no_think soft switch
     val loadAll: Boolean = false,// debug: read ALL experts each token (A/B baseline)
 ) {
     /** Build the bmoe-cli argument list. Thinking is toggled with Qwen3's /no_think switch. */
@@ -30,7 +29,6 @@ data class AppSettings(
             "--io-threads", ioThreads.toString(),
             "--progress",
         )
-        if (chatml) a += "--chatml"
         if (!oDirect) a += "--no-odirect"
         if (loadAll) a += "--load-all"
         return a
@@ -39,7 +37,7 @@ data class AppSettings(
     fun save(ctx: Context) {
         ctx.prefs().edit()
             .putInt("cacheMb", cacheMb).putInt("ioThreads", ioThreads).putInt("threads", threads)
-            .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect).putBoolean("chatml", chatml)
+            .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
             .putBoolean("thinking", thinking).putBoolean("loadAll", loadAll)
             .apply()
     }
@@ -61,7 +59,6 @@ data class AppSettings(
                 threads = p.getInt("threads", d.threads),
                 nPredict = p.getInt("nPredict", d.nPredict),
                 oDirect = p.getBoolean("oDirect", d.oDirect),
-                chatml = p.getBoolean("chatml", d.chatml),
                 thinking = p.getBoolean("thinking", d.thinking),
                 loadAll = p.getBoolean("loadAll", d.loadAll),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -190,6 +190,16 @@ private fun MainScreen(settings: AppSettings, onOpenSettings: () -> Unit) {
             fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
+        if (ui.loading) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                Text("Loading model…", fontSize = 14.sp)
+            }
+        }
+
         TelemetryCard(ui)
 
         if (ui.answer.isNotEmpty()) {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -22,9 +22,16 @@ object ModelManager {
     private val MOE_MARKER = "ffn_down_exps".toByteArray(Charsets.US_ASCII)
     private const val PROBE_BYTES = 16 * 1024 * 1024
 
+    // A gguf larger than the free space on shared storage cannot be copied there, but it can
+    // still be adb-pushed to /data/local/tmp (same physical partition, no duplicate needed) and
+    // read in place: the path is world-traversable and the file world-readable, so the app's
+    // untrusted_app domain can open it. Scanned in addition to shared storage for that case.
+    private val TMP_MODEL_DIR = File("/data/local/tmp/shardllm")
+
     private fun scanDirs(ctx: Context): List<File> = buildList {
         Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.let { add(it) }
         ctx.getExternalFilesDir(null)?.let { add(it) }
+        if (TMP_MODEL_DIR.isDirectory) add(TMP_MODEL_DIR)
     }
 
     private fun allGguf(ctx: Context): List<File> =

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.update
 /** Immutable snapshot of a run, observed by the Compose UI. */
 data class UiState(
     val running: Boolean = false,
+    val loading: Boolean = false, // model started, first token not yet emitted
     val telemetry: Telemetry = Telemetry(),
     val answer: String = "",
     val summary: String = "",
@@ -24,6 +25,8 @@ object RunBus {
     val state: StateFlow<UiState> = _state.asStateFlow()
 
     fun reset() = _state.update { UiState(running = it.running) }
-    fun setRunning(running: Boolean) = _state.update { it.copy(running = running) }
+    fun setRunning(running: Boolean) =
+        _state.update { it.copy(running = running, loading = if (running) it.loading else false) }
+    fun setLoading(loading: Boolean) = _state.update { it.copy(loading = loading) }
     fun update(block: (UiState) -> UiState) = _state.update(block)
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -39,6 +39,7 @@ class RunService : Service() {
 
         RunBus.reset()
         RunBus.setRunning(true)
+        RunBus.setLoading(true) // held until the first token arrives (model load + prompt eval)
 
         wake = (getSystemService(Context.POWER_SERVICE) as PowerManager)
             .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "bmoe:gen").apply { acquire(30 * 60 * 1000L) }
@@ -70,6 +71,7 @@ class RunService : Service() {
                     if (telemetry.onLine(line)) {
                         RunBus.update {
                             it.copy(
+                                loading = false, // first telemetry line means the model is up
                                 telemetry = telemetry.current.copy(),
                                 summary = telemetry.summary,
                                 answer = telemetry.current.text,

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -72,10 +72,6 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     "Thinking", "Qwen3 reasoning; off appends the /no_think switch",
                     current.thinking,
                 ) { onChange(current.copy(thinking = it)) }
-                SwitchRow(
-                    "ChatML template", "Wrap the prompt in a chat turn",
-                    current.chatml,
-                ) { onChange(current.copy(chatml = it)) }
             }
 
             Section("Debug") {

--- a/scripts/make-tiny-moe.py
+++ b/scripts/make-tiny-moe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a tiny random-weight qwen3moe gguf for the byte-identity gates.
+"""Generate a tiny random-weight MoE gguf for the byte-identity gates.
 
 The gates compare STREAMED-experts output against FULL-RESIDENT output of the SAME
 file, so random weights are fine — quality is irrelevant, only that routing is a valid
@@ -7,9 +7,18 @@ top-k distribution (argsort of random logits) and that llama.cpp loads the model
 MoE. The model is deliberately multi-layer with a few experts so the LRU cache path
 sees real evictions on a small budget.
 
+Two architectures are emitted, selected with --arch:
+
+  qwen3moe  split expert layout — three tensors per layer
+            (ffn_gate_exps / ffn_up_exps / ffn_down_exps).
+  gemma4    fused gate+up layout — two expert tensors per layer
+            (ffn_gate_up_exps / ffn_down_exps), plus a resident shared expert and an
+            interleaved dense layer, so the gates cover the fused streaming path.
+
 Requires: pip install gguf numpy
 
-    python scripts/make-tiny-moe.py --out tiny-moe.gguf
+    python scripts/make-tiny-moe.py --arch qwen3moe --out tiny-moe.gguf
+    python scripts/make-tiny-moe.py --arch gemma4   --out tiny-moe-gemma4.gguf
 """
 import argparse
 import numpy as np
@@ -54,16 +63,92 @@ def rnd(*shape, seed):
     return g.standard_normal(shape).astype(np.float32) * 0.02
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--out", default="tiny-moe.gguf")
-    args = ap.parse_args()
+def add_tokenizer(w, tokens, scores, toktypes):
+    w.add_tokenizer_model("llama")
+    w.add_tokenizer_pre("default")
+    w.add_token_list(tokens)
+    w.add_token_scores(scores)
+    w.add_token_types(toktypes)
+    w.add_unk_token_id(0)
+    w.add_bos_token_id(1)
+    w.add_eos_token_id(2)
+    w.add_add_bos_token(True)
+    w.add_add_eos_token(False)
 
+
+def add_attn_tensors(w, p, s):
+    """Attention block shared by both architectures (numpy shapes are ggml dims reversed)."""
+    w.add_tensor(p + "attn_q.weight",      rnd(N_EMBD_HEAD * N_HEAD, N_EMBD, seed=s + 1))
+    w.add_tensor(p + "attn_k.weight",      rnd(N_EMBD_GQA, N_EMBD, seed=s + 2))
+    w.add_tensor(p + "attn_v.weight",      rnd(N_EMBD_GQA, N_EMBD, seed=s + 3))
+    w.add_tensor(p + "attn_output.weight", rnd(N_EMBD, N_EMBD_HEAD * N_HEAD, seed=s + 4))
+    w.add_tensor(p + "attn_q_norm.weight", rnd(N_EMBD_HEAD, seed=s + 5))
+    w.add_tensor(p + "attn_k_norm.weight", rnd(N_EMBD_HEAD, seed=s + 6))
+
+
+# --- qwen3moe: split expert layout -------------------------------------------------
+def build_qwen3moe(out):
     tokens, scores, toktypes = build_vocab()
     n_vocab = len(tokens)
 
-    w = gguf.GGUFWriter(args.out, "qwen3moe")
+    w = gguf.GGUFWriter(out, "qwen3moe")
+    w.add_name("tiny-moe")
+    w.add_context_length(N_CTX)
+    w.add_embedding_length(N_EMBD)
+    w.add_block_count(N_LAYER)
+    w.add_feed_forward_length(N_FF)
+    w.add_head_count(N_HEAD)
+    w.add_head_count_kv(N_HEAD_KV)
+    w.add_key_length(N_EMBD_HEAD)
+    w.add_value_length(N_EMBD_HEAD)
+    w.add_rope_freq_base(ROPE_BASE)
+    w.add_layer_norm_rms_eps(RMS_EPS)
+    w.add_expert_count(N_EXPERT)
+    w.add_expert_used_count(N_EXPERT_USED)
+    w.add_expert_feed_forward_length(N_FF_EXP)
+    w.add_file_type(gguf.LlamaFileType.ALL_F32)
+    add_tokenizer(w, tokens, scores, toktypes)
 
+    w.add_tensor("token_embd.weight",  rnd(n_vocab, N_EMBD, seed=1))
+    w.add_tensor("output_norm.weight", rnd(N_EMBD, seed=2))
+    w.add_tensor("output.weight",      rnd(n_vocab, N_EMBD, seed=3))
+
+    s = 100
+    for i in range(N_LAYER):
+        p = f"blk.{i}."
+        w.add_tensor(p + "attn_norm.weight", rnd(N_EMBD, seed=s + 0))
+        add_attn_tensors(w, p, s)
+        w.add_tensor(p + "ffn_norm.weight",     rnd(N_EMBD, seed=s + 7))
+        w.add_tensor(p + "ffn_gate_inp.weight", rnd(N_EXPERT, N_EMBD, seed=s + 8))
+        # experts: dim-2 (numpy axis 0) indexes the expert
+        w.add_tensor(p + "ffn_gate_exps.weight", rnd(N_EXPERT, N_FF_EXP, N_EMBD, seed=s + 9))
+        w.add_tensor(p + "ffn_down_exps.weight", rnd(N_EXPERT, N_EMBD, N_FF_EXP, seed=s + 10))
+        w.add_tensor(p + "ffn_up_exps.weight",   rnd(N_EXPERT, N_FF_EXP, N_EMBD, seed=s + 11))
+        s += 100
+
+    w.write_header_to_file()
+    w.write_kv_data_to_file()
+    w.write_tensors_to_file()
+    w.close()
+    print(f"wrote {out}: qwen3moe, {N_LAYER} layers, {N_EXPERT} experts "
+          f"(top-{N_EXPERT_USED}), vocab {n_vocab}")
+
+
+# --- gemma4: fused gate+up layout --------------------------------------------------
+# Gemma 4 MoE packs gate+up into one expert tensor (ffn_gate_up_exps) and keeps an
+# always-on shared expert (the layer's dense ffn_{gate,up,down}). We interleave one dense
+# layer (no ffn_gate_inp) and make one layer full-attention (the rest sliding-window) so
+# the fixture covers dense/MoE interleaving and the mixed SWA KV cache. Only the two
+# expert weight tensors stream; the shared expert, router and gate_inp.scale stay resident.
+DENSE_LAYER = 0            # a dense (non-MoE) layer, to exercise interleaving
+FULL_ATTN_LAYER = 2        # the one non-SWA layer (rest are sliding-window)
+
+
+def build_gemma4(out):
+    tokens, scores, toktypes = build_vocab()
+    n_vocab = len(tokens)
+
+    w = gguf.GGUFWriter(out, "gemma4")
     w.add_name("tiny-moe")
     w.add_context_length(N_CTX)
     w.add_embedding_length(N_EMBD)
@@ -80,47 +165,70 @@ def main():
     w.add_expert_feed_forward_length(N_FF_EXP)
     w.add_file_type(gguf.LlamaFileType.ALL_F32)
 
-    # tokenizer
-    w.add_tokenizer_model("llama")
-    w.add_tokenizer_pre("default")
-    w.add_token_list(tokens)
-    w.add_token_scores(scores)
-    w.add_token_types(toktypes)
-    w.add_unk_token_id(0)
-    w.add_bos_token_id(1)
-    w.add_eos_token_id(2)
-    w.add_add_bos_token(True)
-    w.add_add_eos_token(False)
+    # gemma4-specific hparams. One full-attention layer, the rest sliding-window; SWA head
+    # dims equal the global ones so every layer shares the same shape. Per-layer input
+    # embeddings are disabled (length 0) to keep the tensor set minimal.
+    swa_pattern = [i != FULL_ATTN_LAYER for i in range(N_LAYER)]
+    w.add_sliding_window_pattern(swa_pattern)
+    w.add_sliding_window(N_CTX)
+    w.add_key_length_swa(N_EMBD_HEAD)
+    w.add_value_length_swa(N_EMBD_HEAD)
+    w.add_embedding_length_per_layer_input(0)
 
-    # global tensors (numpy shapes are ggml dims reversed)
+    add_tokenizer(w, tokens, scores, toktypes)
+
+    # Tied output (no output.weight → llama.cpp reuses token_embd). One shared rope_freqs
+    # tensor covers the full-attention layer.
     w.add_tensor("token_embd.weight",  rnd(n_vocab, N_EMBD, seed=1))
     w.add_tensor("output_norm.weight", rnd(N_EMBD, seed=2))
-    w.add_tensor("output.weight",      rnd(n_vocab, N_EMBD, seed=3))
+    w.add_tensor("rope_freqs.weight",  rnd(N_EMBD_HEAD // 2, seed=3))
 
     s = 100
     for i in range(N_LAYER):
         p = f"blk.{i}."
-        w.add_tensor(p + "attn_norm.weight",   rnd(N_EMBD, seed=s + 0))
-        w.add_tensor(p + "attn_q.weight",      rnd(N_EMBD_HEAD * N_HEAD, N_EMBD, seed=s + 1))
-        w.add_tensor(p + "attn_k.weight",      rnd(N_EMBD_GQA, N_EMBD, seed=s + 2))
-        w.add_tensor(p + "attn_v.weight",      rnd(N_EMBD_GQA, N_EMBD, seed=s + 3))
-        w.add_tensor(p + "attn_output.weight", rnd(N_EMBD, N_EMBD_HEAD * N_HEAD, seed=s + 4))
-        w.add_tensor(p + "attn_q_norm.weight", rnd(N_EMBD_HEAD, seed=s + 5))
-        w.add_tensor(p + "attn_k_norm.weight", rnd(N_EMBD_HEAD, seed=s + 6))
-        w.add_tensor(p + "ffn_norm.weight",    rnd(N_EMBD, seed=s + 7))
-        w.add_tensor(p + "ffn_gate_inp.weight", rnd(N_EXPERT, N_EMBD, seed=s + 8))
-        # experts: dim-2 (numpy axis 0) indexes the expert
-        w.add_tensor(p + "ffn_gate_exps.weight", rnd(N_EXPERT, N_FF_EXP, N_EMBD, seed=s + 9))
-        w.add_tensor(p + "ffn_down_exps.weight", rnd(N_EXPERT, N_EMBD, N_FF_EXP, seed=s + 10))
-        w.add_tensor(p + "ffn_up_exps.weight",   rnd(N_EXPERT, N_FF_EXP, N_EMBD, seed=s + 11))
+        w.add_tensor(p + "attn_norm.weight", rnd(N_EMBD, seed=s + 0))
+        add_attn_tensors(w, p, s)
+        w.add_tensor(p + "post_attention_norm.weight", rnd(N_EMBD, seed=s + 7))
+
+        # shared / dense FFN (also the shared expert on MoE layers)
+        w.add_tensor(p + "ffn_norm.weight", rnd(N_EMBD, seed=s + 8))
+        w.add_tensor(p + "ffn_gate.weight", rnd(N_FF, N_EMBD, seed=s + 9))
+        w.add_tensor(p + "ffn_up.weight",   rnd(N_FF, N_EMBD, seed=s + 10))
+        w.add_tensor(p + "ffn_down.weight", rnd(N_EMBD, N_FF, seed=s + 11))
+        w.add_tensor(p + "post_ffw_norm.weight", rnd(N_EMBD, seed=s + 12))
+
+        if i != DENSE_LAYER:
+            # MoE layer: router (+ its required scale), extra norms, and the two streamed
+            # expert tensors. ffn_gate_up_exps fuses gate+up: dim-1 is 2*N_FF_EXP.
+            w.add_tensor(p + "ffn_gate_inp.weight", rnd(N_EXPERT, N_EMBD, seed=s + 13))
+            w.add_tensor(p + "ffn_gate_inp.scale",  rnd(N_EMBD, seed=s + 14))
+            w.add_tensor(p + "pre_ffw_norm_2.weight",  rnd(N_EMBD, seed=s + 15))
+            w.add_tensor(p + "post_ffw_norm_1.weight", rnd(N_EMBD, seed=s + 16))
+            w.add_tensor(p + "post_ffw_norm_2.weight", rnd(N_EMBD, seed=s + 17))
+            # experts: dim-2 (numpy axis 0) indexes the expert
+            w.add_tensor(p + "ffn_gate_up_exps.weight", rnd(N_EXPERT, 2 * N_FF_EXP, N_EMBD, seed=s + 18))
+            w.add_tensor(p + "ffn_down_exps.weight",    rnd(N_EXPERT, N_EMBD, N_FF_EXP, seed=s + 19))
         s += 100
 
     w.write_header_to_file()
     w.write_kv_data_to_file()
     w.write_tensors_to_file()
     w.close()
-    print(f"wrote {args.out}: qwen3moe, {N_LAYER} layers, {N_EXPERT} experts "
-          f"(top-{N_EXPERT_USED}), vocab {n_vocab}")
+    n_moe = N_LAYER - 1
+    print(f"wrote {out}: gemma4, {N_LAYER} layers ({n_moe} MoE, fused gate_up), "
+          f"{N_EXPERT} experts (top-{N_EXPERT_USED}), vocab {n_vocab}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arch", choices=["qwen3moe", "gemma4"], default="qwen3moe")
+    ap.add_argument("--out", default="tiny-moe.gguf")
+    args = ap.parse_args()
+
+    if args.arch == "gemma4":
+        build_gemma4(args.out)
+    else:
+        build_qwen3moe(args.out)
 
 
 if __name__ == "__main__":

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,23 +1,28 @@
-# Byte-identity gates. The tiny synthetic model is generated at test time by
+# Byte-identity gates. The tiny synthetic models are generated at test time by
 # scripts/make-tiny-moe.py (requires python3 with the gguf package); if it is
-# unavailable the test is skipped rather than failing the build.
+# unavailable the tests are skipped rather than failing the build. One model per expert
+# layout the streamer supports: qwen3moe (split gate/up/down) and gemma4 (fused gate_up).
 
 add_executable(bmoe_moe_gates moe_gates.cpp)
 target_link_libraries(bmoe_moe_gates PRIVATE bmoe_core)
 
-set(TINY_MODEL "${CMAKE_CURRENT_BINARY_DIR}/tiny-moe.gguf")
-
 find_program(PYTHON3 NAMES python3 python)
 
 if(PYTHON3)
-    add_test(
-        NAME moe_make_tiny_model
-        COMMAND ${PYTHON3} ${CMAKE_SOURCE_DIR}/scripts/make-tiny-moe.py --out ${TINY_MODEL}
-    )
-    set_tests_properties(moe_make_tiny_model PROPERTIES FIXTURES_SETUP TINY_MOE_MODEL)
+    # arch → (fixture id, gguf filename). Each gets a generate fixture + a gate run.
+    foreach(spec "qwen3moe" "gemma4")
+        set(_model "${CMAKE_CURRENT_BINARY_DIR}/tiny-moe-${spec}.gguf")
+        set(_fixture "TINY_MOE_MODEL_${spec}")
 
-    add_test(NAME moe_gates COMMAND bmoe_moe_gates ${TINY_MODEL})
-    set_tests_properties(moe_gates PROPERTIES FIXTURES_REQUIRED TINY_MOE_MODEL)
+        add_test(
+            NAME moe_make_tiny_model_${spec}
+            COMMAND ${PYTHON3} ${CMAKE_SOURCE_DIR}/scripts/make-tiny-moe.py --arch ${spec} --out ${_model}
+        )
+        set_tests_properties(moe_make_tiny_model_${spec} PROPERTIES FIXTURES_SETUP ${_fixture})
+
+        add_test(NAME moe_gates_${spec} COMMAND bmoe_moe_gates ${_model})
+        set_tests_properties(moe_gates_${spec} PROPERTIES FIXTURES_REQUIRED ${_fixture})
+    endforeach()
 else()
-    message(WARNING "python3 not found: MoE gates will not run (model cannot be generated)")
+    message(WARNING "python3 not found: MoE gates will not run (models cannot be generated)")
 endif()


### PR DESCRIPTION
## What

Adds streaming support for the **fused gate+up expert layout** used by Gemma 4 MoE
(`gemma4`, e.g. 26B-A4B), where each MoE layer packs gate+up into one
`blk.<il>.ffn_gate_up_exps` tensor instead of separate `ffn_gate_exps`/`ffn_up_exps`.

## How

The recipe generalizes from three named projection suffixes to a **suffix list**
(`exps_suffix[max_exps]`, nullptr-terminated). To the streamer a fused `gate_up` is just an
expert tensor with a larger per-expert stride, discovered at runtime like any other — so
`gemma4` is a **single registry row**, not a distinct recipe shape, and nothing in the
streaming path branches on layout.

- `recipe.h` — `exps_suffix[max_exps]` replaces the gate/up/down fields.
- `arch_registry.cpp` — `{ "gemma4", { "ffn_gate_up_exps", "ffn_down_exps", nullptr } }`.
- `router_hook.cpp` — `match_expert` iterates the suffix list; the exact `.weight` tail
  keeps companion `.scale` tensors (and the shared expert) mmap-resident.
- `expert_stream_source` — sizing/alloc/rebind/stage/evict skip absent slots; no zero-byte
  buffer is reserved for the fused layout's empty tail.
- `runtime.cpp` — the capture completeness check requires exactly the recipe's present
  slots and a consistent `ne[2]`, refusing a mismatched gguf rather than guessing.

The always-on shared expert, the router and per-expert `.scale` tensors of `gemma4` match no
suffix and stay resident; only the two expert weight tensors stream.

## Tests

- `make-tiny-moe.py --arch {qwen3moe,gemma4}`; `tests/CMakeLists.txt` wires one
  generate-fixture + gate per architecture.
- The **qwen3moe fixture is byte-identical** to before (verified), so the existing gate is
  unchanged. The new **gemma4 gate** exercises the two-projection path (dense/MoE
  interleaving, mixed SWA, LRU eviction). The gemma4 fixture was validated structurally
  against the real unsloth Q4_K_M header; the byte-identity gate itself runs in CI.

## Docs

`adding-a-model.md`, `roadmap.md`, `limitations.md`, `seam.md` updated: the fused layout is
now one row, shared experts stay resident, and the seam note makes explicit that the
naming-convention fragility is what the gates guard on each submodule bump.