### PR TITLE
feat(android): Play-compliant model acquisition (dev/play flavors, in-app download + import)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,17 @@ jobs:
           # bmoe-cli links the c++_shared STL; ship its runtime from the NDK sysroot.
           cp "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" "$jni/"
           ls -la "$jni"
-      - name: Build debug APK
+      - name: Build debug APK (dev flavor — sideloaded, all-files access)
         working-directory: examples/android
-        run: ./gradlew assembleDebug --no-daemon
+        run: ./gradlew assembleDevDebug --no-daemon
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: bmoe-example-debug-apk
-          path: examples/android/app/build/outputs/apk/debug/app-debug.apk
+          name: bmoe-example-dev-debug-apk
+          path: examples/android/app/build/outputs/apk/dev/debug/app-dev-debug.apk
           if-no-files-found: error
       - name: Attach APK to release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: examples/android/app/build/outputs/apk/debug/app-debug.apk
+          files: examples/android/app/build/outputs/apk/dev/debug/app-dev-debug.apk

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -20,21 +20,39 @@ research harness and keeps the app a thin driver over the CLI.
    `libllama`/`libggml` shared libraries.
 
 2. Build and install the APK. Open this folder in Android Studio, or use the committed
-   Gradle wrapper directly:
+   Gradle wrapper directly. The app has two distribution flavors (see below); build the one
+   you want:
 
    ```bash
-   ./gradlew assembleDebug
-   adb install app/build/outputs/apk/debug/app-debug.apk
+   ./gradlew assembleDevDebug
+   adb install app/build/outputs/apk/dev/debug/app-dev-debug.apk
    ```
 
-## Push a model
+## Flavors
 
-```bash
-adb push Qwen3-30B-A3B-Q4_K_M.gguf \
-  /sdcard/Android/data/io.bigmoeonedge.example/files/
-```
+Two build flavors differ only in how a model reaches the device:
 
-The model picker lists every `.gguf` in that directory.
+- **dev** — sideloaded (this is what CI attaches to releases). Keeps all-files access, so it
+  can also read a model adb-pushed to shared storage. Application id `…​.example.dev`.
+- **play** — Play-Store-compliant. No broad storage permission: models come only through the
+  in-app downloader or the file picker. `./gradlew assemblePlayDebug`.
+
+## Getting a model onto the device
+
+Any of these — the picker lists every MoE `.gguf` it finds (dense models are filtered out by
+a gguf-header check):
+
+1. **In-app URL download** (both flavors). Tap **Add → Download** and paste a direct gguf URL
+   (e.g. a Hugging Face `…/resolve/main/model.gguf` link). It downloads in the background to
+   the app's files dir — no permission needed — and appears in the picker when done.
+2. **In-app file picker** (both flavors). Tap **Add → Pick file** and choose a `.gguf` already
+   on the device; it is imported into the app's files dir.
+3. **adb push** (dev flavor only — needs all-files access, which the dev build requests):
+
+   ```bash
+   adb push Qwen3-30B-A3B-Q4_K_M.gguf /sdcard/Download/
+   # or the app's own dir, or /data/local/tmp/shardllm for a model too big to duplicate
+   ```
 
 ## Expected numbers
 

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -19,6 +19,30 @@ android {
         }
     }
 
+    // Two distribution channels differing only in how a model reaches the device.
+    //   dev   sideloaded (GitHub Release). Keeps all-files access, so it can read a gguf
+    //         adb-pushed to /sdcard/Download or /data/local/tmp — the fastest way to get a
+    //         multi-GB model onto a dev device. Declares MANAGE_EXTERNAL_STORAGE via
+    //         src/dev/AndroidManifest.xml.
+    //   play  Play-Store-compliant. No broad storage permission: models arrive only through
+    //         the in-app URL downloader or the system file picker (SAF), both writing to the
+    //         app-specific external files dir, which needs no permission.
+    // SHARED_STORAGE gates the storage-permission code paths; no model names or URLs are
+    // ever hardcoded — the scanned directories are the only difference.
+    flavorDimensions += 'distribution'
+    productFlavors {
+        dev {
+            dimension 'distribution'
+            applicationIdSuffix '.dev'
+            versionNameSuffix '-dev'
+            buildConfigField 'boolean', 'SHARED_STORAGE', 'true'
+        }
+        play {
+            dimension 'distribution'
+            buildConfigField 'boolean', 'SHARED_STORAGE', 'false'
+        }
+    }
+
     // The CLI is a real executable shipped as lib*.so; it must reach the device
     // uncompressed and extracted into nativeLibraryDir so it can be exec'd.
     packagingOptions {
@@ -41,6 +65,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig true
     }
     composeOptions {
         // Matches Kotlin 1.9.24 (see the Compose-Kotlin compatibility map).

--- a/examples/android/app/src/dev/AndroidManifest.xml
+++ b/examples/android/app/src/dev/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- dev flavor only. A gguf is tens of GB; with all-files access the dev build can read
+         one adb-pushed to /sdcard/Download or /data/local/tmp in place, without copying it
+         into app storage. The Play flavor omits this and takes models via the in-app
+         downloader / file picker instead. -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+
+</manifest>

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!-- gguf models are tens of GB and are read in place from shared storage (e.g.
-         /sdcard/Download) by the bmoe-cli subprocess, so the app needs all-files access. -->
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <!-- No broad storage permission here: models arrive through the in-app URL downloader or
+         the system file picker, both writing to the app-specific external files dir. The dev
+         flavor overlay (src/dev/AndroidManifest.xml) adds all-files access to also read
+         adb-pushed models in place. -->
 
     <application
         android:allowBackup="false"

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/GgufHeader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/GgufHeader.kt
@@ -1,0 +1,207 @@
+package io.bigmoeonedge.example
+
+import java.io.BufferedInputStream
+import java.io.EOFException
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Minimal streaming reader for the gguf header — enough to tell a MoE model from a dense one
+ * without loading tensor data. It walks the real structure (magic, version, KV metadata, then
+ * the tensor-info block) instead of scanning a fixed prefix, so it works no matter how large
+ * the KV section is (a big tokenizer can push the tensor names well past any fixed window).
+ *
+ * gguf layout: "GGUF" magic, u32 version, then counts and a key/value metadata block, then one
+ * info record per tensor (name, dims, type, offset). We only need the tensor names: a MoE model
+ * names its down projection `blk.<il>.ffn_down_exps`, absent from dense models.
+ *
+ * Spec: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md
+ */
+object GgufHeader {
+    private const val MOE_MARKER = "ffn_down_exps"
+
+    // gguf value types (for skipping KV entries we don't read).
+    private const val T_UINT8 = 0
+    private const val T_INT8 = 1
+    private const val T_UINT16 = 2
+    private const val T_INT16 = 3
+    private const val T_UINT32 = 4
+    private const val T_INT32 = 5
+    private const val T_FLOAT32 = 6
+    private const val T_BOOL = 7
+    private const val T_STRING = 8
+    private const val T_ARRAY = 9
+    private const val T_UINT64 = 10
+    private const val T_INT64 = 11
+    private const val T_FLOAT64 = 12
+
+    // Guards against a corrupt/adversarial header: bound the work and reject absurd sizes
+    // rather than allocating or looping unboundedly.
+    private const val MAX_HEADER_BYTES = 64L * 1024 * 1024
+    private const val MAX_STRING_LEN = 1L * 1024 * 1024
+    private const val MAX_TENSORS = 1_000_000L
+
+    /**
+     * True if the gguf declares expert tensors (i.e. it is a MoE model). Reads only the header.
+     * Falls back to a substring scan of the header region if the structured parse fails, so this
+     * can only improve on the old probe, never miss a model the probe would have caught.
+     */
+    fun isMoe(f: File): Boolean =
+        runCatching { f.inputStream().buffered().use { parseIsMoe(Counting(it)) } }
+            .getOrElse { substringFallback(f) }
+
+    private fun parseIsMoe(s: Counting): Boolean {
+        val magic = ByteArray(4)
+        s.readFully(magic)
+        if (magic[0].toInt() != 'G'.code || magic[1].toInt() != 'G'.code ||
+            magic[2].toInt() != 'U'.code || magic[3].toInt() != 'F'.code
+        ) {
+            throw IllegalArgumentException("not a gguf file")
+        }
+        val version = s.u32()
+        // v1 used 32-bit counts and string lengths; v2+ use 64-bit. We support v2+ (every
+        // current model); a v1 file throws and takes the substring fallback.
+        if (version < 2) throw IllegalArgumentException("unsupported gguf version $version")
+
+        val tensorCount = s.u64()
+        val kvCount = s.u64()
+        if (tensorCount < 0 || tensorCount > MAX_TENSORS || kvCount < 0) {
+            throw IllegalArgumentException("implausible header counts")
+        }
+
+        // Skip the KV metadata block to reach the tensor-info records.
+        for (i in 0 until kvCount) {
+            skipString(s)                 // key
+            skipValue(s, s.u32())         // value
+            if (s.pos > MAX_HEADER_BYTES) throw IllegalArgumentException("header too large")
+        }
+
+        // Tensor-info records: we only need the names.
+        for (i in 0 until tensorCount) {
+            val name = readString(s)
+            if (name.contains(MOE_MARKER)) return true
+            val nDims = s.u32()
+            if (nDims < 0 || nDims > 8) throw IllegalArgumentException("implausible tensor dims")
+            s.skipFully(nDims * 8L)       // dims (u64 each)
+            s.u32()                       // ggml type
+            s.u64()                       // data offset
+            if (s.pos > MAX_HEADER_BYTES) throw IllegalArgumentException("header too large")
+        }
+        return false
+    }
+
+    private fun skipValue(s: Counting, type: Int) {
+        when (type) {
+            T_UINT8, T_INT8, T_BOOL -> s.skipFully(1)
+            T_UINT16, T_INT16 -> s.skipFully(2)
+            T_UINT32, T_INT32, T_FLOAT32 -> s.skipFully(4)
+            T_UINT64, T_INT64, T_FLOAT64 -> s.skipFully(8)
+            T_STRING -> skipString(s)
+            T_ARRAY -> {
+                val elemType = s.u32()
+                val count = s.u64()
+                if (count < 0) throw IllegalArgumentException("bad array count")
+                if (elemType == T_STRING) {
+                    for (i in 0 until count) skipString(s)
+                } else if (elemType == T_ARRAY) {
+                    throw IllegalArgumentException("nested gguf arrays unsupported")
+                } else {
+                    s.skipFully(count * scalarSize(elemType))
+                }
+            }
+            else -> throw IllegalArgumentException("unknown gguf value type $type")
+        }
+    }
+
+    private fun scalarSize(type: Int): Long = when (type) {
+        T_UINT8, T_INT8, T_BOOL -> 1
+        T_UINT16, T_INT16 -> 2
+        T_UINT32, T_INT32, T_FLOAT32 -> 4
+        T_UINT64, T_INT64, T_FLOAT64 -> 8
+        else -> throw IllegalArgumentException("non-scalar gguf type $type")
+    }
+
+    private fun readString(s: Counting): String {
+        val len = s.u64()
+        if (len < 0 || len > MAX_STRING_LEN) throw IllegalArgumentException("implausible string length $len")
+        val bytes = ByteArray(len.toInt())
+        s.readFully(bytes)
+        return String(bytes, Charsets.UTF_8)
+    }
+
+    private fun skipString(s: Counting) {
+        val len = s.u64()
+        if (len < 0 || len > MAX_STRING_LEN) throw IllegalArgumentException("implausible string length $len")
+        s.skipFully(len)
+    }
+
+    // Last-resort scan of the header region, matching the old behaviour so the structured parse
+    // can only add detections. Reads up to 16 MiB — the tensor-info block starts right after the
+    // KV metadata and is normally well within that.
+    private fun substringFallback(f: File): Boolean = runCatching {
+        val cap = minOf(f.length(), 16L * 1024 * 1024).toInt()
+        val buf = ByteArray(cap)
+        f.inputStream().use { s ->
+            var off = 0
+            while (off < cap) {
+                val n = s.read(buf, off, cap - off)
+                if (n <= 0) break
+                off += n
+            }
+        }
+        String(buf, Charsets.US_ASCII).contains(MOE_MARKER)
+    }.getOrDefault(false)
+
+    /** InputStream wrapper: little-endian primitive reads, exact skipping, and a byte counter. */
+    private class Counting(private val src: InputStream) {
+        var pos: Long = 0
+            private set
+
+        fun readFully(b: ByteArray) {
+            var off = 0
+            while (off < b.size) {
+                val n = src.read(b, off, b.size - off)
+                if (n < 0) throw EOFException()
+                off += n
+                pos += n
+            }
+        }
+
+        fun skipFully(n: Long) {
+            if (n < 0) throw IllegalArgumentException("negative skip")
+            var left = n
+            val scratch = ByteArray(8192)
+            while (left > 0) {
+                val step = src.skip(left)
+                if (step > 0) {
+                    left -= step
+                    pos += step
+                    continue
+                }
+                // skip() can return 0 legitimately; fall back to reading.
+                val want = minOf(left, scratch.size.toLong()).toInt()
+                val got = src.read(scratch, 0, want)
+                if (got < 0) throw EOFException()
+                left -= got
+                pos += got
+            }
+        }
+
+        fun u32(): Int {
+            val b = ByteArray(4)
+            readFully(b)
+            return (b[0].toInt() and 0xff) or
+                ((b[1].toInt() and 0xff) shl 8) or
+                ((b[2].toInt() and 0xff) shl 16) or
+                ((b[3].toInt() and 0xff) shl 24)
+        }
+
+        fun u64(): Long {
+            val b = ByteArray(8)
+            readFully(b)
+            var v = 0L
+            for (i in 0 until 8) v = v or ((b[i].toLong() and 0xff) shl (8 * i))
+            return v
+        }
+    }
+}

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.os.Environment
 import android.provider.Settings
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
@@ -28,6 +29,8 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.Locale
@@ -58,8 +61,10 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    // gguf models are read in place from shared storage, which needs all-files access.
+    // Only the dev flavor reads models in place from shared storage; the Play flavor takes them
+    // through the in-app downloader / file picker and needs no broad storage permission.
     private fun requestAllFilesAccess() {
+        if (!BuildConfig.SHARED_STORAGE) return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
             runCatching {
                 startActivity(
@@ -151,6 +156,10 @@ private fun MainScreen(settings: AppSettings, onOpenSettings: () -> Unit) {
             )
         }
 
+        // Bring a model onto the device without adb: download by URL or pick a local file.
+        // Both land in the app models dir; on completion we re-scan so it appears above.
+        AddModelSection(onModelReady = { refreshKey++ })
+
         OutlinedTextField(
             value = prompt,
             onValueChange = { prompt = it },
@@ -204,6 +213,134 @@ private fun MainScreen(settings: AppSettings, onOpenSettings: () -> Unit) {
 
         if (ui.answer.isNotEmpty()) {
             SelectionContainer { Text(ui.answer, fontSize = 15.sp) }
+        }
+    }
+}
+
+/**
+ * "Add a model" card: download a gguf by URL (DownloadManager) or import one the user already
+ * has via the system file picker (SAF). Both write to the app models dir with no permission;
+ * [onModelReady] triggers a re-scan so the new model shows up in the picker above.
+ */
+@Composable
+private fun AddModelSection(onModelReady: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var url by rememberSaveable { mutableStateOf("") }
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    var downloadId by rememberSaveable { mutableStateOf(-1L) }
+    var progress by remember { mutableStateOf<ModelDownloader.Progress?>(null) }
+    var importStatus by remember { mutableStateOf<String?>(null) }
+    var importFrac by remember { mutableStateOf(-1f) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        error = null
+        importStatus = "Importing…"
+        importFrac = -1f
+        scope.launch {
+            SafImport.importGguf(context, uri) { copied, total ->
+                importFrac = if (total > 0) (copied.toFloat() / total).coerceIn(0f, 1f) else -1f
+            }.onSuccess {
+                importStatus = null; importFrac = -1f; onModelReady()
+            }.onFailure {
+                importStatus = null; importFrac = -1f; error = it.message ?: "import failed"
+            }
+        }
+    }
+
+    // Poll an active download to completion, then finalize (.part → .gguf) and re-scan.
+    LaunchedEffect(downloadId) {
+        if (downloadId < 0) return@LaunchedEffect
+        while (true) {
+            val p = ModelDownloader.query(context, downloadId) ?: break
+            progress = p
+            if (p.state == ModelDownloader.State.SUCCESS) {
+                ModelDownloader.finalizeDownload(context, p.name)
+                downloadId = -1L; progress = null; onModelReady()
+                break
+            }
+            if (p.state == ModelDownloader.State.FAILED) {
+                error = p.reason ?: "download failed"
+                downloadId = -1L; progress = null
+                break
+            }
+            delay(700)
+        }
+    }
+
+    ElevatedCard(Modifier.fillMaxWidth()) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Add a model", fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                TextButton(onClick = { expanded = !expanded }) { Text(if (expanded) "Hide" else "Add") }
+            }
+            if (expanded) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    label = { Text("gguf URL (e.g. a Hugging Face resolve link)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Button(
+                        onClick = {
+                            error = null
+                            ModelDownloader.enqueue(context, url)
+                                .onSuccess { downloadId = it }
+                                .onFailure { error = it.message ?: "invalid URL" }
+                        },
+                        enabled = url.isNotBlank() && downloadId < 0,
+                        modifier = Modifier.weight(1f),
+                    ) { Text("Download") }
+                    OutlinedButton(
+                        onClick = { picker.launch(arrayOf("*/*")) },
+                        modifier = Modifier.weight(1f),
+                    ) { Text("Pick file") }
+                }
+            }
+
+            progress?.let { p ->
+                val pct = if (p.totalBytes > 0) {
+                    (p.downloadedBytes.toFloat() / p.totalBytes).coerceIn(0f, 1f)
+                } else {
+                    null
+                }
+                Text(
+                    if (pct != null) {
+                        String.format(
+                            Locale.US, "Downloading %s — %d%% (%d/%d MiB)",
+                            p.name, (pct * 100).toInt(), p.downloadedBytes shr 20, p.totalBytes shr 20,
+                        )
+                    } else {
+                        "Downloading ${p.name}…"
+                    },
+                    fontSize = 12.sp,
+                )
+                if (pct != null) {
+                    LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
+                } else {
+                    LinearProgressIndicator(Modifier.fillMaxWidth())
+                }
+                TextButton(onClick = {
+                    ModelDownloader.cancel(context, p.id, p.name)
+                    downloadId = -1L; progress = null
+                }) { Text("Cancel") }
+            }
+
+            importStatus?.let { st ->
+                Text(st, fontSize = 12.sp)
+                if (importFrac >= 0f) {
+                    LinearProgressIndicator(progress = { importFrac }, modifier = Modifier.fillMaxWidth())
+                } else {
+                    LinearProgressIndicator(Modifier.fillMaxWidth())
+                }
+            }
+
+            error?.let { Text(it, color = MaterialTheme.colorScheme.error, fontSize = 12.sp) }
         }
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -1,0 +1,125 @@
+package io.bigmoeonedge.example
+
+import android.app.DownloadManager
+import android.content.Context
+import android.net.Uri
+import java.io.File
+
+/**
+ * Downloads a gguf by URL into the app-specific external files dir using the system
+ * [DownloadManager]. That destination needs no storage permission, and DownloadManager keeps
+ * going across process death and resumes on reconnect — the right fit for multi-GB models.
+ *
+ * The file is written as `<name>.gguf.part` and renamed to `<name>.gguf` only on success, so a
+ * half-finished download is never listed as a runnable model.
+ */
+object ModelDownloader {
+    private const val PART_SUFFIX = ".part"
+
+    enum class State { PENDING, RUNNING, PAUSED, SUCCESS, FAILED }
+
+    data class Progress(
+        val id: Long,
+        val name: String,
+        val downloadedBytes: Long,
+        val totalBytes: Long, // -1 when the server didn't send a length
+        val state: State,
+        val reason: String? = null,
+    )
+
+    /**
+     * Start a download. Returns the DownloadManager id, or an error if the URL doesn't name a
+     * .gguf file. No model names or hosts are assumed — the filename comes from the URL.
+     */
+    fun enqueue(ctx: Context, rawUrl: String): Result<Long> = runCatching {
+        val url = rawUrl.trim()
+        val uri = Uri.parse(url)
+        require(uri.scheme == "http" || uri.scheme == "https") { "URL must be http(s)" }
+
+        val name = fileNameFromUrl(uri)
+        require(name.endsWith(".gguf")) { "URL must point to a .gguf file" }
+
+        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        val req = DownloadManager.Request(uri)
+            .setTitle(name)
+            .setDescription("BigMoeOnEdge model")
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(false)
+            // App-specific external files dir → no permission required, and the same directory
+            // ModelManager scans. Written as .part so the scanner ignores it until complete.
+            .setDestinationInExternalFilesDir(ctx, null, name + PART_SUFFIX)
+        dm.enqueue(req)
+    }
+
+    /** Current status of a download, or null if the id is unknown. */
+    fun query(ctx: Context, id: Long): Progress? {
+        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        dm.query(DownloadManager.Query().setFilterById(id)).use { c ->
+            if (c == null || !c.moveToFirst()) return null
+            val status = c.getInt(c.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+            val soFar = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
+            val total = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
+            val title = c.getString(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TITLE)) ?: "model.gguf"
+            val reasonCode = c.getInt(c.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+            val state = when (status) {
+                DownloadManager.STATUS_PENDING -> State.PENDING
+                DownloadManager.STATUS_RUNNING -> State.RUNNING
+                DownloadManager.STATUS_PAUSED -> State.PAUSED
+                DownloadManager.STATUS_SUCCESSFUL -> State.SUCCESS
+                else -> State.FAILED
+            }
+            val reason = when (state) {
+                State.FAILED -> failureReason(reasonCode)
+                State.PAUSED -> pauseReason(reasonCode)
+                else -> null
+            }
+            return Progress(id, title, soFar, total, state, reason)
+        }
+    }
+
+    /**
+     * Finish a successful download: rename `<name>.gguf.part` to `<name>.gguf` in the app models
+     * dir and return the final file, or null if the part file is missing. Idempotent — if the
+     * final file already exists it is returned as-is.
+     */
+    fun finalizeDownload(ctx: Context, name: String): File? {
+        val dir = ModelManager.appModelsDir(ctx) ?: return null
+        val finalFile = File(dir, name)
+        if (finalFile.isFile) return finalFile
+        val part = File(dir, name + PART_SUFFIX)
+        if (!part.isFile) return null
+        return if (part.renameTo(finalFile)) finalFile else null
+    }
+
+    /** Remove a download from DownloadManager and delete any leftover .part file. */
+    fun cancel(ctx: Context, id: Long, name: String) {
+        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        dm.remove(id)
+        ModelManager.appModelsDir(ctx)?.let { File(it, name + PART_SUFFIX).delete() }
+    }
+
+    // Last path segment, query stripped, sanitized to a bare filename (no separators).
+    private fun fileNameFromUrl(uri: Uri): String {
+        val seg = uri.lastPathSegment?.substringAfterLast('/') ?: ""
+        val cleaned = seg.substringBefore('?').filter { it.isLetterOrDigit() || it in "._-" }
+        require(cleaned.isNotEmpty()) { "cannot derive a filename from the URL" }
+        return cleaned
+    }
+
+    private fun failureReason(code: Int): String = when (code) {
+        DownloadManager.ERROR_INSUFFICIENT_SPACE -> "not enough free space"
+        DownloadManager.ERROR_HTTP_DATA_ERROR -> "network data error"
+        DownloadManager.ERROR_UNHANDLED_HTTP_CODE -> "server returned an unexpected status"
+        DownloadManager.ERROR_FILE_ERROR -> "file error writing the download"
+        DownloadManager.ERROR_CANNOT_RESUME -> "download could not resume"
+        else -> "download failed (code $code)"
+    }
+
+    private fun pauseReason(code: Int): String = when (code) {
+        DownloadManager.PAUSED_WAITING_FOR_NETWORK -> "waiting for network"
+        DownloadManager.PAUSED_WAITING_TO_RETRY -> "waiting to retry"
+        DownloadManager.PAUSED_QUEUED_FOR_WIFI -> "queued for Wi-Fi"
+        else -> "paused"
+    }
+}

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -5,33 +5,35 @@ import android.os.Environment
 import java.io.File
 
 /**
- * Finds MoE gguf models on shared storage. A gguf can be tens of GB, so the app reads it
- * in place (via the bmoe-cli subprocess) rather than copying it into app storage — which
- * requires all-files access. Scans the public Downloads folder plus the app's own
- * external files dir.
+ * Finds MoE gguf models on device. Models are read in place by the bmoe-cli subprocess (a gguf
+ * can be tens of GB), so every source is a real filesystem directory the subprocess can open.
  *
- *   adb push Qwen3-30B-A3B-Q4_K_M.gguf /sdcard/Download/
+ * Which directories are scanned depends on the distribution flavor (BuildConfig.SHARED_STORAGE):
  *
- * Only MoE models are listed: this engine streams experts, so dense models (which have no
- * expert tensors) are filtered out by probing the gguf header.
+ *   always      the app-specific external files dir — no permission needed. The in-app URL
+ *               downloader and the file picker both land models here.
+ *   dev only    the public Downloads folder and /data/local/tmp/shardllm, for models adb-pushed
+ *               to the device. These need all-files access, which only the dev flavor requests.
+ *
+ * Only MoE models are listed: this engine streams experts, so dense models are filtered out by
+ * reading the gguf header (see [GgufHeader]).
  */
 object ModelManager {
-    // Every MoE gguf, in any expert layout, names its down projection blk.<il>.ffn_down_exps
-    // — a marker absent from dense models (which have blk.<il>.ffn_down). It lives in the
-    // tensor-info block right after the KV metadata, well within this probe window.
-    private val MOE_MARKER = "ffn_down_exps".toByteArray(Charsets.US_ASCII)
-    private const val PROBE_BYTES = 16 * 1024 * 1024
-
     // A gguf larger than the free space on shared storage cannot be copied there, but it can
     // still be adb-pushed to /data/local/tmp (same physical partition, no duplicate needed) and
     // read in place: the path is world-traversable and the file world-readable, so the app's
-    // untrusted_app domain can open it. Scanned in addition to shared storage for that case.
+    // untrusted_app domain can open it.
     private val TMP_MODEL_DIR = File("/data/local/tmp/shardllm")
 
+    /** The app-specific external files dir — the download/import target, readable with no permission. */
+    fun appModelsDir(ctx: Context): File? = ctx.getExternalFilesDir(null)
+
     private fun scanDirs(ctx: Context): List<File> = buildList {
-        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.let { add(it) }
-        ctx.getExternalFilesDir(null)?.let { add(it) }
-        if (TMP_MODEL_DIR.isDirectory) add(TMP_MODEL_DIR)
+        appModelsDir(ctx)?.let { add(it) }
+        if (BuildConfig.SHARED_STORAGE) {
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.let { add(it) }
+            if (TMP_MODEL_DIR.isDirectory) add(TMP_MODEL_DIR)
+        }
     }
 
     private fun allGguf(ctx: Context): List<File> =
@@ -40,38 +42,21 @@ object ModelManager {
             .distinctBy { it.absolutePath }
             .sortedBy { it.name }
 
-    /** True if the gguf declares expert tensors (i.e. it is a MoE model). Reads only the header. */
-    fun isMoe(f: File): Boolean = runCatching {
-        val cap = minOf(f.length(), PROBE_BYTES.toLong()).toInt()
-        val buf = ByteArray(cap)
-        f.inputStream().use { s ->
-            var off = 0
-            while (off < cap) {
-                val n = s.read(buf, off, cap - off)
-                if (n <= 0) break
-                off += n
-            }
-        }
-        indexOf(buf, MOE_MARKER) >= 0
-    }.getOrDefault(false)
-
     /** List MoE models only. Blocking header reads — call off the main thread. */
-    fun listMoeModels(ctx: Context): List<File> = allGguf(ctx).filter { isMoe(it) }
+    fun listMoeModels(ctx: Context): List<File> = allGguf(ctx).filter { GgufHeader.isMoe(it) }
 
     /** Absolute path of libbmoe-cli.so inside the app's nativeLibraryDir. */
     fun cliPath(ctx: Context): String =
         File(ctx.applicationInfo.nativeLibraryDir, "libbmoe-cli.so").absolutePath
 
+    /** Empty-state guidance, phrased for the current flavor's model-acquisition paths. */
     fun pushHint(): String =
-        "No MoE .gguf found. Grant all-files access, then push a model with:\n" +
-            "adb push model.gguf /sdcard/Download/"
-
-    private fun indexOf(haystack: ByteArray, needle: ByteArray): Int {
-        if (needle.isEmpty() || haystack.size < needle.size) return -1
-        outer@ for (i in 0..haystack.size - needle.size) {
-            for (j in needle.indices) if (haystack[i + j] != needle[j]) continue@outer
-            return i
+        if (BuildConfig.SHARED_STORAGE) {
+            "No MoE .gguf found. Add one below (download by URL or pick a file), or adb-push a\n" +
+                "model to shared storage:\n" +
+                "adb push model.gguf /sdcard/Download/"
+        } else {
+            "No MoE .gguf found. Add one below: download by URL, or pick a .gguf you already\n" +
+                "have on the device."
         }
-        return -1
-    }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SafImport.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SafImport.kt
@@ -1,0 +1,80 @@
+package io.bigmoeonedge.example
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Imports a gguf the user picked with the system file picker (Storage Access Framework). The
+ * picker hands back a content:// URI, but the bmoe-cli subprocess needs a real filesystem path,
+ * so we stream the bytes into the app-specific external files dir (no permission required). This
+ * is the Play-flavor path for a model already downloaded with the browser — public Downloads is
+ * not readable without all-files access.
+ *
+ * Copied as `<name>.gguf.part`, renamed on completion, so a partial copy is never listed.
+ */
+object SafImport {
+    private const val PART_SUFFIX = ".part"
+
+    /** Copy the picked document into app storage, reporting progress. Runs on the IO dispatcher. */
+    suspend fun importGguf(
+        ctx: Context,
+        uri: Uri,
+        onProgress: (copied: Long, total: Long) -> Unit,
+    ): Result<File> = withContext(Dispatchers.IO) {
+        runCatching {
+            val (displayName, size) = queryNameAndSize(ctx, uri)
+            val name = displayName.filter { it.isLetterOrDigit() || it in "._-" }
+            require(name.endsWith(".gguf")) { "please pick a .gguf file" }
+
+            val dir = ModelManager.appModelsDir(ctx) ?: error("no app storage available")
+            val finalFile = File(dir, name)
+            if (finalFile.isFile) return@runCatching finalFile
+
+            if (size > 0 && size > dir.usableSpace) {
+                error("not enough free space (need ${size shr 20} MiB)")
+            }
+
+            val part = File(dir, name + PART_SUFFIX)
+            try {
+                val input = ctx.contentResolver.openInputStream(uri) ?: error("cannot open the picked file")
+                input.use { src ->
+                    part.outputStream().use { dst ->
+                        val buf = ByteArray(1 shl 20)
+                        var copied = 0L
+                        while (true) {
+                            val n = src.read(buf)
+                            if (n < 0) break
+                            dst.write(buf, 0, n)
+                            copied += n
+                            onProgress(copied, size)
+                        }
+                        dst.flush()
+                    }
+                }
+                if (!part.renameTo(finalFile)) error("could not finalize the imported file")
+                finalFile
+            } catch (t: Throwable) {
+                part.delete()
+                throw t
+            }
+        }
+    }
+
+    private fun queryNameAndSize(ctx: Context, uri: Uri): Pair<String, Long> {
+        var name = uri.lastPathSegment?.substringAfterLast('/') ?: "model.gguf"
+        var size = -1L
+        ctx.contentResolver.query(uri, null, null, null, null)?.use { c ->
+            if (c.moveToFirst()) {
+                val nameIdx = c.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (nameIdx >= 0 && !c.isNull(nameIdx)) name = c.getString(nameIdx)
+                val sizeIdx = c.getColumnIndex(OpenableColumns.SIZE)
+                if (sizeIdx >= 0 && !c.isNull(sizeIdx)) size = c.getLong(sizeIdx)
+            }
+        }
+        return name to size
+    }
+}


### PR DESCRIPTION
## What

Makes the example app installable from the Play Store without all-files access, and lets a
user bring a model onto the device without adb — while keeping the fast adb-push workflow for
development.

## Flavors (`distribution` dimension)

- **dev** — sideloaded (CI builds and attaches this). Keeps `MANAGE_EXTERNAL_STORAGE` via a
  `src/dev/AndroidManifest.xml` overlay, appId suffix `.dev`. Reads adb-pushed models in place.
- **play** — no broad storage permission, clean appId. Verified on the built APKs: the play
  APK declares only `FOREGROUND_SERVICE(_DATA_SYNC)`, `POST_NOTIFICATIONS`, `WAKE_LOCK`; the
  dev APK additionally has `MANAGE_EXTERNAL_STORAGE`.

`BuildConfig.SHARED_STORAGE` gates every storage-permission code path — no model names or URLs
are hardcoded; the only difference is which directories are scanned.

## In-app model acquisition (both flavors, permission-free)

- **URL download** (`ModelDownloader`) — `DownloadManager` fetches a gguf into the
  app-specific external files dir (resumable, survives process death). Written `*.gguf.part`,
  renamed on success so a partial file is never listed.
- **File import** (`SafImport`) — the system file picker returns a `content://` URI; since the
  `bmoe-cli` subprocess needs a real path, the bytes are streamed into the app files dir with a
  free-space check.

Both show progress in a new "Add a model" card and re-scan on completion.

## Robust MoE detection (`GgufHeader`)

Replaces the 16 MiB substring probe with a streaming gguf-header parse that walks the KV block
and reads tensor names. On a real Gemma 4 gguf the tensor block starts at **~15.8 MiB** — right
at the old probe's edge — so the structured parse removes that fragility. Falls back to the
substring scan if parsing fails, so detection can only improve.

## Validation

- `assembleDevDebug` + `assemblePlayDebug` both build; Kotlin compiles for both flavors.
- Declared permissions confirmed via `aapt dump permissions` on both APKs (see above).
- The `GgufHeader` parse algorithm was cross-checked against the two tiny fixtures and the real
  Gemma 4 header (finds the MoE marker, reaches the tensor block at 15.8 MiB).

## Note

CI builds the **dev** flavor APK (`app/build/outputs/apk/dev/debug/app-dev-debug.apk`).