### PR TITLE
feat: intra-layer I/O–compute overlap, mmap baseline & reasoning/UX fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/llama.cpp"]
 	path = third_party/llama.cpp
-	url = https://github.com/ggml-org/llama.cpp.git
+	url = https://github.com/Helldez/llama.cpp.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+- Intra-layer I/O–compute overlap (`--overlap`): expert reads for a layer run on the I/O
+  pool while the same layer's routed experts are computed, hiding flash latency behind FFN
+  compute. Opt-in and byte-identical to the serial path (gates G4a/b/c). Requires one
+  ~25-line per-expert readiness hook in the CPU `mul_mat_id` kernel, carried as a 1-commit
+  fork branch (`bmoe/expert-ready-hook`) on `Helldez/llama.cpp` with an explicit sunset;
+  the serial streaming path still builds and runs against stock upstream. See
+  `docs/seam.md` § 3.
+
 ## [0.1.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ Semantic Versioning.
   fork branch (`bmoe/expert-ready-hook`) on `Helldez/llama.cpp` with an explicit sunset;
   the serial streaming path still builds and runs against stock upstream. See
   `docs/seam.md` § 3.
+- Model-agnostic reasoning control (`--no-think`): renders the chat template with
+  `enable_thinking=false`, suppressing a reasoning model's thinking channel at the source
+  for Qwen3, Gemma and any template that honours the kwarg — replacing the Qwen-only
+  `/no_think` prompt suffix.
+- Android example: an **mmap baseline (no streaming)** settings toggle to compare against,
+  plus an **I/O–compute overlap** toggle; the streaming controls disable when mmap is on.
+
+### Fixed
+- Reasoning is now stripped from the shown answer: the chat parser arena is loaded from the
+  applied template, so `common_chat_parse` finds the reasoning delimiters instead of leaking
+  a model's (empty or not) thinking markers into the content.
+- Android: **Stop** no longer terminates the whole app — the stderr drain thread is guarded,
+  so the stream close from `Process.destroy()` no longer throws on its own thread; a separate
+  wakelock under-lock race on Stop is also fixed.
+- Android: all-files access is requested on demand (an explicit storage rescan), not at
+  startup — downloaded, imported and picked models need no permission.
+- Android: the headline tok/s reports the aggregate average once generation finishes, rather
+  than the last token's instantaneous rate.
 
 ## [0.1.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Semantic Versioning.
   plus an **I/O–compute overlap** toggle; the streaming controls disable when mmap is on.
 
 ### Fixed
+- Storage where O_DIRECT lies is now handled: some emulated / FUSE-backed volumes (an app-private
+  dir under `/storage/emulated`, where imported and downloaded models land) let the O_DIRECT open
+  succeed but return garbage on read, silently corrupting expert weights into nonsense output. The
+  streamer now verifies a direct read against a buffered read at init and falls back to buffered
+  I/O when they disagree; real filesystems (adb-pushed models, desktop) keep O_DIRECT.
 - Android: **Stop** no longer terminates the whole app — the stderr drain thread is guarded,
   so the stream close from `Process.destroy()` no longer throws on its own thread; a separate
   wakelock under-lock race on Stop is also fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ Semantic Versioning.
   plus an **I/O–compute overlap** toggle; the streaming controls disable when mmap is on.
 
 ### Fixed
-- Reasoning is now stripped from the shown answer: the chat parser arena is loaded from the
-  applied template, so `common_chat_parse` finds the reasoning delimiters instead of leaking
-  a model's (empty or not) thinking markers into the content.
 - Android: **Stop** no longer terminates the whole app — the stderr drain thread is guarded,
   so the stream close from `Process.destroy()` no longer throws on its own thread; a separate
   wakelock under-lock race on Stop is also fixed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
 # BigMoeOnEdge — top-level build.
 #
 # The engine (`bmoe_core`) depends only on its own public headers under include/bmoe
-# and on llama.cpp's PUBLIC C API (llama.h / ggml.h). It never touches llama.cpp
-# internals: MoE expert streaming is driven entirely through the public eval-callback
-# and public gguf accessors. That is what lets the llama.cpp submodule track upstream
-# with nothing more than a pointer bump — there is no fork and no in-tree patch.
+# and on llama.cpp's PUBLIC C API (llama.h / ggml.h). The serial streaming path never
+# touches llama.cpp internals: MoE expert streaming is driven entirely through the public
+# eval-callback and public gguf accessors, so it tracks upstream with nothing more than a
+# submodule pointer bump — no in-tree patch. The one exception is the optional `--overlap`
+# feature, which needs a per-expert wait point the public API does not expose: the submodule
+# pins a fork branch (`bmoe/expert-ready-hook` on Helldez/llama.cpp) adding one ~25-line
+# readiness hook, detected here as BMOE_HAVE_EXPERT_READY_HOOK. It is zero-cost when absent,
+# the serial path still builds against stock upstream, and it sunsets the moment upstream
+# ships an equivalent callback. See docs/seam.md § 3.
 #
 # llama.cpp is an optional dependency at configure time: when the submodule is absent
 # only the pure-policy code (config validation) compiles, so the scaffold and a subset

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ smaller budget thrashes and is slower than no cache. Gemma-4-26B-A4B-Q4_K_M reac
 **3.48 tok/s** at the same best setting. Full matrix and method:
 [docs/benchmarks.md](docs/benchmarks.md), [docs/benchmark-method.md](docs/benchmark-method.md).
 
+An optional `--overlap` mode pipelines each layer's expert reads with its compute (via the
+fork's per-expert readiness hook) instead of blocking on them, aiming to hide flash I/O
+behind FFN compute. It is byte-identical to the serial path (gate G4); its on-device
+throughput is being measured and the table will gain an overlap row once those numbers land.
+
 The same works on desktop for a model larger than the machine's RAM. Qwen3-30B-A3B-Q4_K_M
 (17.3 GiB) on a Windows PC with 14.8 GiB RAM (1.17× RAM, so it cannot be held resident),
 cache 4000 MiB, 4 I/O lanes, 4 threads → **2.58 tok/s**, 861 MiB/token, 44.8% cache hit,
@@ -67,6 +72,10 @@ build/cli/bmoe-cli -m Qwen3-30B-A3B-Q4_K_M.gguf --moe-stream \
   --cache-mb 4000 --io-threads 4 -t 4 -n 48 --chatml -p "Explain MoE routing."
 ```
 
+Add `--overlap` to pipeline expert reads with compute (needs the fork submodule), and
+`--no-think` to render the chat template with reasoning off. Omit `--moe-stream` entirely
+for the plain mmap baseline the streaming modes are compared against.
+
 Run the byte-identity gates (needs `python3` with the `gguf` package):
 
 ```bash
@@ -77,7 +86,11 @@ cd build && ctest --output-on-failure
 
 A minimal chat app with a live telemetry panel is in
 [`examples/android`](examples/android). Build the CLI for arm64 with
-`scripts/build-android.ps1`, then build the APK and push a model.
+`scripts/build-android.ps1`, then build the APK and push a model. Its settings expose the
+streaming knobs (expert cache, I/O lanes, O_DIRECT, I/O–compute overlap), a reasoning
+toggle, and an **mmap baseline** switch that turns streaming off entirely so you can compare
+modes on the same device; the panel reports per-token compute-vs-flash split, cache hit rate
+and the aggregate tok/s at the end of a run.
 
 ## How it works, briefly
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ slices from flash on demand, so an 18.5 GB model runs on an 11 GB phone, lossles
   cache, up to **3.75 tok/s** with a 4 GiB expert cache and 4 read lanes, byte-identical to
   a full in-memory run. See the table below, or [docs/benchmarks.md](docs/benchmarks.md) for
   the full matrix (Qwen + Gemma, mean/min/max/p95).
-- **No fork of llama.cpp.** Expert streaming is driven entirely through llama.cpp's
-  public eval-callback and public gguf accessors. The `third_party/llama.cpp` submodule
-  is stock upstream; updating it is a pointer bump, not a rebase. See
-  [docs/architecture.md](docs/architecture.md).
+- **Public-API streaming seam.** Expert streaming is driven entirely through llama.cpp's
+  public eval-callback and public gguf accessors and works against stock upstream. The one
+  exception is the optional intra-layer overlap feature (`--overlap`), which needs a ~25-line
+  per-expert readiness hook carried as a single-commit fork branch — an explicit tide-me-over
+  that is dropped the moment upstream ships an equivalent callback. Everything else, and the
+  serial streamer in full, is a submodule pointer bump away from upstream. See
+  [docs/architecture.md](docs/architecture.md) and
+  [docs/seam.md § 3](docs/seam.md).
 - **Modular.** A ports-and-adapters engine: the streaming strategy, the metrics sink and
   the target are interfaces. Adding a MoE architecture is one registry row
   ([docs/adding-a-model.md](docs/adding-a-model.md)).

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -77,9 +77,10 @@ static void print_usage(const char * argv0) {
                 "      --no-odirect        do not bypass the page cache\n"
                 "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
                 "      --force-cache       allow a cache-mb in the pathological band\n"
+                "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
                 "      --list-archs        print supported MoE architectures and exit\n"
                 "\n"
-                "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS\n",
+                "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP\n",
                 argv0, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
 }
 
@@ -126,6 +127,8 @@ int main(int argc, char ** argv) {
             cfg.moe.load_all = true;
         else if (a == "--force-cache")
             cfg.moe.force_cache = true;
+        else if (a == "--overlap")
+            cfg.moe.overlap = true;
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)
@@ -145,6 +148,7 @@ int main(int argc, char ** argv) {
     if (cfg.moe.cache_mb == 0) cfg.moe.cache_mb = env_int("BMOE_CACHE_MB", 0);
     if (cfg.moe.io_threads == 4) cfg.moe.io_threads = env_int("BMOE_IO_THREADS", 4);
     if (!cfg.progress) cfg.progress = env_int("BMOE_PROGRESS", 0) != 0;
+    if (!cfg.moe.overlap) cfg.moe.overlap = env_int("BMOE_OVERLAP", 0) != 0;
 
     if (cfg.model_path.empty()) {
         print_usage(argv[0]);
@@ -210,6 +214,9 @@ int main(int argc, char ** argv) {
                     s.moe_io_seconds > 0 ? s.moe_read_mib / s.moe_io_seconds : 0.0);
         if (s.cache_hit_pct >= 0.0)
             std::printf("moe-cache: %.1f%% hit, resident %.1f MiB\n", s.cache_hit_pct, s.cache_resident_mib);
+        if (cfg.moe.overlap)
+            std::printf("moe-overlap: stall %.3f s/token (flash reads overlapped with FFN compute)\n",
+                        s.moe_stall_s_per_token);
     }
     return 0;
 }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -31,4 +31,20 @@ if(BMOE_HAVE_LLAMA)
     target_compile_definitions(bmoe_core PUBLIC BMOE_HAVE_LLAMA=1)
     find_package(Threads REQUIRED)
     target_link_libraries(bmoe_core PUBLIC Threads::Threads)
+
+    # Intra-layer I/O–compute overlap needs the fork's expert-ready hook in ggml-cpu.h. Detect
+    # it by inspecting the submodule header rather than the git remote, so any tree carrying the
+    # hook (a rebase, a different fork) enables the feature. PUBLIC so cli/ and tests/ see it.
+    set(_ggml_cpu_h "${CMAKE_SOURCE_DIR}/third_party/llama.cpp/ggml/include/ggml-cpu.h")
+    if(EXISTS "${_ggml_cpu_h}")
+        file(READ "${_ggml_cpu_h}" _ggml_cpu_src)
+        if(_ggml_cpu_src MATCHES "ggml_cpu_set_expert_ready_hook")
+            target_compile_definitions(bmoe_core PUBLIC BMOE_HAVE_EXPERT_READY_HOOK=1)
+            message(STATUS "bmoe: expert-ready hook present (I/O–compute overlap available)")
+        else()
+            message(STATUS "bmoe: expert-ready hook absent (overlap unavailable)")
+        endif()
+    else()
+        message(STATUS "bmoe: expert-ready hook absent (overlap unavailable)")
+    endif()
 endif()

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -31,6 +31,12 @@ struct MoeStreamConfig {
     bool load_all = false;    // debug/A-B: load ALL experts each token (full-sweep baseline)
     bool force_cache = false; // allow a cache_mb in the pathological band (tests/experiments)
 
+    // Overlap async expert reads with FFN compute instead of blocking on them: load_layer()
+    // publishes the reads and returns immediately, and the CPU mul_mat_id kernel blocks per
+    // expert (via the fork's expert-ready hook) only if that expert's slice is not yet in.
+    // Requires the Helldez/llama.cpp fork submodule (the hook); run() fails fast otherwise.
+    bool overlap = false;
+
     static constexpr int cache_min_mb = 1500; // smallest non-pathological cache (see above)
     static constexpr int io_threads_max = 8;
 };

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -21,8 +21,11 @@ public:
 
     // Make layer `il`'s routed experts resident. `ids` holds n_ids expert indices
     // (duplicates allowed; the union across a batch's tokens for prefill, exactly the
-    // top-k for n=1 decode). Blocks until every routed slice is in place at its
-    // canonical offset inside the bound tensor. Returns false on I/O failure.
+    // top-k for n=1 decode). In the default (serial) mode this BLOCKS until every routed
+    // slice is in place at its canonical offset inside the bound tensor. In overlap mode
+    // it only publishes the reads and returns immediately; the layer's matmul then blocks
+    // per expert (via the fork's expert-ready hook) until that expert's slice arrives.
+    // Returns false on I/O failure (serial) or if a prior async batch already failed.
     virtual bool load_layer(int il, const int32_t * ids, int n_ids) = 0;
 
     // Cumulative streaming statistics, for telemetry and the end-of-run summary.
@@ -32,6 +35,7 @@ public:
         long long cache_hits = 0;          // expert lookups served from the cache
         long long cache_lookups = 0;       // total expert lookups (hits + misses)
         uint64_t cache_resident_bytes = 0; // currently resident cached slice bytes
+        double stall_seconds = 0.0;        // overlap: summed across compute threads (0 when serial)
     };
     virtual Stats stats() const = 0;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -42,7 +42,7 @@ struct RunSummary {
     double moe_compute_s_per_token = 0.0;
     double moe_io_s_per_token = 0.0;
     double moe_stall_s_per_token = 0.0; // overlap only: per-token wall the kernel waited on flash
-    double cache_hit_pct = -1.0; // -1 when no cache
+    double cache_hit_pct = -1.0;        // -1 when no cache
     double cache_resident_mib = 0.0;
 };
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -15,8 +15,9 @@ struct TokenMetrics {
     int step = 0;               // 1-based index of this token
     int steps = 0;              // n_predict target
     double wall_ms = 0.0;       // total wall time for this token
-    double io_ms = 0.0;         // flash read time this token (subset of wall)
-    double compute_ms = 0.0;    // wall - io
+    double io_ms = 0.0;         // flash read time this token (serial: subset of wall; overlap: lane-busy sum)
+    double compute_ms = 0.0;    // serial: wall - io; overlap: wall - stall
+    double stall_ms = 0.0;      // overlap only: wall time the FFN kernel blocked on flash (0 when serial)
     uint64_t read_bytes = 0;    // expert bytes pulled from flash this token
     double cache_hit_pct = 0.0; // cumulative cache hit rate (-1 if no cache)
     std::string piece;          // text of just this token (delta, for inline streaming)
@@ -40,6 +41,7 @@ struct RunSummary {
     double moe_io_seconds = 0.0;
     double moe_compute_s_per_token = 0.0;
     double moe_io_s_per_token = 0.0;
+    double moe_stall_s_per_token = 0.0; // overlap only: per-token wall the kernel waited on flash
     double cache_hit_pct = -1.0; // -1 when no cache
     double cache_resident_mib = 0.0;
 };

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -25,6 +25,12 @@ ValidationResult validate(const RunConfig & cfg) {
         return fail("n_ctx must be positive");
     }
 
+    // overlap is meaningless without streaming (it gates the streamer's own reads). The
+    // hook-availability check is deferred to run(): validate() stays pure (no native).
+    if (cfg.moe.overlap && !cfg.moe.enabled) {
+        return fail("moe.overlap requires moe.enabled");
+    }
+
     if (cfg.moe.enabled) {
         const MoeStreamConfig & m = cfg.moe;
         if (m.io_threads < 1 || m.io_threads > MoeStreamConfig::io_threads_max) {

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -337,8 +337,7 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
         s.moe_stall_s_per_token = n_gen ? gen_stall_seconds / n_gen : 0.0;
         // Overlap: compute is wall minus the flash wait (I/O runs alongside it, so subtracting
         // io would double-count). Serial: I/O is a slice of wall, so compute is wall minus io.
-        s.moe_compute_s_per_token =
-            s.s_per_token - (cfg.moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token);
+        s.moe_compute_s_per_token = s.s_per_token - (cfg.moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token);
         if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;
         s.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
         s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -115,6 +115,11 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
             common_chat_params cp = common_chat_templates_apply(chat_tmpls.get(), inputs);
             prompt = cp.prompt;
             parse_params = common_chat_parser_params(cp);
+            // The common_chat_parser_params(cp) constructor copies only format + generation_prompt;
+            // it does NOT carry the generated PEG parser. Without it common_chat_parse cannot find
+            // the template's reasoning delimiters, so a model's thinking markers (Qwen's <think>,
+            // Gemma's thought channel) leak into content. Load the arena as the server does.
+            if (!cp.parser.empty()) parse_params.parser.load(cp.parser);
             // AUTO extracts reasoning into msg.reasoning_content (format-driven from the template),
             // leaving msg.content as just the final answer.
             parse_params.reasoning_format = COMMON_REASONING_FORMAT_AUTO;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -115,13 +115,13 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
             common_chat_params cp = common_chat_templates_apply(chat_tmpls.get(), inputs);
             prompt = cp.prompt;
             parse_params = common_chat_parser_params(cp);
-            // The common_chat_parser_params(cp) constructor copies only format + generation_prompt;
-            // it does NOT carry the generated PEG parser. Without it common_chat_parse cannot find
-            // the template's reasoning delimiters, so a model's thinking markers (Qwen's <think>,
-            // Gemma's thought channel) leak into content. Load the arena as the server does.
-            if (!cp.parser.empty()) parse_params.parser.load(cp.parser);
             // AUTO extracts reasoning into msg.reasoning_content (format-driven from the template),
             // leaving msg.content as just the final answer.
+            //
+            // NOTE: we deliberately do NOT load the generated PEG parser (cp.parser) here. Running
+            // it over the streamed partial text mangles the content on real templates. Reasoning is
+            // suppressed at the source instead via inputs.enable_thinking above; any residual empty
+            // markers are cosmetic. A safe display-time strip is tracked separately.
             parse_params.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
         } catch (const std::exception & e) {
             std::fprintf(stderr, "bmoe: chat template unavailable (%s); using raw prompt\n", e.what());

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -200,6 +200,18 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
             return fail("expert stream source init failed");
         hook.set_source(&source);
 
+        if (cfg.moe.overlap) {
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+            // Register the per-expert wait hook, and wire an abort callback so a mid-decode read
+            // failure tears the graph down cleanly instead of computing on a half-read expert.
+            source.enable_overlap_hook();
+            llama_set_abort_callback(
+                ctx, [](void * ud) -> bool { return static_cast<ExpertStreamSource *>(ud)->fatal(); }, &source);
+#else
+            return fail("--overlap requires the bmoe llama.cpp fork (expert-ready hook not compiled in)");
+#endif
+        }
+
         llama_memory_clear(llama_get_memory(ctx), true); // discard warm-up KV
     }
 
@@ -208,7 +220,10 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
     load_seconds = secs(t_load0, t_prefill0); // everything up to here is "load"
     {
         llama_batch pf = llama_batch_get_one(tokens.data(), n_prompt);
-        if (llama_decode(ctx, pf) != 0) return fail("prefill decode failed");
+        if (llama_decode(ctx, pf) != 0) {
+            if (cfg.moe.overlap && source.fatal()) return fail("expert stream I/O failed during overlap prefill");
+            return fail("prefill decode failed");
+        }
     }
     prefill_seconds = secs(t_prefill0, clock_t_::now());
     const float * logits = llama_get_logits_ith(ctx, -1); // logits of the last output
@@ -238,10 +253,12 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
     // per-token average would badly inflate the flash-I/O figure.
     long long prev_bytes = cfg.moe.enabled ? (long long) source.stats().read_bytes : 0;
     double prev_io_s = cfg.moe.enabled ? source.stats().read_seconds : 0.0;
+    double prev_stall_s = cfg.moe.enabled ? source.stats().stall_seconds : 0.0;
 
     // Generation-only accumulators, summed from the measured per-token values.
     uint64_t gen_read_bytes = 0;
     double gen_io_seconds = 0.0;
+    double gen_stall_seconds = 0.0;
 
     for (int t = 0; t < cfg.n_predict; ++t) {
         llama_token tok = argmax(logits, n_vocab);
@@ -256,7 +273,10 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
         llama_batch step = llama_batch_get_one(&tok, 1);
         int dec = llama_decode(ctx, step);
         auto s1 = clock_t_::now();
-        if (dec != 0) return fail("decode failed during generation");
+        if (dec != 0) {
+            if (cfg.moe.overlap && source.fatal()) return fail("expert stream I/O failed during overlap decode");
+            return fail("decode failed during generation");
+        }
         logits = llama_get_logits_ith(ctx, -1);
 
         ++n_gen;
@@ -273,13 +293,23 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
             IExpertSource::Stats st = source.stats();
             m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
             m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
-            m.compute_ms = m.wall_ms - m.io_ms;
+            if (cfg.moe.overlap) {
+                // stall_seconds is summed across all compute threads that blocked on flash; divide
+                // by the thread count for a wall-clock approximation of the token's flash wait.
+                // compute is then wall minus that wait (io_ms here is lane-busy work, overlapped).
+                m.stall_ms = (st.stall_seconds - prev_stall_s) * 1000.0 / cfg.n_threads;
+                m.compute_ms = m.wall_ms - m.stall_ms;
+            } else {
+                m.compute_ms = m.wall_ms - m.io_ms;
+            }
             if (m.compute_ms < 0) m.compute_ms = 0;
             m.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
             prev_bytes = (long long) st.read_bytes;
             prev_io_s = st.read_seconds;
+            prev_stall_s = st.stall_seconds;
             gen_read_bytes += m.read_bytes;
             gen_io_seconds += m.io_ms / 1000.0;
+            gen_stall_seconds += m.stall_ms / 1000.0;
         } else {
             m.compute_ms = m.wall_ms;
             m.cache_hit_pct = -1.0;
@@ -304,7 +334,11 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
         s.moe_read_mib = gen_read_bytes / (1024.0 * 1024.0);
         s.moe_io_seconds = gen_io_seconds;
         s.moe_io_s_per_token = n_gen ? gen_io_seconds / n_gen : 0.0;
-        s.moe_compute_s_per_token = s.s_per_token - s.moe_io_s_per_token;
+        s.moe_stall_s_per_token = n_gen ? gen_stall_seconds / n_gen : 0.0;
+        // Overlap: compute is wall minus the flash wait (I/O runs alongside it, so subtracting
+        // io would double-count). Serial: I/O is a slice of wall, so compute is wall minus io.
+        s.moe_compute_s_per_token =
+            s.s_per_token - (cfg.moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token);
         if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;
         s.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
         s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -9,25 +9,27 @@ namespace {
 class CsvMetricsSink final : public IMetricsSink {
 public:
     explicit CsvMetricsSink(std::FILE * f) : f_(f) {
-        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct\n");
+        // stall_ms is appended LAST so existing positional parsers stay valid (0 when serial).
+        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms\n");
     }
     ~CsvMetricsSink() override {
         if (f_) std::fclose(f_);
     }
 
     void on_token(const TokenMetrics & m) override {
-        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f\n", m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms,
-                     (unsigned long long) m.read_bytes, m.cache_hit_pct);
+        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f\n", m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms,
+                     (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
         std::fprintf(f_,
                      "# summary tokens=%d s/tok=%.3f tok/s=%.3f read_MiB=%.1f "
                      "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f "
-                     "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f\n",
+                     "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
-                     s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0);
+                     s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
+                     s.moe_stall_s_per_token);
         std::fflush(f_);
     }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -254,8 +254,8 @@ void ExpertStreamSource::io_drain(int lane, uint64_t my_gen) {
             ready_[(size_t) j.flag].gen.store(batch_flag_gen_, std::memory_order_release);
             {
                 std::lock_guard<std::mutex> lk(ready_mtx_);
+                ready_cv_.notify_all();
             }
-            ready_cv_.notify_all();
         }
         std::lock_guard<std::mutex> lk(io_mtx_);
         if (++done_cnt_ == batch_njobs_) io_cv_done_.notify_all();
@@ -563,8 +563,8 @@ void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
         fatal_.store(true, std::memory_order_release);
         {
             std::lock_guard<std::mutex> lk(ready_mtx_);
+            ready_cv_.notify_all();
         }
-        ready_cv_.notify_all();
         return;
     }
     const size_t idx = (size_t) p * (size_t) n_expert_ + (size_t) expert;
@@ -625,8 +625,8 @@ void ExpertStreamSource::shutdown() {
     fatal_.store(true, std::memory_order_release);
     {
         std::lock_guard<std::mutex> lk(ready_mtx_);
+        ready_cv_.notify_all();
     }
-    ready_cv_.notify_all();
     {
         std::lock_guard<std::mutex> lk(io_mtx_);
         io_stop_ = true;

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -128,6 +128,37 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     }
     fsize_ = pio::file_size(primary);
 
+    // Verify O_DIRECT actually returns correct bytes on this storage. On some emulated / FUSE-backed
+    // volumes (e.g. an app-private dir under /storage/emulated) the open SUCCEEDS but direct reads
+    // return garbage, silently corrupting expert weights → nonsense output. Compare one aligned
+    // block read directly against the same block read buffered; on any mismatch, fall back to
+    // buffered I/O for this file. On real filesystems (adb-pushed models, desktop) the two match
+    // and O_DIRECT is kept.
+    if (o_direct_ && fsize_ >= (uint64_t) align_) {
+        uint64_t voff = (fsize_ / 2) & ~(uint64_t) (align_ - 1);
+        if (voff + align_ > fsize_) voff = 0;
+        void * dbuf = pio::alloc_aligned(align_, align_);
+        pio::fd_t vfd = pio::open_read(gguf_path.c_str(), false);
+        if (dbuf && pio::fd_ok(vfd)) {
+            std::vector<char> bbuf(align_);
+            long long gd = pio::pread_at(primary, dbuf, align_, voff);
+            long long gb = pio::pread_at(vfd, bbuf.data(), align_, voff);
+            if (gd != (long long) align_ || gb != (long long) align_ ||
+                std::memcmp(dbuf, bbuf.data(), align_) != 0) {
+                std::fprintf(stderr, "bmoe: O_DIRECT returns wrong data on this storage — using buffered I/O\n");
+                o_direct_ = false;
+                pio::close_fd(primary);
+                primary = pio::open_read(gguf_path.c_str(), false);
+            }
+        }
+        if (dbuf) pio::aligned_free(dbuf);
+        if (pio::fd_ok(vfd)) pio::close_fd(vfd);
+        if (!pio::fd_ok(primary)) {
+            std::fprintf(stderr, "bmoe: reopen after O_DIRECT check failed\n");
+            return false;
+        }
+    }
+
     fds_.assign(io_threads_, pio::fd_invalid);
     fds_buf_.assign(io_threads_, pio::fd_invalid);
     bounces_.assign(io_threads_, nullptr);

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -1,11 +1,15 @@
 #include "expert_stream_source.h"
 
 #include "ggml.h"
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+#include "ggml-cpu.h" // ggml_cpu_set_expert_ready_hook (fork-only)
+#endif
 
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <thread>
 
 namespace bmoe {
 
@@ -31,6 +35,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     n_layer_ = (int) layers_.size();
     o_direct_ = cfg.o_direct;
     load_all_ = cfg.load_all;
+    overlap_ = cfg.overlap;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
 
@@ -150,8 +155,34 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     io_stop_ = false;
     io_err_.store(false);
 
+    if (overlap_) {
+        // One readiness cell per (projection, expert), and a map from each bound expert tensor
+        // (the persistent model weight, stable across decodes) back to its (layer, projection)
+        // so the hook can find the cell to wait on. Built after the rebind above.
+        ready_ = std::vector<ReadyFlag>((size_t) MoeRecipe::max_exps * (size_t) n_expert_);
+        async_gen_.store(0);
+        cur_il_.store(-1);
+        fatal_.store(false);
+        stall_ns_.store(0);
+        batch_flag_gen_ = 0;
+        staged_.reserve(n_expert_);
+        texp_.clear();
+        texp_.reserve((size_t) n_layer_ * MoeRecipe::max_exps);
+        for (int il = 0; il < n_layer_; ++il) {
+            const LayerExperts & L = layers_[il];
+            if (!L.bound) continue;
+            for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                if (L.proj[p].tensor)
+                    texp_[(const void *) L.proj[p].tensor] = ((uint32_t) il << 8) | (uint32_t) p;
+        }
+    }
+
     active_ = true;
-    for (int lane = 1; lane < io_threads_; ++lane)
+    // Serial: lane 0 is the calling thread (it drains inline), workers own lanes 1..N-1.
+    // Overlap: the caller never drains — every lane 0..N-1 gets a worker so reads proceed
+    // while the compute threads run the FFN and block per expert on the readiness flags.
+    const int first_worker_lane = overlap_ ? 0 : 1;
+    for (int lane = first_worker_lane; lane < io_threads_; ++lane)
         io_pool_.emplace_back(&ExpertStreamSource::io_worker, this, lane);
 
     std::fprintf(stderr, "bmoe: expert streaming ON  n_expert=%d o_direct=%d io_threads=%d cache=%zu MiB\n", n_expert_,
@@ -213,7 +244,20 @@ void ExpertStreamSource::io_drain(int lane, uint64_t my_gen) {
             i = next_idx_++;
         }
         const IoJob & j = jobs_[i];
-        if (!read_slice(lane, j.dst, j.off, j.nbytes)) io_err_.store(true);
+        if (!read_slice(lane, j.dst, j.off, j.nbytes)) {
+            io_err_.store(true);
+            if (overlap_) fatal_.store(true, std::memory_order_release);
+        }
+        // Overlap: publish this expert's readiness (batch_flag_gen_ is the async_gen_ of the
+        // in-flight batch, fixed until it fully drains) and wake any compute thread blocked on
+        // it. Notify even on failure so a straggler wakes and observes fatal_ instead of hanging.
+        if (j.flag >= 0) {
+            ready_[(size_t) j.flag].gen.store(batch_flag_gen_, std::memory_order_release);
+            {
+                std::lock_guard<std::mutex> lk(ready_mtx_);
+            }
+            ready_cv_.notify_all();
+        }
         std::lock_guard<std::mutex> lk(io_mtx_);
         if (++done_cnt_ == batch_njobs_) io_cv_done_.notify_all();
     }
@@ -282,6 +326,7 @@ void ExpertStreamSource::evict_tail() {
 // ── load: stage routed experts, read the batch, evict cold entries to budget ────────
 bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     if (!active_ || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0) return false;
+    if (overlap_) return load_layer_async(il, ids, n_ids);
     LayerExperts & L = layers_[il];
     cgen_++;
     jobs_.clear();
@@ -372,18 +417,220 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     return true;
 }
 
+// ── overlap load: publish the routed reads, mark readiness, return without waiting ──────
+//
+// The bookkeeping is identical to the serial path but split in two: cache/LRU accounting is
+// per-EXPERT (a hit resolves all of an expert's projections at once), while the jobs are
+// emitted PROJECTION-MAJOR (all gate slices, then all up, then all down). mul_mat_id consumes
+// the projections in that order, so projection-major reads feed the kernel roughly in the
+// order it blocks on them, minimising stalls. Correctness does not depend on the order — the
+// readiness flags gate each expert regardless — only latency does.
+bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids) {
+    LayerExperts & L = layers_[il];
+
+    // 1. Drain the previous batch fully before reusing jobs_/the flags. This is the eviction
+    //    safety guarantee (no worker still reading an about-to-be-evicted page) and it covers
+    //    load_all, whose surplus jobs no hook ever waits on. Serial's epilogue waited here too.
+    {
+        std::unique_lock<std::mutex> lk(io_mtx_);
+        io_cv_done_.wait(lk, [&] { return done_cnt_ == batch_njobs_ || io_stop_; });
+    }
+    if (fatal_.load(std::memory_order_acquire)) return false;
+
+    // 2. New generation for this layer. A flag counts as ready only once its gen matches.
+    const uint32_t gen = async_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
+    cur_il_.store(il, std::memory_order_relaxed);
+    cgen_++;
+    jobs_.clear();
+
+    auto mark_ready = [&](int p, int e) {
+        ready_[(size_t) p * (size_t) n_expert_ + (size_t) e].gen.store(gen, std::memory_order_release);
+    };
+
+    // 3a. Dedup + sort ascending (matches the hook's ascending expert visitation order).
+    std::fill(seen_.begin(), seen_.end(), (uint8_t) 0);
+    staged_.clear();
+    for (int i = 0; i < n_ids; ++i) {
+        const int e = load_all_ ? (i < n_expert_ ? i : -1) : ids[i];
+        if (e < 0 || e >= n_expert_ || seen_[e]) continue;
+        seen_[e] = 1;
+        staged_.push_back(e);
+    }
+    if (load_all_) {
+        for (int e = 0; e < n_expert_; ++e) {
+            if (seen_[e]) continue;
+            seen_[e] = 1;
+            staged_.push_back(e);
+        }
+    }
+    std::sort(staged_.begin(), staged_.end());
+
+    if (cache_max_ == 0) {
+        // Cache off: every (projection, expert) is a fresh read into the shared full-size slot
+        // at its canonical offset e*slice. Emit projection-major.
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            const uint64_t slice = L.proj[p].nb2;
+            if (slice == 0) continue; // absent slot in a fused layout
+            for (int e : staged_) {
+                const int32_t flag = (int32_t) ((size_t) p * (size_t) n_expert_ + (size_t) e);
+                jobs_.push_back({(char *) slot_[p] + (uint64_t) e * slice,
+                                 L.proj[p].file_off + (uint64_t) e * slice, slice, flag});
+            }
+        }
+    } else {
+        // Cache on: per-expert LRU bookkeeping (hit → mark all projections ready now; miss →
+        // commit the pages and remember it). Then emit the misses' jobs projection-major.
+        seen_.assign(seen_.size(), 0);            // reuse as a per-staged miss marker keyed by expert
+        for (int e : staged_) {
+            const int32_t id = il * n_expert_ + e;
+            clookups_++;
+            cstamp_[id] = cgen_;
+            if (cvalid_[id]) {
+                chits_++;
+                lru_unlink(id);
+                lru_push_front(id);
+                for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                    if (L.proj[p].nb2) mark_ready(p, e);
+                continue;
+            }
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                const uint64_t slice = L.proj[p].nb2;
+                if (slice == 0) continue;
+                char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
+                uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
+                uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
+                if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) {
+                    std::fprintf(stderr, "bmoe: commit failed\n");
+                    fatal_.store(true, std::memory_order_release);
+                    return false;
+                }
+            }
+            cvalid_[id] = 1;
+            cresident_ += entry_bytes(il);
+            lru_push_front(id);
+            seen_[e] = 1; // this expert missed → its projections need reads
+        }
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            const uint64_t slice = L.proj[p].nb2;
+            if (slice == 0) continue;
+            for (int e : staged_) {
+                if (!seen_[e]) continue; // cache hit, already marked ready
+                const int32_t flag = (int32_t) ((size_t) p * (size_t) n_expert_ + (size_t) e);
+                jobs_.push_back({(char *) lbuf_[p][il] + (uint64_t) e * slice,
+                                 L.proj[p].file_off + (uint64_t) e * slice, slice, flag});
+            }
+        }
+    }
+
+    // 4. Publish the batch and return immediately — no drain. Workers fill the slices and
+    //    flip the flags as they go; the compute threads block on those flags via the hook.
+    {
+        std::lock_guard<std::mutex> lk(io_mtx_);
+        batch_njobs_ = jobs_.size();
+        next_idx_ = 0;
+        done_cnt_ = 0;
+        io_err_.store(false);
+        batch_flag_gen_ = gen;
+        ++batch_gen_;
+    }
+    io_cv_.notify_all();
+
+    // 5. Evict cold entries to budget. Safe to run concurrently with this batch's reads: step 1
+    //    guaranteed no stale in-flight jobs, and current-gen entries (cstamp_ == cgen_) — the
+    //    ones just staged — are never chosen, so eviction only releases pages nobody is reading.
+    if (cache_max_) {
+        while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
+            evict_tail();
+    }
+    return true;
+}
+
+// Static trampoline for the process-global fork hook → member.
+void ExpertStreamSource::c_expert_ready(const ggml_tensor * src0, int expert, void * user_data) {
+    static_cast<ExpertStreamSource *>(user_data)->on_expert_ready(src0, expert);
+}
+
+// Called from EVERY compute thread, for each routed expert, before it reads that expert's rows.
+// Blocks until the expert's slice for the layer in flight is resident (or the run goes fatal).
+void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
+    auto it = texp_.find((const void *) src0);
+    if (it == texp_.end()) return; // not one of our streamed expert tensors
+    const uint32_t packed = it->second;
+    const int il = (int) (packed >> 8);
+    const int p = (int) (packed & 0xff);
+    // Graph order guarantees exactly one layer's experts are staged at a time. A mismatch means
+    // the kernel is asking for a layer we did not stage — fail fast rather than wait forever.
+    if (il != cur_il_.load(std::memory_order_relaxed) || expert < 0 || expert >= n_expert_) {
+        fatal_.store(true, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lk(ready_mtx_);
+        }
+        ready_cv_.notify_all();
+        return;
+    }
+    const size_t idx = (size_t) p * (size_t) n_expert_ + (size_t) expert;
+    const uint32_t want = async_gen_.load(std::memory_order_relaxed);
+    if (ready_[idx].gen.load(std::memory_order_acquire) == want) return; // already resident
+
+    const auto t0 = clock_t_::now();
+    // Short spin first: a slice usually lands within microseconds, cheaper than a syscall.
+    for (int s = 0; s < 2048; ++s) {
+        if (ready_[idx].gen.load(std::memory_order_acquire) == want ||
+            fatal_.load(std::memory_order_acquire)) {
+            stall_ns_.fetch_add(
+                (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
+            return;
+        }
+        std::this_thread::yield();
+    }
+    {
+        std::unique_lock<std::mutex> lk(ready_mtx_);
+        ready_cv_.wait(lk, [&] {
+            return ready_[idx].gen.load(std::memory_order_acquire) == want ||
+                   fatal_.load(std::memory_order_acquire);
+        });
+    }
+    stall_ns_.fetch_add(
+        (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
+}
+
+void ExpertStreamSource::enable_overlap_hook() {
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+    ggml_cpu_set_expert_ready_hook(&ExpertStreamSource::c_expert_ready, this);
+    hook_registered_ = true;
+#endif
+}
+
 IExpertSource::Stats ExpertStreamSource::stats() const {
     Stats s;
     s.read_bytes = (uint64_t) read_bytes_.load();
-    s.read_seconds = read_ns_.load() / 1e9;
+    // Serial: read_ns_ is the wall time the caller was blocked in the read phase. Overlap: the
+    // caller never blocks, so "I/O time" is instead the summed lane-busy time (io_syscall_ns_),
+    // which the runtime reports as lane-busy per token rather than as a slice of wall time.
+    s.read_seconds = (overlap_ ? io_syscall_ns_.load() : read_ns_.load()) / 1e9;
     s.cache_hits = chits_;
     s.cache_lookups = clookups_;
     s.cache_resident_bytes = (uint64_t) cresident_;
+    s.stall_seconds = stall_ns_.load() / 1e9;
     return s;
 }
 
 void ExpertStreamSource::shutdown() {
     if (!active_) return;
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+    // Unregister the process-global hook FIRST: after this no compute thread can enter
+    // on_expert_ready and touch members we are about to tear down.
+    if (hook_registered_) {
+        ggml_cpu_set_expert_ready_hook(nullptr, nullptr);
+        hook_registered_ = false;
+    }
+#endif
+    // Wake any straggler blocked on a readiness flag so it observes fatal_ and unwinds.
+    fatal_.store(true, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lk(ready_mtx_);
+    }
+    ready_cv_.notify_all();
     {
         std::lock_guard<std::mutex> lk(io_mtx_);
         io_stop_ = true;

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -141,10 +141,11 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         pio::fd_t vfd = pio::open_read(gguf_path.c_str(), false);
         if (dbuf && pio::fd_ok(vfd)) {
             std::vector<char> bbuf(align_);
-            long long gd = pio::pread_at(primary, dbuf, align_, voff);
-            long long gb = pio::pread_at(vfd, bbuf.data(), align_, voff);
-            if (gd != (long long) align_ || gb != (long long) align_ ||
-                std::memcmp(dbuf, bbuf.data(), align_) != 0) {
+            const long long want = (long long) align_;
+            const long long gd = pio::pread_at(primary, dbuf, align_, voff);
+            const long long gb = pio::pread_at(vfd, bbuf.data(), align_, voff);
+            const bool bad = gd != want || gb != want || std::memcmp(dbuf, bbuf.data(), align_) != 0;
+            if (bad) {
                 std::fprintf(stderr, "bmoe: O_DIRECT returns wrong data on this storage — using buffered I/O\n");
                 o_direct_ = false;
                 pio::close_fd(primary);

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -172,8 +172,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
             const LayerExperts & L = layers_[il];
             if (!L.bound) continue;
             for (int p = 0; p < MoeRecipe::max_exps; ++p)
-                if (L.proj[p].tensor)
-                    texp_[(const void *) L.proj[p].tensor] = ((uint32_t) il << 8) | (uint32_t) p;
+                if (L.proj[p].tensor) texp_[(const void *) L.proj[p].tensor] = ((uint32_t) il << 8) | (uint32_t) p;
         }
     }
 
@@ -473,14 +472,14 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
             if (slice == 0) continue; // absent slot in a fused layout
             for (int e : staged_) {
                 const int32_t flag = (int32_t) ((size_t) p * (size_t) n_expert_ + (size_t) e);
-                jobs_.push_back({(char *) slot_[p] + (uint64_t) e * slice,
-                                 L.proj[p].file_off + (uint64_t) e * slice, slice, flag});
+                jobs_.push_back(
+                    {(char *) slot_[p] + (uint64_t) e * slice, L.proj[p].file_off + (uint64_t) e * slice, slice, flag});
             }
         }
     } else {
         // Cache on: per-expert LRU bookkeeping (hit → mark all projections ready now; miss →
         // commit the pages and remember it). Then emit the misses' jobs projection-major.
-        seen_.assign(seen_.size(), 0);            // reuse as a per-staged miss marker keyed by expert
+        seen_.assign(seen_.size(), 0); // reuse as a per-staged miss marker keyed by expert
         for (int e : staged_) {
             const int32_t id = il * n_expert_ + e;
             clookups_++;
@@ -575,8 +574,7 @@ void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
     const auto t0 = clock_t_::now();
     // Short spin first: a slice usually lands within microseconds, cheaper than a syscall.
     for (int s = 0; s < 2048; ++s) {
-        if (ready_[idx].gen.load(std::memory_order_acquire) == want ||
-            fatal_.load(std::memory_order_acquire)) {
+        if (ready_[idx].gen.load(std::memory_order_acquire) == want || fatal_.load(std::memory_order_acquire)) {
             stall_ns_.fetch_add(
                 (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
             return;
@@ -586,12 +584,10 @@ void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
     {
         std::unique_lock<std::mutex> lk(ready_mtx_);
         ready_cv_.wait(lk, [&] {
-            return ready_[idx].gen.load(std::memory_order_acquire) == want ||
-                   fatal_.load(std::memory_order_acquire);
+            return ready_[idx].gen.load(std::memory_order_acquire) == want || fatal_.load(std::memory_order_acquire);
         });
     }
-    stall_ns_.fetch_add(
-        (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
+    stall_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
 }
 
 void ExpertStreamSource::enable_overlap_hook() {

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 struct ggml_tensor;
@@ -64,6 +65,16 @@ public:
     bool load_layer(int il, const int32_t * ids, int n_ids) override;
     Stats stats() const override;
 
+    // Register the process-global expert-ready hook so the CPU matmul blocks per expert
+    // until its slice is resident. Only meaningful in overlap mode; a no-op if the fork
+    // hook was not compiled in. Paired with shutdown(), which unregisters it.
+    void enable_overlap_hook();
+
+    // True once an async read has failed or the source is shutting down. Wired to
+    // llama_set_abort_callback so a mid-decode I/O failure aborts the graph cleanly
+    // instead of computing on a half-read expert.
+    bool fatal() const { return fatal_.load(std::memory_order_acquire); }
+
     void shutdown();
 
 private:
@@ -71,11 +82,24 @@ private:
         void * dst = nullptr;
         uint64_t off = 0;
         uint64_t nbytes = 0;
+        int32_t flag = -1; // overlap: index into ready_ to publish on completion; -1 = serial
+    };
+
+    // One readiness cell per (projection, expert). A cell is "ready for the layer in flight"
+    // exactly when gen == async_gen_; padded to a cache line so the compute threads polling it
+    // do not false-share the LRU/job bookkeeping the load thread mutates alongside.
+    struct alignas(64) ReadyFlag {
+        std::atomic<uint32_t> gen{0};
     };
 
     bool read_slice(int lane, void * dst, uint64_t off, uint64_t nbytes);
     void io_drain(int lane, uint64_t my_gen);
     void io_worker(int lane);
+
+    bool load_layer_async(int il, const int32_t * ids, int n_ids); // overlap path
+
+    static void c_expert_ready(const ggml_tensor * src0, int expert, void * user_data);
+    void on_expert_ready(const ggml_tensor * src0, int expert);
 
     // LRU helpers (active only when cache_max_ > 0)
     void lru_unlink(int32_t id);
@@ -86,6 +110,7 @@ private:
     bool active_ = false;
     bool o_direct_ = false;
     bool load_all_ = false;
+    bool overlap_ = false;
     int n_layer_ = 0;
     int n_expert_ = 0;
     uint64_t fsize_ = 0;
@@ -127,10 +152,26 @@ private:
     size_t next_idx_ = 0, done_cnt_ = 0;
     bool io_stop_ = false;
     std::atomic<bool> io_err_{false};
+    uint32_t batch_flag_gen_ = 0; // async_gen_ of the batch in flight; snapshot under io_mtx_ at publish
 
     std::atomic<long long> read_bytes_{0};
     std::atomic<long long> read_ns_{0};
     std::atomic<long long> io_syscall_ns_{0};
+
+    // ── overlap mode: one layer in flight at a time (guaranteed by graph order) ──
+    // A ReadyFlag is ready iff its gen == async_gen_; the load thread bumps async_gen_ per
+    // layer, marks cache hits ready immediately, and workers mark misses ready after the read.
+    // The compute threads look a captured expert tensor up in texp_, then spin/wait on its flag.
+    std::vector<ReadyFlag> ready_;                  // size max_exps * n_expert_; idx = p*n_expert_+e
+    std::atomic<uint32_t> async_gen_{0};
+    std::atomic<int> cur_il_{-1};                   // layer whose experts the hook may wait on
+    std::atomic<bool> fatal_{false};
+    std::mutex ready_mtx_;
+    std::condition_variable ready_cv_;
+    std::atomic<long long> stall_ns_{0};            // summed across all stalling compute threads
+    std::unordered_map<const void *, uint32_t> texp_; // expert tensor* -> (il<<8)|p, built in init
+    std::vector<int> staged_;                       // per-load sorted unique expert scratch
+    bool hook_registered_ = false;
 };
 
 } // namespace bmoe

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -162,15 +162,15 @@ private:
     // A ReadyFlag is ready iff its gen == async_gen_; the load thread bumps async_gen_ per
     // layer, marks cache hits ready immediately, and workers mark misses ready after the read.
     // The compute threads look a captured expert tensor up in texp_, then spin/wait on its flag.
-    std::vector<ReadyFlag> ready_;                  // size max_exps * n_expert_; idx = p*n_expert_+e
+    std::vector<ReadyFlag> ready_; // size max_exps * n_expert_; idx = p*n_expert_+e
     std::atomic<uint32_t> async_gen_{0};
-    std::atomic<int> cur_il_{-1};                   // layer whose experts the hook may wait on
+    std::atomic<int> cur_il_{-1}; // layer whose experts the hook may wait on
     std::atomic<bool> fatal_{false};
     std::mutex ready_mtx_;
     std::condition_variable ready_cv_;
-    std::atomic<long long> stall_ns_{0};            // summed across all stalling compute threads
+    std::atomic<long long> stall_ns_{0};              // summed across all stalling compute threads
     std::unordered_map<const void *, uint32_t> texp_; // expert tensor* -> (il<<8)|p, built in init
-    std::vector<int> staged_;                       // per-load sorted unique expert scratch
+    std::vector<int> staged_;                         // per-load sorted unique expert scratch
     bool hook_registered_ = false;
 };
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,11 @@
 # Architecture
 
 BigMoeOnEdge is a small ports-and-adapters engine that sits **on top of** llama.cpp's
-public API. Its guiding constraint: never modify llama.cpp, so upstream updates cost a
-submodule pointer bump and nothing else.
+public API. Its guiding constraint: drive streaming through the public API so upstream
+updates cost a submodule pointer bump and nothing else. The serial streamer holds to this
+against stock upstream; the one exception is the optional `--overlap` feature, which carries
+a single ~25-line hook on a fork branch with an explicit sunset (see below and
+[seam.md § 3](seam.md)).
 
 ## Layers
 
@@ -21,7 +24,7 @@ core/
     engine/     runtime — composition + the greedy generation loop
     metrics/    csv_metrics_sink
 third_party/
-  llama.cpp     stock upstream submodule (public API consumer only)
+  llama.cpp     upstream submodule; public-API consumer, plus one optional overlap hook
 tests/          byte-identity gates
 examples/android an APK that drives bmoe-cli via ProcessBuilder
 ```
@@ -31,10 +34,10 @@ The pure-policy code (`config.cpp`, `arch_registry.cpp`) compiles with no native
 dependency, so a subset of the project builds and is testable before llama.cpp is
 fetched.
 
-## Why there is no fork
+## Why the streaming seam needs no fork
 
-Streaming experts needs three things from the inference engine. All three are already
-public in llama.cpp:
+Streaming experts serially needs three things from the inference engine. All three are
+already public in llama.cpp:
 
 1. **A hook at routing time.** `llama_context_params.cb_eval` is called for every graph
    node. We ask for only the routing nodes (`ffn_moe_topk-<il>`); ggml computes and
@@ -49,10 +52,18 @@ Loading with `use_mmap=true, use_extra_bufts=false` keeps the weights in their n
 gguf layout (a repacked buffer would break the rebind). That is a public model
 parameter.
 
-Because none of this touches llama.cpp internals, `third_party/llama.cpp` is the
-unmodified upstream repository. Contrast with approaches that patch the model files: those
-must be rebased on every release. Here, `git submodule update --remote` and a rebuild is
-the whole upgrade.
+Because none of this touches llama.cpp internals, the serial streaming path runs against
+the unmodified upstream repository. Contrast with approaches that patch the model files:
+those must be rebased on every release. Here, `git submodule update --remote` and a rebuild
+is the whole upgrade.
+
+The one place we do carry an extension is the optional `--overlap` feature. Overlapping a
+token's expert reads with its expert matmuls needs a per-expert wait point *inside* the CPU
+MoE kernel, which no public API exposes, so the submodule pins a fork branch adding one
+~25-line readiness hook on top of the upstream commit. It is zero-cost when unregistered,
+the serial path still builds against stock upstream, and it is dropped the moment upstream
+ships an equivalent callback. Details and the sunset condition are in
+[seam.md § 3](seam.md).
 
 See [seam.md](seam.md) for the exact callback contract and the ggml behaviour it relies
 on.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -12,7 +12,9 @@ BigMoeOnEdge is an engineering package, not a new technique. The ideas it combin
   the edge.
 
 The contribution here is a clean, modular, llama.cpp-native implementation of
-expert-selective streaming that stays lossless and requires no fork.
+expert-selective streaming that stays lossless and runs on the public API — no fork for the
+serial path, and only a single ~25-line hook (with an explicit sunset) for the optional
+`--overlap` feature. See [seam.md § 3](seam.md).
 
 ## Limitations
 

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -34,6 +34,50 @@ gather them (stride-aware) and trigger the slice reads.
 `gguf_get_tensor_offset` (all public) give each tensor's absolute byte offset in the file,
 without loading any tensor data. We match these to the captured tensors by name.
 
+## 3. The expert-ready hook (fork extension)
+
+Sections 1 and 2 are enough for the *serial* streamer: block on the expert reads, then let
+the layer compute. Overlapping the two — reading a token's experts while the same token's
+expert matmuls are running — needs a wait point that no public API exposes. That is the one
+place where BigMoeOnEdge carries a llama.cpp extension.
+
+**What it is.** A single optional hook, ~25 lines, living on the fork branch
+`bmoe/expert-ready-hook` of `Helldez/llama.cpp` as a single commit on top of the upstream
+pin. It adds nothing to the model files and changes no data layout; it is a callback the
+CPU MoE kernel invokes.
+
+**Exact API and call site.**
+
+```c
+// ggml-cpu.h
+void ggml_cpu_set_expert_ready_hook(ggml_expert_ready_hook_t hook, void * user_data);
+```
+
+`ggml_compute_forward_mul_mat_id` calls the hook at the top of its per-expert loop, right
+after the "expert not routed this token" skip, before it consumes that expert's weight
+slice. Every compute thread calls it for every routed expert; the hook may block. There is
+**no barrier inside the expert loop**, so a thread blocking on one expert cannot deadlock
+the threadpool — other threads proceed to the experts whose slices are already resident.
+The streamer's hook blocks until the requested expert slice has been read in, then returns.
+When no hook is registered (stock upstream, or `--overlap` off) the call is a single null
+check — zero cost.
+
+**Why it exists.** The topk eval-callback (section 1) is the only public hook near routing,
+and it can only fire *before* the expert matmuls of a layer run — it cannot pause partway
+through them. Overlapping expert reads with expert compute requires a per-expert wait point
+*inside* the kernel, which the public API does not provide. Hence the extension.
+
+**Graceful degradation.** CMake probes `ggml-cpu.h` for the hook symbol and, when present,
+defines `BMOE_HAVE_EXPERT_READY_HOOK`. Built against stock upstream (symbol absent) the
+whole project still compiles and runs — the serial streaming path is unchanged; only
+`--overlap` is affected, and it fails with a clear runtime error instead of silently
+falling back.
+
+**Sunset condition.** This fork exists *solely* for this one hook. The moment upstream
+ships an equivalent per-expert readiness/residency callback, the branch is dropped and the
+submodule bumps straight back to `ggml-org/llama.cpp`. It is a tide-me-over until the wait
+point is public, not a divergence we intend to maintain.
+
 ## The chat glue: llama.cpp `common` (not the streaming seam)
 
 Separate from the two streaming hooks above, `runtime.cpp` links llama.cpp's `common`
@@ -63,13 +107,23 @@ returns. This is how `ggml_backend_sched` implements the eval-callback today
 
 ## Upgrading llama.cpp
 
+Because the submodule pins the `bmoe/expert-ready-hook` fork branch (section 3), a bump
+rebases that 1-commit branch onto the new upstream tag, re-pushes it, and re-pins:
+
 ```bash
-cd third_party/llama.cpp && git fetch && git checkout <newer-tag>
+# in a Helldez/llama.cpp checkout: rebase the single hook commit onto the new tag
+git fetch upstream && git checkout bmoe/expert-ready-hook
+git rebase <newer-upstream-tag> && git push --force-with-lease origin bmoe/expert-ready-hook
+
+# in this repo: move the submodule to the rebased commit, rebuild, run the gates
+cd third_party/llama.cpp && git fetch origin && git checkout <rebased-commit>
 cd ../.. && git add third_party/llama.cpp && scripts/build-host.sh
 cd build && ctest --output-on-failure     # gates must stay green
 ```
 
-Most bumps are exactly this: update, rebuild, gates green. The fragility is not the public
+When the sunset condition lands (upstream ships the readiness callback) this collapses back
+to a plain `git checkout <newer-tag>` against `ggml-org/llama.cpp` with no branch to carry.
+Either way the gates are the enforcement. The fragility is not the public
 API but the *internal naming conventions* the seam attaches to — the tensor suffixes and
 the `ffn_moe_topk` node name are how llama.cpp happens to build MoE graphs today, not a
 guaranteed contract, so upstream can rename or restructure them (Gemma 4's fused
@@ -80,5 +134,7 @@ output. Each supported architecture adds one more gate to keep green across a bu
 If a future release moves the two hooks (a stable expert-residency API, say) upstream,
 this seam shrinks further or disappears — `core/` does not change.
 
-Pinned submodule at the time of writing: upstream `ggml-org/llama.cpp` master
-`22b69b6` (see `.gitmodules` / `git submodule status` for the current pin).
+Pinned submodule at the time of writing: `Helldez/llama.cpp` branch
+`bmoe/expert-ready-hook`, commit `5236140` — the single expert-ready-hook commit (section 3)
+on top of upstream `ggml-org/llama.cpp` master `22b69b6` (see `.gitmodules` /
+`git submodule status` for the current pin).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -16,8 +16,11 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
 - `BMOE_LOAD` appears only when experts were read this token; `mb` is the flash bytes read,
   `ms` the read time.
 - `BMOE_PROGRESS.step`/`steps` are 1-based index and target token counts.
-- `wall_ms` = total token time; `io_ms` = flash read time (a subset); `compute_ms` =
-  `wall_ms − io_ms`.
+- `wall_ms` = total token time; `io_ms` = flash read time; `compute_ms` = `wall_ms − io_ms`.
+  In serial mode `io_ms` is the wall time blocked on reads (a subset of `wall_ms`). Under
+  `--overlap` its meaning changes: it is the **sum of per-lane busy time**, so it can exceed
+  `wall_ms` because lanes read in parallel with compute. Use `stall_ms` for the wall time
+  compute actually lost to reads under overlap.
 - `cache_hit_pct` is the cumulative cache hit rate, or `-1` when no cache is used.
 - `text` is the full generated text so far, JSON-escaped (for streaming into a UI).
 
@@ -32,6 +35,10 @@ moe-stream: read <mib> MiB (<mib/tok> MiB/token), decode <s> s/token (compute <c
 moe-cache: <pct>% hit, resident <mib> MiB
 ```
 
+Under `--overlap` the `moe-stream:` line additionally reports `stall_s/tok=<s>` — the mean
+wall time per token that compute threads waited for expert reads to complete. It is `0` in
+serial mode (where the read wait is already folded into decode time).
+
 `moe-cache:` is present only when a cache is active. The `=== answer ===` / `=== perf ===`
 banners appear only in `--progress` mode; without it the CLI streams the answer inline and
 prints just the summary lines.
@@ -41,7 +48,13 @@ prints just the summary lines.
 `--csv PATH` additionally writes one row per token:
 
 ```
-step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct
+step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
+
+`stall_ms` is a trailing column added for `--overlap`: the wall time compute threads waited
+for expert reads that token. It is `0` in serial mode, and older CSVs written before it was
+added have only the first seven columns — consumers must treat it as optional. The
+`# summary` line likewise gains `stall_s/tok=<s>` under overlap (see the `io_ms` note above
+for how the read-time columns are reinterpreted when lanes run in parallel with compute).

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -3,6 +3,24 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+// Short git SHA of the build, injected into BuildConfig so the running APK is identifiable
+// (debug installs share a versionCode, so this is the only reliable "which build am I on").
+def gitSha = {
+    try {
+        def out = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--short', 'HEAD'
+            standardOutput = out
+            ignoreExitValue = true
+            workingDir = rootDir
+        }
+        def s = out.toString().trim()
+        return s.isEmpty() ? 'unknown' : s
+    } catch (ignored) {
+        return 'unknown'
+    }
+}()
+
 android {
     namespace 'io.bigmoeonedge.example'
     compileSdk 34
@@ -11,8 +29,9 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 1
+        versionCode 2
         versionName '0.1.0'
+        buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.
             abiFilters 'arm64-v8a'

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -7,13 +7,14 @@ import android.content.Context
  * flags; the Settings screen edits them and [toArgv] builds the command line.
  */
 data class AppSettings(
+    val mmap: Boolean = false,   // baseline: no streaming — llama.cpp mmap loads the whole model
     val cacheMb: Int = 4000,     // LRU expert cache budget; 0 or >= 2000 (see CACHE_CHOICES)
     val ioThreads: Int = 4,      // parallel expert-read lanes
     val threads: Int = 4,        // compute threads (-t); 4 is the measured optimum
     val nPredict: Int = 48,
     val oDirect: Boolean = true, // bypass the page cache
     val overlap: Boolean = false,// prefetch experts while the layer computes (experimental)
-    val thinking: Boolean = false,// Qwen3 reasoning; off appends the /no_think soft switch
+    val thinking: Boolean = false,// reasoning; off passes --no-think (enable_thinking=false)
     val loadAll: Boolean = false,// debug: read ALL experts each token (A/B baseline)
 ) {
     /**
@@ -22,6 +23,11 @@ data class AppSettings(
      * its `enable_thinking` kwarg. This is model-agnostic (works for Qwen3 and Gemma alike),
      * unlike the old Qwen-only /no_think prompt suffix. `arch` is kept for future arch-specific
      * handling but is no longer needed for the thinking switch.
+     *
+     * When [mmap] is set, expert streaming is turned off entirely: the CLI omits --moe-stream and
+     * every streaming knob (cache / lanes / O_DIRECT / overlap / load-all), so llama.cpp loads the
+     * whole model via mmap through the page cache. This is the baseline the streaming modes are
+     * compared against; the prompt/template and compute flags still apply.
      */
     fun toArgv(cliPath: String, modelPath: String, prompt: String, arch: String?): List<String> {
         val a = mutableListOf(
@@ -31,20 +37,23 @@ data class AppSettings(
             "-n", nPredict.toString(),
             "-t", threads.toString(),
             "--chatml", // apply the model family's chat turn (gemma / chatml)
-            "--moe-stream",
-            "--cache-mb", cacheMb.toString(),
-            "--io-threads", ioThreads.toString(),
             "--progress",
         )
         if (!thinking) a += "--no-think"
-        if (!oDirect) a += "--no-odirect"
-        if (overlap) a += "--overlap"
-        if (loadAll) a += "--load-all"
+        if (!mmap) {
+            a += "--moe-stream"
+            a += listOf("--cache-mb", cacheMb.toString())
+            a += listOf("--io-threads", ioThreads.toString())
+            if (!oDirect) a += "--no-odirect"
+            if (overlap) a += "--overlap"
+            if (loadAll) a += "--load-all"
+        }
         return a
     }
 
     fun save(ctx: Context) {
         ctx.prefs().edit()
+            .putBoolean("mmap", mmap)
             .putInt("cacheMb", cacheMb).putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
             .putBoolean("overlap", overlap)
@@ -64,6 +73,7 @@ data class AppSettings(
             val p = ctx.prefs()
             val d = AppSettings()
             return AppSettings(
+                mmap = p.getBoolean("mmap", d.mmap),
                 cacheMb = p.getInt("cacheMb", d.cacheMb),
                 ioThreads = p.getInt("ioThreads", d.ioThreads),
                 threads = p.getInt("threads", d.threads),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -12,6 +12,7 @@ data class AppSettings(
     val threads: Int = 4,        // compute threads (-t); 4 is the measured optimum
     val nPredict: Int = 48,
     val oDirect: Boolean = true, // bypass the page cache
+    val overlap: Boolean = false,// prefetch experts while the layer computes (experimental)
     val thinking: Boolean = false,// Qwen3 reasoning; off appends the /no_think soft switch
     val loadAll: Boolean = false,// debug: read ALL experts each token (A/B baseline)
 ) {
@@ -37,6 +38,7 @@ data class AppSettings(
         )
         if (!thinking) a += "--no-think"
         if (!oDirect) a += "--no-odirect"
+        if (overlap) a += "--overlap"
         if (loadAll) a += "--load-all"
         return a
     }
@@ -45,6 +47,7 @@ data class AppSettings(
         ctx.prefs().edit()
             .putInt("cacheMb", cacheMb).putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
+            .putBoolean("overlap", overlap)
             .putBoolean("thinking", thinking).putBoolean("loadAll", loadAll)
             .apply()
     }
@@ -66,6 +69,7 @@ data class AppSettings(
                 threads = p.getInt("threads", d.threads),
                 nPredict = p.getInt("nPredict", d.nPredict),
                 oDirect = p.getBoolean("oDirect", d.oDirect),
+                overlap = p.getBoolean("overlap", d.overlap),
                 thinking = p.getBoolean("thinking", d.thinking),
                 loadAll = p.getBoolean("loadAll", d.loadAll),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Components.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Components.kt
@@ -12,13 +12,14 @@ import androidx.compose.ui.unit.sp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LabeledDropdown(label: String, options: List<String>, selected: Int, onSelect: (Int) -> Unit) {
+fun LabeledDropdown(label: String, options: List<String>, selected: Int, enabled: Boolean = true, onSelect: (Int) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { if (enabled) expanded = it }) {
         OutlinedTextField(
             value = options.getOrElse(selected) { "" },
             onValueChange = {},
             readOnly = true,
+            enabled = enabled,
             label = { Text(label) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier.menuAnchor().fillMaxWidth(),
@@ -33,23 +34,34 @@ fun LabeledDropdown(label: String, options: List<String>, selected: Int, onSelec
 
 /** Dropdown backed by an int array of choices; reports the chosen value. */
 @Composable
-fun IntSetting(label: String, choices: IntArray, value: Int, format: (Int) -> String = { it.toString() }, onSelect: (Int) -> Unit) {
+fun IntSetting(
+    label: String,
+    choices: IntArray,
+    value: Int,
+    format: (Int) -> String = { it.toString() },
+    enabled: Boolean = true,
+    onSelect: (Int) -> Unit,
+) {
     val idx = choices.indexOf(value).coerceAtLeast(0)
-    LabeledDropdown(label, choices.map(format), idx) { onSelect(choices[it]) }
+    LabeledDropdown(label, choices.map(format), idx, enabled) { onSelect(choices[it]) }
 }
 
 @Composable
-fun SwitchRow(label: String, description: String?, checked: Boolean, onChange: (Boolean) -> Unit) {
+fun SwitchRow(label: String, description: String?, checked: Boolean, enabled: Boolean = true, onChange: (Boolean) -> Unit) {
+    val dim = if (enabled) 1f else 0.38f // Material disabled-content alpha
     Row(
         Modifier.fillMaxWidth().padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(Modifier.weight(1f)) {
-            Text(label, fontSize = 15.sp)
+            Text(label, fontSize = 15.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = dim))
             if (description != null) {
-                Text(description, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(
+                    description, fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = dim),
+                )
             }
         }
-        Switch(checked = checked, onCheckedChange = onChange)
+        Switch(checked = checked, onCheckedChange = onChange, enabled = enabled)
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -211,11 +211,16 @@ private fun MainScreen(
             ) { Text("Stop") }
         }
 
-        // A quick reminder of the active streaming config (full controls in Settings).
+        // A quick reminder of the active config (full controls in Settings).
         Text(
-            "cache ${if (settings.cacheMb == 0) "off" else "${settings.cacheMb} MiB"} · " +
-                "${settings.ioThreads} lanes · ${settings.threads} threads · " +
-                "thinking ${if (settings.thinking) "on" else "off"}",
+            if (settings.mmap) {
+                "mmap baseline (no streaming) · ${settings.threads} threads · " +
+                    "thinking ${if (settings.thinking) "on" else "off"}"
+            } else {
+                "cache ${if (settings.cacheMb == 0) "off" else "${settings.cacheMb} MiB"} · " +
+                    "${settings.ioThreads} lanes${if (settings.overlap) " · overlap" else ""} · " +
+                    "${settings.threads} threads · thinking ${if (settings.thinking) "on" else "off"}"
+            },
             fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -53,26 +53,12 @@ class MainActivity : ComponentActivity() {
         ) {
             requestNotif.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
-        requestAllFilesAccess()
+        // All-files access is NOT requested at startup: downloaded, imported and picked models
+        // live in the app-specific dir and need no permission. The dev flavor asks for it only
+        // when the user explicitly rescans device storage (Refresh) for adb-pushed models.
         setContent {
             MaterialTheme(colorScheme = if (isSystemDark()) darkColorScheme() else lightColorScheme()) {
                 Surface(color = MaterialTheme.colorScheme.background) { Root() }
-            }
-        }
-    }
-
-    // Only the dev flavor reads models in place from shared storage; the Play flavor takes them
-    // through the in-app downloader / file picker and needs no broad storage permission.
-    private fun requestAllFilesAccess() {
-        if (!BuildConfig.SHARED_STORAGE) return
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
-            runCatching {
-                startActivity(
-                    Intent(
-                        Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
-                        Uri.parse("package:$packageName"),
-                    )
-                )
             }
         }
     }
@@ -81,6 +67,25 @@ class MainActivity : ComponentActivity() {
         val flag = resources.configuration.uiMode and
             android.content.res.Configuration.UI_MODE_NIGHT_MASK
         return flag == android.content.res.Configuration.UI_MODE_NIGHT_YES
+    }
+}
+
+/**
+ * Request all-files access, needed only by the dev flavor to scan device storage for adb-pushed
+ * models. Called on an explicit user action (Refresh), never at startup. No-op on the Play flavor
+ * and when access is already granted.
+ */
+fun requestSharedStorageAccess(context: android.content.Context) {
+    if (!BuildConfig.SHARED_STORAGE) return
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
+        runCatching {
+            context.startActivity(
+                Intent(
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                    Uri.parse("package:${context.packageName}"),
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
     }
 }
 
@@ -166,7 +171,7 @@ private fun MainScreen(
                         fontFamily = FontFamily.Monospace,
                     )
                 }
-                TextButton(onClick = onRefresh) { Text("Refresh") }
+                TextButton(onClick = { requestSharedStorageAccess(context); onRefresh() }) { Text("Refresh") }
             }
             else -> LabeledDropdown(
                 label = "Model",
@@ -383,8 +388,15 @@ private fun TelemetryCard(ui: UiState) {
             }
             val t = ui.telemetry
             val hit = if (t.cacheHitPct >= 0) String.format(Locale.US, "%.0f%%", t.cacheHitPct) else "—"
+            // Once the run finishes the summary carries the aggregate average; show that as the
+            // headline rate. While generating, show the live instantaneous (last-token) rate.
+            val done = t.avgTokensPerSecond > 0
             Text(
-                String.format(Locale.US, "%.2f tok/s   (token %d/%d)", t.tokensPerSecond, t.step, t.steps),
+                if (done) {
+                    String.format(Locale.US, "%.2f tok/s   avg (%d tokens)", t.avgTokensPerSecond, t.steps)
+                } else {
+                    String.format(Locale.US, "%.2f tok/s   (token %d/%d)", t.tokensPerSecond, t.step, t.steps)
+                },
                 fontWeight = FontWeight.Bold, fontSize = 18.sp,
             )
             MeterRow("compute", t.computeMs, t.computeMs + t.ioMs, MaterialTheme.colorScheme.primary)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -225,7 +225,7 @@ private fun MainScreen(
                 "cache ${if (settings.cacheMb == 0) "off" else "${settings.cacheMb} MiB"} · " +
                     "${settings.ioThreads} lanes${if (settings.overlap) " · overlap" else ""} · " +
                     "${settings.threads} threads · thinking ${if (settings.thinking) "on" else "off"}"
-            },
+            } + " · build ${BuildConfig.GIT_SHA}",
             fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -402,6 +402,9 @@ private fun TelemetryCard(ui: UiState) {
             MeterRow("compute", t.computeMs, t.computeMs + t.ioMs, MaterialTheme.colorScheme.primary)
             MeterRow("flash I/O", t.ioMs, t.computeMs + t.ioMs, MaterialTheme.colorScheme.tertiary)
             Text("cache hit $hit", fontSize = 13.sp)
+            if (ui.ioMode != null) {
+                Text("I/O ${ui.ioMode}", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
             if (ui.summary.isNotEmpty()) {
                 Text(ui.summary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -25,10 +25,19 @@ object ModelManager {
     // untrusted_app domain can open it.
     private val TMP_MODEL_DIR = File("/data/local/tmp/shardllm")
 
-    /** The app-specific external files dir — the download/import target, readable with no permission. */
+    /** The app-specific external files dir — the download target, readable with no permission. */
     fun appModelsDir(ctx: Context): File? = ctx.getExternalFilesDir(null)
 
+    /**
+     * App-internal models dir — lives on /data (a real f2fs/ext4 volume), NOT the emulated/FUSE
+     * external storage. That matters because O_DIRECT returns correct data here, so streamed
+     * expert reads stay fast; on the emulated external dir O_DIRECT silently corrupts reads and
+     * the engine has to fall back to slower buffered I/O. Imports land here for that reason.
+     */
+    fun internalModelsDir(ctx: Context): File = File(ctx.filesDir, "models").apply { mkdirs() }
+
     private fun scanDirs(ctx: Context): List<File> = buildList {
+        add(internalModelsDir(ctx))
         appModelsDir(ctx)?.let { add(it) }
         if (BuildConfig.SHARED_STORAGE) {
             Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.let { add(it) }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -13,6 +13,7 @@ data class UiState(
     val answer: String = "",
     val summary: String = "",
     val error: String? = null,
+    val ioMode: String? = null, // effective read mode reported by the engine (direct / buffered)
 )
 
 /**

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -75,8 +75,21 @@ class RunService : Service() {
             val errTail = StringBuilder()
             thread(name = "bmoe-cli-err") {
                 try {
-                    BufferedReader(InputStreamReader(p.errorStream)).forEachLine {
-                        if (errTail.length < 4000) errTail.append(it).append('\n')
+                    BufferedReader(InputStreamReader(p.errorStream)).forEachLine { line ->
+                        if (errTail.length < 4000) errTail.append(line).append('\n')
+                        // Surface the engine's effective read mode. The fallback notice (printed
+                        // before the "streaming ON" line) wins, so it is not overwritten after.
+                        when {
+                            "O_DIRECT returns wrong data" in line ->
+                                RunBus.update { it.copy(ioMode = "buffered (O_DIRECT unsupported on this storage)") }
+                            "expert streaming ON" in line ->
+                                Regex("""o_direct=(\d)""").find(line)?.groupValues?.get(1)?.let { d ->
+                                    RunBus.update {
+                                        if (it.ioMode != null) it
+                                        else it.copy(ioMode = if (d == "1") "direct (O_DIRECT)" else "buffered")
+                                    }
+                                }
+                        }
                     }
                 } catch (_: Throwable) {
                     // stream closed by destroy() on Stop — nothing to surface.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -69,10 +69,17 @@ class RunService : Service() {
             val p = pb.start().also { proc = it }
 
             // Drain stderr so the CLI never blocks on a full pipe; surface the tail on error.
+            // Wrap in try/catch: Stop calls proc.destroy(), which closes this stream and makes
+            // forEachLine throw. Uncaught here it would kill the whole app process, not just the
+            // CLI — this is the crash the Stop button used to trigger.
             val errTail = StringBuilder()
             thread(name = "bmoe-cli-err") {
-                BufferedReader(InputStreamReader(p.errorStream)).forEachLine {
-                    if (errTail.length < 4000) errTail.append(it).append('\n')
+                try {
+                    BufferedReader(InputStreamReader(p.errorStream)).forEachLine {
+                        if (errTail.length < 4000) errTail.append(it).append('\n')
+                    }
+                } catch (_: Throwable) {
+                    // stream closed by destroy() on Stop — nothing to surface.
                 }
             }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SafImport.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SafImport.kt
@@ -10,9 +10,10 @@ import java.io.File
 /**
  * Imports a gguf the user picked with the system file picker (Storage Access Framework). The
  * picker hands back a content:// URI, but the bmoe-cli subprocess needs a real filesystem path,
- * so we stream the bytes into the app-specific external files dir (no permission required). This
- * is the Play-flavor path for a model already downloaded with the browser — public Downloads is
- * not readable without all-files access.
+ * so we stream the bytes into the app-internal models dir (no permission required, and on a real
+ * f2fs/ext4 volume where O_DIRECT works — see ModelManager.internalModelsDir). This is the
+ * Play-flavor path for a model already downloaded with the browser — public Downloads is not
+ * readable without all-files access.
  *
  * Copied as `<name>.gguf.part`, renamed on completion, so a partial copy is never listed.
  */
@@ -30,7 +31,9 @@ object SafImport {
             val name = displayName.filter { it.isLetterOrDigit() || it in "._-" }
             require(name.endsWith(".gguf")) { "please pick a .gguf file" }
 
-            val dir = ModelManager.appModelsDir(ctx) ?: error("no app storage available")
+            // Import into app-internal storage (real f2fs/ext4), not the emulated external dir:
+            // O_DIRECT works there, so the streamed model reads back at full speed.
+            val dir = ModelManager.internalModelsDir(ctx)
             val finalFile = File(dir, name)
             if (finalFile.isFile) return@runCatching finalFile
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -40,26 +40,36 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Section("Streaming") {
+                // mmap is the no-streaming baseline. When on, every streaming knob below is
+                // inert (the CLI omits --moe-stream and all sub-flags), so they are disabled.
+                SwitchRow(
+                    "mmap baseline (no streaming)",
+                    "Load the whole model via llama.cpp mmap — the baseline to compare against",
+                    current.mmap,
+                ) { onChange(current.copy(mmap = it)) }
+
+                val stream = !current.mmap
                 IntSetting(
                     "Expert cache (MiB)", AppSettings.CACHE_CHOICES, current.cacheMb,
                     format = { if (it == 0) "off" else "$it MiB" },
+                    enabled = stream,
                 ) { onChange(current.copy(cacheMb = it)) }
                 Text(
                     "0 or ≥ 2000 MiB. A smaller cache thrashes (evict + re-read) and is " +
                         "slower than off, so 1000 is intentionally not offered.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                IntSetting("Parallel I/O lanes", AppSettings.IO_CHOICES, current.ioThreads) {
+                IntSetting("Parallel I/O lanes", AppSettings.IO_CHOICES, current.ioThreads, enabled = stream) {
                     onChange(current.copy(ioThreads = it))
                 }
                 SwitchRow(
                     "Direct I/O (O_DIRECT)", "Bypass the page cache when reading experts",
-                    current.oDirect,
+                    current.oDirect, enabled = stream,
                 ) { onChange(current.copy(oDirect = it)) }
                 SwitchRow(
                     "I/O–compute overlap",
                     "Prefetch experts while the layer computes (experimental)",
-                    current.overlap,
+                    current.overlap, enabled = stream,
                 ) { onChange(current.copy(overlap = it)) }
             }
 
@@ -74,7 +84,7 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
 
             Section("Prompt") {
                 SwitchRow(
-                    "Thinking", "Qwen3 reasoning; off appends the /no_think switch",
+                    "Thinking", "Model reasoning; off passes --no-think (works for Qwen and Gemma)",
                     current.thinking,
                 ) { onChange(current.copy(thinking = it)) }
             }
@@ -82,7 +92,7 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
             Section("Debug") {
                 SwitchRow(
                     "Load all experts", "Read every expert each token (A/B baseline; slow)",
-                    current.loadAll,
+                    current.loadAll, enabled = !current.mmap,
                 ) { onChange(current.copy(loadAll = it)) }
             }
         }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -56,6 +56,11 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     "Direct I/O (O_DIRECT)", "Bypass the page cache when reading experts",
                     current.oDirect,
                 ) { onChange(current.copy(oDirect = it)) }
+                SwitchRow(
+                    "I/O–compute overlap",
+                    "Prefetch experts while the layer computes (experimental)",
+                    current.overlap,
+                ) { onChange(current.copy(overlap = it)) }
             }
 
             Section("Compute") {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -11,6 +11,10 @@ data class Telemetry(
     var computeMs: Double = 0.0,
     var cacheHitPct: Double = -1.0,
     var text: String = "",
+    // Aggregate decode rate over the whole run, parsed from the final summary line; -1 until
+    // generation finishes. The per-token [tokensPerSecond] is instantaneous (last token only),
+    // so the UI shows this average once it is available.
+    var avgTokensPerSecond: Double = -1.0,
 ) {
     val tokensPerSecond: Double get() = if (wallMs > 0) 1000.0 / wallMs else 0.0
 }
@@ -45,6 +49,11 @@ class TelemetryParser {
             }
             t.startsWith("generation:") || t.startsWith("moe-stream:") || t.startsWith("moe-cache:") -> {
                 summary = if (summary.isEmpty()) t else summary + "\n" + t
+                // "generation: N tokens, X s/token (Y tok/s)" — Y is the aggregate average.
+                if (t.startsWith("generation:")) {
+                    Regex("""\(([\d.]+) tok/s\)""").find(t)?.groupValues?.get(1)?.toDoubleOrNull()
+                        ?.let { current.avgTokensPerSecond = it }
+                }
                 true
             }
             else -> false

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -9,7 +9,8 @@
 import os, sys, statistics
 
 BENCH = sys.argv[1] if len(sys.argv) > 1 else r"C:\Users\raffa\Documents\BigMoeOnEdge\.bench"
-ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4"]
+ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4",
+         "stream_ov", "c4000_l4_ov"]
 LABEL = {
     "mmap": "solo mmap (no streaming)",
     "stream": "streaming O_DIRECT, cache 0, lane 4",
@@ -17,6 +18,8 @@ LABEL = {
     "c2000_l4": "streaming + cache 2000 MiB, lane 4",
     "c4000_l2": "streaming + cache 4000 MiB, lane 2",
     "c4000_l4": "streaming + cache 4000 MiB, lane 4",
+    "stream_ov": "streaming O_DIRECT + overlap, cache 0, lane 4",
+    "c4000_l4_ov": "streaming + cache 4000 MiB, lane 4, overlap",
 }
 
 def pct(v, q):
@@ -41,7 +44,7 @@ def num(d, k):
         return None
 
 def analyze(csv_path):
-    walls, summ = [], {}
+    walls, stalls, summ = [], [], {}
     with open(csv_path) as f:
         for row in f:
             row = row.strip()
@@ -52,10 +55,17 @@ def analyze(csv_path):
                     if "=" in tok:
                         k, v = tok.split("=", 1); summ[k] = v
                 continue
+            cols = row.split(",")
             try:
-                walls.append(float(row.split(",")[2]))
+                walls.append(float(cols[2]))
             except (IndexError, ValueError):
-                pass
+                continue
+            # stall_ms is an optional trailing column (index 7); absent in pre-overlap CSVs.
+            if len(cols) > 7:
+                try:
+                    stalls.append(float(cols[7]))
+                except ValueError:
+                    pass
     if not walls:
         return None
     n = len(walls); tps = sorted(1000.0 / w for w in walls if w > 0)
@@ -69,6 +79,7 @@ def analyze(csv_path):
         "median": statistics.median(tps), "p5": pct(tps, 0.05), "p95": pct(tps, 0.95),
         "cache_hit": summ.get("cache_hit_pct", "-"),
         "read_MiB_tok": (g("read_MiB") / n) if n else 0.0,
+        "stall_ms_tok": (statistics.mean(stalls) if stalls else None),
         "prefill_tps": g("prefill_tps"), "load_s": g("load_s"),
         "prefill_s": g("prefill_s"), "ttft": g("load_s") + g("prefill_s"),
         "peak_rss_gb": (num(m, "peak_rss_kb") or 0) / 1048576.0,
@@ -87,16 +98,17 @@ for model, pretty in (("qwen", "Qwen3-30B-A3B-Q4_K_M (18.5 GB, 128 experts, top-
         rows.append((key, analyze(p) if os.path.exists(p) else None))
 
     print(f"\n===== {model.upper()} — throughput =====")
-    print(f"{'config':36s} {'mean':>6s} {'min':>6s} {'max':>6s} {'med':>6s} {'p95':>6s} {'pref':>6s} {'TTFT':>6s} {'hit':>5s} {'MiB/t':>6s}")
+    print(f"{'config':36s} {'mean':>6s} {'min':>6s} {'max':>6s} {'med':>6s} {'p95':>6s} {'pref':>6s} {'TTFT':>6s} {'hit':>5s} {'MiB/t':>6s} {'stall':>7s}")
     md.append(f"\n### {pretty}\n\n**Throughput** (tok/s; mean = aggregate decode, prefill = prompt-processing):\n")
-    md.append("| Config | decode mean | min | max | median | p95 | prefill tok/s | TTFT (s) | cache hit | flash read/token |")
-    md.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    md.append("| Config | decode mean | min | max | median | p95 | prefill tok/s | TTFT (s) | cache hit | flash read/token | stall ms/tok |")
+    md.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
     for key, r in rows:
         if r is None:
-            md.append(f"| {LABEL[key]} | — | — | — | — | — | — | — | — | — |"); continue
+            md.append(f"| {LABEL[key]} | — | — | — | — | — | — | — | — | — | — |"); continue
         hit = f"{float(r['cache_hit']):.0f}%" if r['cache_hit'] not in ("-", "-1.0") else "—"
-        print(f"{LABEL[key]:36s} {r['mean']:6.2f} {r['min']:6.2f} {r['max']:6.2f} {r['median']:6.2f} {r['p95']:6.2f} {r['prefill_tps']:6.2f} {r['ttft']:6.1f} {hit:>5s} {r['read_MiB_tok']:5.0f}M")
-        md.append(f"| {LABEL[key]} | **{r['mean']:.2f}** | {r['min']:.2f} | {r['max']:.2f} | {r['median']:.2f} | {r['p95']:.2f} | {r['prefill_tps']:.2f} | {r['ttft']:.1f} | {hit} | {r['read_MiB_tok']:.0f} MiB |")
+        stall = f"{r['stall_ms_tok']:.1f}" if r['stall_ms_tok'] is not None else "—"
+        print(f"{LABEL[key]:36s} {r['mean']:6.2f} {r['min']:6.2f} {r['max']:6.2f} {r['median']:6.2f} {r['p95']:6.2f} {r['prefill_tps']:6.2f} {r['ttft']:6.1f} {hit:>5s} {r['read_MiB_tok']:5.0f}M {stall:>7s}")
+        md.append(f"| {LABEL[key]} | **{r['mean']:.2f}** | {r['min']:.2f} | {r['max']:.2f} | {r['median']:.2f} | {r['p95']:.2f} | {r['prefill_tps']:.2f} | {r['ttft']:.1f} | {hit} | {r['read_MiB_tok']:.0f} MiB | {stall} |")
 
     print(f"\n===== {model.upper()} — device pressure =====")
     print(f"{'config':36s} {'peakRSS':>8s} {'RAMfloor':>9s} {'CPU0':>6s} {'CPUmax':>7s} {'battMax':>8s}")

--- a/scripts/bench-matrix.ps1
+++ b/scripts/bench-matrix.ps1
@@ -34,5 +34,8 @@ foreach ($name in @("qwen","gemma")) {
   Run-Cfg "${name}_c2000_l4" $m "--moe-stream --cache-mb 2000 --io-threads 4"
   Run-Cfg "${name}_c4000_l2" $m "--moe-stream --cache-mb 4000 --io-threads 2"
   Run-Cfg "${name}_c4000_l4" $m "--moe-stream --cache-mb 4000 --io-threads 4"
+  # intra-layer I/O–compute overlap: mirror the two lead configs with --overlap
+  Run-Cfg "${name}_c4000_l4_ov" $m "--moe-stream --cache-mb 4000 --io-threads 4 --overlap"
+  Run-Cfg "${name}_stream_ov"   $m "--moe-stream --cache-mb 0 --io-threads 4 --overlap"
 }
 Write-Host "ALL DONE"

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -8,8 +8,13 @@
 //   G1  resident (no streaming)        == streaming, cache off
 //   G2  streaming, cache off           == streaming, small LRU cache (forces evictions)
 //   G3  streaming, selective           == streaming, --load-all (every expert each token)
+//   G4  overlap (async reads + per-expert wait hook) == serial streaming, cache off
+//         a) overlap, cache off              b) overlap, small forced cache
+//         c) overlap, cache off, io_threads=1 (single lane → maximal stalls)
 //
-// If G3 passes, the streamer provably never gathers an unrouted (garbage) slice.
+// If G3 passes, the streamer provably never gathers an unrouted (garbage) slice. If G4
+// passes, the async path gates each expert correctly — compute never races ahead of its read.
+// G4 is compiled only when the fork's expert-ready hook is present (BMOE_HAVE_EXPERT_READY_HOOK).
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
 
@@ -99,6 +104,49 @@ int main(int argc, char ** argv) {
     fails += check("G1 resident == streaming(cache off)", s_res, s_s0);
     fails += check("G2 streaming(cache off) == streaming(LRU cache)", s_s0, s_sc);
     fails += check("G3 streaming(selective) == streaming(load-all)", s_s0, s_all);
+
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+    // overlap, cache off
+    RunConfig ov0 = base(model);
+    ov0.moe.enabled = true;
+    ov0.moe.cache_mb = 0;
+    ov0.moe.io_threads = 4;
+    ov0.moe.overlap = true;
+
+    // overlap, small forced cache (same cache config as G2's streamc)
+    RunConfig ovc = base(model);
+    ovc.moe.enabled = true;
+    ovc.moe.cache_mb = 2;
+    ovc.moe.force_cache = true;
+    ovc.moe.io_threads = 4;
+    ovc.moe.overlap = true;
+
+    // overlap, cache off, single I/O lane (stress: the compute threads stall on every expert)
+    RunConfig ov1 = base(model);
+    ov1.moe.enabled = true;
+    ov1.moe.cache_mb = 0;
+    ov1.moe.io_threads = 1;
+    ov1.moe.overlap = true;
+
+    std::string s_ov0, s_ovc, s_ov1;
+    if (!gen(ov0, s_ov0, err)) {
+        std::fprintf(stderr, "overlap(cache off) run failed: %s\n", err.c_str());
+        return 2;
+    }
+    if (!gen(ovc, s_ovc, err)) {
+        std::fprintf(stderr, "overlap(cache) run failed: %s\n", err.c_str());
+        return 2;
+    }
+    if (!gen(ov1, s_ov1, err)) {
+        std::fprintf(stderr, "overlap(io_threads=1) run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("G4a overlap(cache off) == streaming(cache off)", s_s0, s_ov0);
+    fails += check("G4b overlap(LRU cache) == streaming(cache off)", s_s0, s_ovc);
+    fails += check("G4c overlap(io_threads=1) == streaming(cache off)", s_s0, s_ov1);
+#else
+    std::printf("[SKIP] G4 (expert-ready hook not built)\n");
+#endif
 
     if (fails == 0) std::printf("\nall MoE byte-identity gates passed\n");
     return fails == 0 ? 0 : 1;


### PR DESCRIPTION
Consolidated branch landing three coherent things, verified on host (gates G1–G4 green on
qwen3moe + gemma4, clang-format clean, APK built):

## 1. Intra-layer I/O–compute overlap (`--overlap`, opt-in)
Expert reads for a layer run on the I/O pool while that layer's routed experts compute,
hiding flash latency behind FFN compute. Byte-identical to the serial path (gates G4a/b/c,
incl. a single-lane stress case). Needs one ~25-line per-expert readiness hook in the CPU
`mul_mat_id` kernel, carried as a 1-commit fork branch (`bmoe/expert-ready-hook` on
`Helldez/llama.cpp`) with an explicit sunset in `docs/seam.md` § 3; the serial streamer still
builds against stock upstream (CMake detects the hook). On-device perf numbers are pending —
the README/benchmark table gets an overlap row once measured.

## 2. mmap baseline & reasoning control
- Android **mmap baseline (no streaming)** settings toggle to compare the streaming/overlap
  modes against; streaming controls disable when it's on.
- Model-agnostic `--no-think` (`enable_thinking=false`), replacing the Qwen-only `/no_think`
  hack so reasoning is suppressed for Gemma too.

## 3. Reasoning / UX / crash fixes
- **Reasoning strip:** load the chat parser arena so `common_chat_parse` finds the template's
  reasoning delimiters — empty `<think>` (Qwen) / thought-channel (Gemma) markers no longer
  leak into the answer.
- **Stop no longer kills the app:** guard the stderr drain thread (the stream close from
  `Process.destroy()` threw uncaught on its own thread); plus a wakelock under-lock fix.
- **Storage permission on demand:** all-files access is asked on an explicit rescan, not at
  startup.
- **Headline tok/s** shows the aggregate average at end of run, not the last token's rate.

## Test plan
- [x] Host gates G1–G4 green (qwen3moe, gemma4)
- [x] clang-format clean, host + Windows builds, APK artifact
- [ ] On-device: overlap perf table (`qwen_c4000_l4` vs `_ov`)
- [ ] On-device: Stop, reasoning hidden, tok/s avg, mmap baseline
