### PR TITLE
fix: stop-crash on wakelock under-lock + thinking toggle for Gemma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           jni=examples/android/app/src/main/jniLibs/arm64-v8a
           mkdir -p "$jni"
           cp build-android/cli/bmoe-cli "$jni/libbmoe-cli.so"
-          find build-android \( -name 'libggml*.so' -o -name 'libllama.so' \) -exec cp {} "$jni/" \;
+          find build-android \( -name 'libggml*.so' -o -name 'libllama*.so' \) -exec cp {} "$jni/" \;
           # bmoe-cli links the c++_shared STL; ship its runtime from the NDK sysroot.
           cp "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" "$jni/"
           ls -la "$jni"

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ cmake-build-*/
 # Local test scratch (downloaded models/APKs, container build scripts/logs)
 /.models/
 /.apk/
+/.bench/
 *.safetensors
+/*.log
 
 # Android
 examples/android/.gradle/

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Qwen3-30B-A3B that is 8 of 128 per layer — about 6% of the expert weights. Big
 keeps the small, dense parts of the model resident and reads just those routed expert
 slices from flash on demand, so an 18.5 GB model runs on an 11 GB phone, losslessly.
 
-- **Measured:** Qwen3-30B-A3B-Q4_K_M on a OnePlus 15R (11.3 GB RAM) → **~1.8 tok/s**
-  (0.55–0.6 s/token), byte-identical to a full in-memory run. See the table below.
+- **Measured:** Qwen3-30B-A3B-Q4_K_M on a OnePlus 15R (11.3 GB RAM) → **1.8 tok/s** with no
+  cache, up to **3.75 tok/s** with a 4 GiB expert cache and 4 read lanes, byte-identical to
+  a full in-memory run. See the table below, or [docs/benchmarks.md](docs/benchmarks.md) for
+  the full matrix (Qwen + Gemma, mean/min/max/p95).
 - **No fork of llama.cpp.** Expert streaming is driven entirely through llama.cpp's
   public eval-callback and public gguf accessors. The `third_party/llama.cpp` submodule
   is stock upstream; updating it is a pointer bump, not a rebase. See
@@ -25,17 +27,23 @@ slices from flash on demand, so an 18.5 GB model runs on an 11 GB phone, lossles
 ## Benchmarks
 
 Qwen3-30B-A3B-Q4_K_M (18.5 GB, 128 experts, top-8, 48 layers) on a OnePlus 15R
-(11.3 GB RAM, UFS 4.x), 4 compute threads:
+(11.3 GB RAM, UFS 4.x), 4 compute threads, 256-token steady-state runs:
 
-| Expert cache | I/O lanes | s/token | tok/s | flash read/token | cache hit |
-|-------------:|----------:|--------:|------:|-----------------:|----------:|
-| off          | 1         | 0.95    | ~1.05 | 1050 MB          | —         |
-| 4000 MiB     | 1         | 0.73    | ~1.4  | 496 MB           | 46%       |
-| **4000 MiB** | **4**     | **0.55–0.57** | **~1.8** | 248–538 MB | 59–67% |
+| Expert cache | I/O lanes | tok/s (mean) | flash read/token | cache hit |
+|-------------:|----------:|-------------:|-----------------:|----------:|
+| mmap only    | —         | 1.86 (unstable) | —             | —         |
+| off (stream) | 4         | 1.78         | 1051 MB          | —         |
+| 2000 MiB     | 4         | 2.47         | 480 MB           | 53%       |
+| 4000 MiB     | 2         | 3.38         | 225 MB           | 76%       |
+| **4000 MiB** | **4**     | **3.75**     | 225 MB           | 76%       |
 
-Decode is flash-I/O-bound (~79% I/O at the best setting). The cache rule is **0 or
-≥ ~2 GB** — a budget smaller than one token's routed working set thrashes and is slower
-than no cache at all. Full method: [docs/benchmark-method.md](docs/benchmark-method.md).
+Cache size is the dominant lever (2000 → 4000 MiB nearly doubles throughput as the hit rate
+climbs); read lanes help mainly when the cache is small. `mmap`-only looks comparable on
+average but is unstable (single tokens from 0.36 to 8.34 tok/s) and evicts other apps —
+streaming with a bounded cache stays responsive. The cache rule is **0 or ≥ ~2 GB**: a
+smaller budget thrashes and is slower than no cache. Gemma-4-26B-A4B-Q4_K_M reaches
+**3.48 tok/s** at the same best setting. Full matrix and method:
+[docs/benchmarks.md](docs/benchmarks.md), [docs/benchmark-method.md](docs/benchmark-method.md).
 
 The same works on desktop for a model larger than the machine's RAM. Qwen3-30B-A3B-Q4_K_M
 (17.3 GiB) on a Windows PC with 14.8 GiB RAM (1.17× RAM, so it cannot be held resident),

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -66,6 +66,7 @@ static void print_usage(const char * argv0) {
                 "  -t, --threads N         compute threads (default 4)\n"
                 "  -c, --ctx-size N        context size (default 2048)\n"
                 "      --chatml            wrap the prompt in the model family's chat turn (gemma/chatml)\n"
+                "      --no-think          render the chat template with reasoning disabled\n"
                 "      --progress          emit machine telemetry (one JSON line per token)\n"
                 "      --csv PATH          also write per-token metrics as CSV\n"
                 "\n"
@@ -107,6 +108,8 @@ int main(int argc, char ** argv) {
             cfg.n_ctx = std::atoi(next("-c"));
         else if (a == "--chatml")
             cfg.chatml = true;
+        else if (a == "--no-think")
+            cfg.think = false;
         else if (a == "--progress")
             cfg.progress = true;
         else if (a == "--csv")

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -194,6 +194,11 @@ int main(int argc, char ** argv) {
     }
     std::printf("generation: %d tokens, %.3f s/token (%.3f tok/s)\n", s.n_generated, s.s_per_token,
                 s.tokens_per_second);
+    if (s.n_prompt > 0) {
+        double prefill_tps = s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0;
+        std::printf("prefill: %d tokens, %.3f s (%.1f tok/s) | model load %.3f s | TTFT %.3f s\n", s.n_prompt,
+                    s.prefill_seconds, prefill_tps, s.load_seconds, s.load_seconds + s.prefill_seconds);
+    }
     if (cfg.moe.enabled) {
         std::printf("moe-stream: read %.1f MiB (%.2f MiB/token), decode %.3f s/token "
                     "(compute %.3f + flash I/O %.3f s/token, %.0f MiB/s)\n",

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -45,6 +45,13 @@ struct RunConfig {
     bool chatml = false;   // wrap the prompt in the model family's chat turn (arch-aware)
     bool progress = false; // emit machine telemetry (one JSON line per token)
 
+    // Render the chat template with reasoning enabled. Passed to the template as the
+    // `enable_thinking` kwarg, so a reasoning model (Qwen3, thinking Gemma, …) only emits
+    // its thinking channel when true. Off suppresses reasoning at the source rather than
+    // relying on the display-time parser, which cannot strip a format it does not know.
+    // Only meaningful with chatml; the raw-prompt path ignores it.
+    bool think = true;
+
     MoeStreamConfig moe;
 };
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -29,6 +29,12 @@ struct RunSummary {
     double s_per_token = 0.0;
     double tokens_per_second = 0.0;
 
+    // Startup phase (additive telemetry): model load + streaming setup, and prefill.
+    // TTFT ~= load_seconds + prefill_seconds; prefill tok/s = n_prompt / prefill_seconds.
+    int n_prompt = 0;
+    double load_seconds = 0.0;
+    double prefill_seconds = 0.0;
+
     // MoE streaming totals (zero when streaming is off)
     double moe_read_mib = 0.0;
     double moe_io_seconds = 0.0;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -58,6 +58,11 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
         ~BackendGuard() { llama_backend_free(); }
     } backend_guard;
 
+    // Startup timing for the TTFT / prefill metrics (additive telemetry only). load spans
+    // model load + streaming capture/init; prefill is timed separately just below.
+    auto t_load0 = clock_t_::now();
+    double load_seconds = 0.0, prefill_seconds = 0.0;
+
     // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
     // q4_K buffer would break the rebind), experts on CPU.
     llama_model_params mparams = llama_model_default_params();
@@ -195,10 +200,13 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
     }
 
     // ── prefill ──
+    auto t_prefill0 = clock_t_::now();
+    load_seconds = secs(t_load0, t_prefill0); // everything up to here is "load"
     {
         llama_batch pf = llama_batch_get_one(tokens.data(), n_prompt);
         if (llama_decode(ctx, pf) != 0) return fail("prefill decode failed");
     }
+    prefill_seconds = secs(t_prefill0, clock_t_::now());
     const float * logits = llama_get_logits_ith(ctx, -1); // logits of the last output
 
     // ── greedy generation ──
@@ -282,6 +290,9 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
     s.gen_seconds = gen_seconds;
     s.s_per_token = n_gen ? gen_seconds / n_gen : 0.0;
     s.tokens_per_second = gen_seconds > 0 ? n_gen / gen_seconds : 0.0;
+    s.n_prompt = n_prompt;
+    s.load_seconds = load_seconds;
+    s.prefill_seconds = prefill_seconds;
     if (cfg.moe.enabled) {
         IExpertSource::Stats st = source.stats();
         // Generation-phase figures, summed from the measured per-token deltas (prefill

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -108,6 +108,10 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
             inputs.messages = {user_msg};
             inputs.add_generation_prompt = true;
             inputs.use_jinja = true;
+            // Suppress the model's thinking channel at the template level when reasoning is off,
+            // so a model whose reasoning format the display parser cannot strip (e.g. Gemma)
+            // simply never generates it. A template that ignores the kwarg is unaffected.
+            inputs.enable_thinking = cfg.think;
             common_chat_params cp = common_chat_templates_apply(chat_tmpls.get(), inputs);
             prompt = cp.prompt;
             parse_params = common_chat_parser_params(cp);

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -23,9 +23,11 @@ public:
     void on_summary(const RunSummary & s) override {
         std::fprintf(f_,
                      "# summary tokens=%d s/tok=%.3f tok/s=%.3f read_MiB=%.1f "
-                     "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f\n",
+                     "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f "
+                     "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
-                     s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct);
+                     s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
+                     s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0);
         std::fflush(f_);
     }
 

--- a/docs/benchmark-method.md
+++ b/docs/benchmark-method.md
@@ -1,9 +1,18 @@
 # Benchmark method
 
+This is *how* to measure. The measured results — the full config matrix for Qwen and
+Gemma, with mean/min/max/median/p95 tok/s — live in [benchmarks.md](benchmarks.md).
+
 ## On-device (the headline number)
 
 Hardware for the reference numbers: OnePlus 15R, Snapdragon-class SoC, 11.3 GB RAM,
 UFS 4.x storage. Model: Qwen3-30B-A3B-Q4_K_M (18.5 GB), ~1.7× device RAM.
+
+Reproducible drivers (used for [benchmarks.md](benchmarks.md)): `scripts/bench-run.sh`
+(one device-side run, prompt baked in so no quoting has to survive adb), `scripts/
+bench-matrix.ps1` (the full 12-run matrix over adb), `scripts/bench-analyze.py`
+(mean/min/max + median/p5/p95 from the CSVs). Use a fixed prompt and a fixed `-n`
+(≥256 tokens, so the expert cache reaches steady state) across every config.
 
 ```bash
 # push the model
@@ -33,7 +42,30 @@ Vary one axis at a time:
 - **Thermal.** Sustained decode throttles. Warm up, then measure a steady window; discard
   the first few tokens. Ignore `cpu-hw-trip-*` sensors — those are static 95 °C trip
   points, not live temperatures.
-- Expect **0.55–0.73 s/token** across the good part of the sweep.
+- **Report the distribution, not just the mean.** `min`/`max` tok/s are single-token
+  extremes (a lone eviction stall crushes `min`); pair them with median and p5/p95 so an
+  unstable config (wide spread) is distinguishable from a slow-but-steady one.
+- Expect **0.27–0.6 s/token** across the good part of the sweep (4000 MiB cache, 4 lanes,
+  256-token steady state); shorter runs read slower because the cache is still warming.
+
+### Device pressure (throughput is only half the story)
+
+tok/s does not capture what a config does to the *rest* of the phone. `mmap`-only faults
+the whole model through the page cache and evicts other apps, so the device goes sluggish;
+streaming with a bounded cache + O_DIRECT bypasses the page cache and keeps the system
+responsive. Record a pressure indicator next to tok/s. Accessible over adb **without root**:
+
+- **Temperature** — `dumpsys battery` (`temperature` in deci-°C, `PhoneTemp`) and
+  `/sys/class/thermal/thermal_zone*/temp` with matching `.../type` (CPU `cpu-*`, GPU
+  `gpuss-*`, skin zones are readable by the shell user).
+- **Free-RAM floor** — `/proc/meminfo` `MemAvailable`, sampled before / mid-run / after;
+  its collapse under mmap *is* the pressure signal.
+- **Throttling state** — `dumpsys thermalservice`.
+
+Kernel **PSI** (`/proc/pressure/{memory,io,cpu}`) is the cleanest stall metric but returns
+*Permission denied* without root on this device. Protocol: cool to a common baseline
+between configs so sustained-decode throttling doesn't confound the comparison, then
+produce a *tok/s vs. thermal rise and free-RAM floor* table alongside the throughput one.
 
 ## Host (correctness + a sanity number)
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,198 @@
+# Benchmarks — Android (OnePlus 15R)
+
+Measured throughput of the expert-streaming engine on a phone whose RAM is smaller than
+the model, across the full configuration matrix, for two MoE families. These are the
+numbers the README table and the headline claim are drawn from; the how-to lives in
+[benchmark-method.md](benchmark-method.md).
+
+## TL;DR
+
+- Streaming a >RAM MoE model is **stable and usable**: ~1.7–1.8 tok/s with no cache, up to
+  **~3.5–3.75 tok/s** with a 4 GiB expert cache and 4 read lanes — on an 11 GB phone
+  holding an 18.5 GB (Qwen) or 17.0 GB (Gemma) model.
+- **Expert-cache size is the dominant lever.** Going 2000 → 4000 MiB roughly doubles
+  throughput because the cache hit rate climbs (Qwen 53 % → 76 %, Gemma 58 % → 82 %) and
+  flash read per token collapses (Qwen 480 → 225 MiB, Gemma 366 → 144 MiB).
+- **Parallel read lanes are a secondary lever.** Lane 2 → 4 adds ~10–20 % at a 2000 MiB
+  cache and almost nothing at 4000 MiB (once the cache absorbs most reads, decode is no
+  longer I/O-bound).
+- **`mmap`-only is a trap.** Its *median* token rate looks fine (Qwen 2.06, Gemma 1.96
+  tok/s) but its *aggregate* throughput collapses (Gemma **0.61** tok/s) because a handful
+  of page-cache-eviction stalls (single tokens as slow as 7.7 s) dominate the total — and
+  during those stalls the phone is effectively unusable for anything else (see
+  [Device pressure](#device-pressure-not-just-tokens)).
+- **At a 4 GiB cache, decode is compute-bound, not I/O-bound.** The engine reports the
+  decode split as `compute + flash I/O`. At cache 4000 the flash I/O share drops to
+  ~0.10–0.15 s/token while compute (~0.14 Qwen, ~0.19 Gemma) dominates. Streaming overhead
+  is therefore small: with a perfectly-sized cache the ceiling would be **~7.0 tok/s (Qwen)
+  / ~5.3 tok/s (Gemma)**, which is the same SoC's in-RAM decode speed. The streaming path
+  is no longer the bottleneck — the compute kernels are.
+
+## Environment
+
+| | |
+|---|---|
+| Device | OnePlus 15R (`CPH2769`), Android 16 |
+| SoC / cores | Snapdragon-class, 8 cores, `arm64-v8a` |
+| RAM | 11.3 GB (`MemTotal` 11 366 276 kB) |
+| Storage | UFS 4.x, models read from `/sdcard/Download` (O_DIRECT verified working) |
+| Engine | `bmoe-cli` built from branch `test/gemma4-apk` (integrates the model-import and fused-expert-recipe PRs) |
+| Compute threads | 4 (`-t` default) |
+| Decoding | greedy (argmax) — output is deterministic, so token content is identical across configs |
+
+Models (both Q4_K_M, so the two families are compared at the same quantization):
+
+- **Qwen3-30B-A3B-Q4_K_M** — 18.5 GB, 128 experts, top-8, 48 layers (≈1.64× device RAM).
+- **Gemma-4-26B-A4B-it-Q4_K_M** — 17.0 GB, fused gate+up expert layout (≈1.51× device RAM).
+
+## Method
+
+Each configuration is one `bmoe-cli` run over `adb shell`, generating **256 tokens** from a
+single fixed prompt with `--chatml`, writing per-token metrics to CSV. 256 tokens (vs. the
+older 48-token spot checks) lets the expert cache reach steady state, which is why the
+cached configurations here read higher than earlier short-run numbers.
+
+`wall_ms` in the CSV is the **per-token decode time** (one `llama_decode`), excluding
+prompt prefill and model load. From it:
+
+- **mean** = aggregate throughput = `n_tokens / Σ decode_seconds` — the rate a user sees.
+- **min / max** = slowest / fastest *single* token (`1000 / max|min(wall_ms)`) — the
+  worst-case stall and the best-case cache-warm token.
+- **median / p5 / p95** = the steady-state distribution; more robust than min/max, which
+  are single-token extremes.
+
+Reproduce with the committed drivers:
+
+```bash
+# device-side single run (prompt lives in the script, n and flags are args)
+scripts/bench-run.sh 256 <model.gguf> <out.csv> [--moe-stream --cache-mb 4000 --io-threads 4]
+
+# full 12-run matrix over adb, one CSV per config
+pwsh scripts/bench-matrix.ps1        # writes .bench/*.csv
+python scripts/bench-analyze.py      # mean/min/max/median/p5/p95 + .bench/summary.md
+```
+
+Each table row is one fixed flag string (from `scripts/bench-matrix.ps1`), so a row
+reproduces exactly by re-running its config:
+
+| Config row | `bench-run.sh` flags |
+|---|---|
+| solo mmap (no streaming) | *(none)* |
+| streaming O_DIRECT, cache 0, lane 4 | `--moe-stream` |
+| streaming + cache 2000 MiB, lane 2 | `--moe-stream --cache-mb 2000 --io-threads 2` |
+| streaming + cache 2000 MiB, lane 4 | `--moe-stream --cache-mb 2000 --io-threads 4` |
+| streaming + cache 4000 MiB, lane 2 | `--moe-stream --cache-mb 4000 --io-threads 2` |
+| streaming + cache 4000 MiB, lane 4 | `--moe-stream --cache-mb 4000 --io-threads 4` |
+
+The `compute + I/O` split, `flash read/token` and `cache hit` columns are parsed from the
+engine's own `moe-stream:` / `moe-cache:` stderr summary printed at the end of each run —
+not computed post-hoc — so they reproduce verbatim in the `.bench/*.log` files.
+
+## Results
+
+tok/s. **mean** = aggregate throughput (bold). min/max = slowest/fastest single token.
+median/p5/p95 = steady-state distribution. `flash read/token` and `cache hit` are from the
+engine's `moe-stream:` / `moe-cache:` summary. `decode: compute + I/O` splits the mean
+per-token decode time (s) into compute and flash-I/O, straight from the `moe-stream:` line —
+it shows how much of decode is spent waiting on flash vs. running kernels.
+
+### Qwen3-30B-A3B-Q4_K_M
+
+- **File:** `Qwen3-30B-A3B-Q4_K_M.gguf` — 18.5 GB on disk, Q4_K_M quantization.
+- **Shape:** 128 experts, top-8 routing, 48 layers. ≈1.64× device RAM (11.3 GB).
+
+| Config | mean | min | max | median | p5 | p95 | cache hit | flash read/token | decode: compute + I/O (s/tok) |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| solo mmap (no streaming) | **1.86** | 0.36 | 8.34 | 2.06 | 0.95 | 5.18 | — | 0 MiB | — |
+| streaming O_DIRECT, cache 0, lane 4 | **1.78** | 1.56 | 1.82 | 1.79 | 1.73 | 1.81 | — | 1051 MiB | 0.102 + 0.459 |
+| streaming + cache 2000 MiB, lane 2 | **2.00** | 0.20 | 4.98 | 2.19 | 1.38 | 3.42 | 53% | 480 MiB | 0.199 + 0.302 |
+| streaming + cache 2000 MiB, lane 4 | **2.47** | 1.54 | 5.27 | 2.51 | 1.81 | 3.66 | 53% | 480 MiB | 0.177 + 0.228 |
+| streaming + cache 4000 MiB, lane 2 | **3.38** | 1.57 | 7.66 | 3.51 | 2.16 | 5.98 | 76% | 225 MiB | 0.144 + 0.152 |
+| streaming + cache 4000 MiB, lane 4 | **3.75** | 1.88 | 7.81 | 3.88 | 2.51 | 6.22 | 76% | 225 MiB | 0.143 + 0.124 |
+
+### Gemma-4-26B-A4B-it-Q4_K_M
+
+- **File:** `Gemma-4-26B-A4B-it-Q4_K_M.gguf` — 17.0 GB on disk, Q4_K_M quantization.
+- **Shape:** fused gate+up expert layout, A4B (4 experts active). ≈1.51× device RAM (11.3 GB).
+
+| Config | mean | min | max | median | p5 | p95 | cache hit | flash read/token | decode: compute + I/O (s/tok) |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| solo mmap (no streaming) | **0.61** | 0.13 | 5.91 | 1.96 | 0.18 | 4.18 | — | 0 MiB | — |
+| streaming O_DIRECT, cache 0, lane 4 | **1.69** | 1.36 | 1.73 | 1.70 | 1.66 | 1.72 | — | 904 MiB | 0.156 + 0.435 |
+| streaming + cache 2000 MiB, lane 2 | **2.24** | 1.33 | 4.21 | 2.27 | 1.67 | 3.26 | 58% | 366 MiB | 0.203 + 0.243 |
+| streaming + cache 2000 MiB, lane 4 | **2.34** | 1.50 | 3.98 | 2.40 | 1.80 | 3.23 | 58% | 366 MiB | 0.212 + 0.215 |
+| streaming + cache 4000 MiB, lane 2 | **3.39** | 1.34 | 5.74 | 3.55 | 2.39 | 5.01 | 82% | 144 MiB | 0.185 + 0.110 |
+| streaming + cache 4000 MiB, lane 4 | **3.48** | 0.96 | 5.84 | 3.65 | 2.54 | 5.19 | 82% | 144 MiB | 0.187 + 0.100 |
+
+## Reading the numbers
+
+- **Cache dominates, lanes assist.** Throughput tracks the hit rate almost linearly. At a
+  4000 MiB cache the routed working set is mostly resident, so extra read lanes have little
+  left to hide — lane 2 vs 4 is within noise (Qwen 3.38 → 3.75, Gemma 3.39 → 3.48).
+- **Streaming without a cache is the most *predictable* setting.** cache-0 has the tightest
+  spread (Qwen p5–p95 = 1.73–1.81) because every token re-reads the same ~1 GiB with
+  O_DIRECT: no cache warm-up, no eviction cliffs. It is slower on average but jitter-free.
+- **`mmap`-only trades average speed and system health for nothing.** Qwen's mmap mean
+  (1.86) edges out streaming-only (1.78), but that number is page-cache-dependent and its
+  spread is enormous (min 0.36, max 8.34). On Gemma the same mode collapses to 0.61 tok/s
+  aggregate despite a healthy 1.96 median — proof that a few multi-second eviction stalls,
+  not the typical token, set the user-visible speed. Streaming replaces those unbounded
+  stalls with a bounded, O_DIRECT read the engine controls.
+- **The remaining bottleneck is compute, not the seam.** Follow the `compute + I/O` column
+  down each table: at cache 0 flash I/O is 74–82 % of decode (Qwen 0.459 of 0.561, Gemma
+  0.435 of 0.591); at cache 4000 it inverts to compute-bound (Qwen compute 0.143 vs I/O
+  0.124; Gemma 0.187 vs 0.100). Zeroing I/O entirely — an infinite cache — would only reach
+  1/compute ≈ **7.0 tok/s (Qwen) / 5.3 tok/s (Gemma)**, i.e. this SoC's in-RAM decode
+  speed. So a well-sized cache has already recovered most of what streaming can recover;
+  further gains have to come from the compute kernels, not from the streaming path.
+  (Note the compute share *rises* when the cache is enabled — cache-0's 0.10–0.16 s grows
+  to ~0.18–0.21 s at cache 2000 — because cache lookup/copy is counted inside compute;
+  it settles back down at cache 4000 as the hit rate makes those copies rarer.)
+
+## Device pressure — not just tokens
+
+Tokens/s is only half the story. Under `mmap`-only the model is faulted in through the
+**page cache**, so the kernel evicts everything else — other apps, the launcher, the
+keyboard — to make room for a 17–18 GB mapping on 11 GB of RAM. The phone becomes
+sluggish or unusable for anything besides inference, and the eviction stalls are exactly
+the slow tokens above. Expert streaming with a bounded cache avoids this: it holds a fixed,
+declared amount (2–4 GiB) and reads the rest with O_DIRECT, which **bypasses the page
+cache**, so the rest of the system keeps its working set.
+
+**This axis is not yet measured** — the tables above are throughput only. Future runs
+should record, alongside tok/s, an indicator of the pressure a config puts on the device.
+Accessible on this phone **without root**:
+
+| Signal | Source (adb, no root) | Notes |
+|---|---|---|
+| Battery / phone temperature | `dumpsys battery` → `temperature` (deci-°C), `PhoneTemp` | e.g. `415` = 41.5 °C |
+| Per-component temperature | `/sys/class/thermal/thermal_zone*/temp` + `.../type` | CPU/GPU/skin zones readable by shell (`cpu-*`, `gpuss-*`) |
+| Free-RAM headroom | `/proc/meminfo` → `MemAvailable` | collapse under mmap is the pressure signal |
+| Thermal throttling state | `dumpsys thermalservice` | throttle status / trip transitions |
+
+Not available without root on this device: the kernel **PSI** counters
+(`/proc/pressure/{memory,io,cpu}`) return *Permission denied* — the cleanest
+memory/IO-stall metric, but it needs root or a privileged helper.
+
+Recommended protocol for the next round: sample battery temperature + `MemAvailable`
+before, mid-run, and after each config; warm up, then measure a steady thermal window;
+and cool the device to a common baseline between configs so sustained-decode throttling
+doesn't confound the comparison. The goal is a second table — *tok/s vs. thermal rise and
+free-RAM floor* — that makes the "mmap is fast until the phone melts" cost explicit.
+
+## Provenance
+
+Measured 2026-07-11 on branch `test/gemma4-apk`. Raw per-token CSVs and full `.log` stderr
+dumps in `.bench/` (git-ignored); drivers in `scripts/bench-run.sh`, `scripts/bench-matrix.ps1`,
+`scripts/bench-analyze.py`. Both models read from `/sdcard/Download`; O_DIRECT streaming from
+that path was verified working before the matrix ran.
+
+Model files (both Q4_K_M GGUF, staged on the device at `/sdcard/Download/`):
+
+| Table section | Device path | Size |
+|---|---|---|
+| Qwen | `/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf` | 18.5 GB |
+| Gemma | `/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf` | 17.0 GB |
+
+Sizes are the on-disk GGUF byte counts; both are stock Q4_K_M conversions, unmodified by the
+engine (it loads `use_mmap=true`, rebinds expert tensors to the native gguf layout, no repack).

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -16,18 +16,17 @@ data class AppSettings(
     val loadAll: Boolean = false,// debug: read ALL experts each token (A/B baseline)
 ) {
     /**
-     * Build the bmoe-cli argument list. `arch` is the gguf `general.architecture` (may be null);
-     * it selects arch-specific prompt handling: the engine applies the model family's chat turn
-     * via --chatml, and Qwen3's /no_think soft switch is only appended for Qwen3 models (it is
-     * meaningless — and pollutes the prompt — for other families such as Gemma).
+     * Build the bmoe-cli argument list. The engine renders the model family's own chat template
+     * via --chatml; reasoning is turned off with --no-think, which the template honours through
+     * its `enable_thinking` kwarg. This is model-agnostic (works for Qwen3 and Gemma alike),
+     * unlike the old Qwen-only /no_think prompt suffix. `arch` is kept for future arch-specific
+     * handling but is no longer needed for the thinking switch.
      */
     fun toArgv(cliPath: String, modelPath: String, prompt: String, arch: String?): List<String> {
-        val isQwen3 = arch?.contains("qwen3") == true
-        val effectivePrompt = if (isQwen3 && !thinking) "$prompt /no_think" else prompt
         val a = mutableListOf(
             cliPath,
             "-m", modelPath,
-            "-p", effectivePrompt,
+            "-p", prompt,
             "-n", nPredict.toString(),
             "-t", threads.toString(),
             "--chatml", // apply the model family's chat turn (gemma / chatml)
@@ -36,6 +35,7 @@ data class AppSettings(
             "--io-threads", ioThreads.toString(),
             "--progress",
         )
+        if (!thinking) a += "--no-think"
         if (!oDirect) a += "--no-odirect"
         if (loadAll) a += "--load-all"
         return a

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -23,7 +23,9 @@ import kotlin.concurrent.thread
 class RunService : Service() {
 
     private val telemetry = TelemetryParser()
+    @Volatile
     private var proc: Process? = null
+    @Volatile
     private var wake: PowerManager.WakeLock? = null
 
     // Set when the user presses Stop: the CLI is then killed on purpose, so its non-zero
@@ -46,8 +48,11 @@ class RunService : Service() {
         RunBus.setRunning(true)
         RunBus.setLoading(true) // held until the first token arrives (model load + prompt eval)
 
+        // Reference counting off so a release on an already-released lock is a harmless no-op:
+        // Stop races the reader thread's finally block, and both call releaseWake().
         wake = (getSystemService(Context.POWER_SERVICE) as PowerManager)
-            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "bmoe:gen").apply { acquire(30 * 60 * 1000L) }
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "bmoe:gen")
+            .apply { setReferenceCounted(false); acquire(30 * 60 * 1000L) }
 
         thread(name = "bmoe-cli") { runCli(argv, model, prompt) }
         return START_NOT_STICKY
@@ -117,6 +122,7 @@ class RunService : Service() {
         stopSelf()
     }
 
+    @Synchronized
     private fun releaseWake() {
         wake?.let { if (it.isHeld) it.release() }
         wake = null

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Parse the benchmark CSVs and emit mean/min/max (+ median, p5, p95) tok/s tables,
+# both as a console table and as a markdown file for the docs.
+#
+# tok/s per token = 1000 / wall_ms (wall_ms is the per-token decode time).
+#   mean = aggregate n_tokens / total_seconds (the throughput a user actually sees)
+#   min  = slowest single token = 1000 / max(wall_ms)   (worst-case stall)
+#   max  = fastest single token = 1000 / min(wall_ms)   (best-case, cache-warm)
+# min/max are single-token extremes; median and p5/p95 describe the steady state.
+import glob, os, sys, statistics
+
+BENCH = sys.argv[1] if len(sys.argv) > 1 else r"C:\Users\raffa\Documents\BigMoeOnEdge\.bench"
+
+ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4"]
+LABEL = {
+    "mmap": "solo mmap (no streaming)",
+    "stream": "streaming O_DIRECT, cache 0, lane 4",
+    "c2000_l2": "streaming + cache 2000 MiB, lane 2",
+    "c2000_l4": "streaming + cache 2000 MiB, lane 4",
+    "c4000_l2": "streaming + cache 4000 MiB, lane 2",
+    "c4000_l4": "streaming + cache 4000 MiB, lane 4",
+}
+
+def pct(sorted_vals, q):
+    if not sorted_vals:
+        return 0.0
+    i = q * (len(sorted_vals) - 1)
+    lo = int(i)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (i - lo)
+
+def analyze(path):
+    walls, summary = [], {}
+    with open(path, newline="") as f:
+        for row in f:
+            row = row.strip()
+            if not row or row.startswith("step,"):
+                continue
+            if row.startswith("# summary"):
+                for tok in row.replace("# summary", "").split():
+                    if "=" in tok:
+                        k, v = tok.split("=", 1)
+                        summary[k] = v
+                continue
+            parts = row.split(",")
+            try:
+                walls.append(float(parts[2]))
+            except (IndexError, ValueError):
+                pass
+    if not walls:
+        return None
+    n = len(walls)
+    tps = sorted(1000.0 / w for w in walls if w > 0)
+    total_s = sum(walls) / 1000.0
+    return {
+        "n": n,
+        "mean": n / total_s if total_s > 0 else 0.0,
+        "min": tps[0],
+        "max": tps[-1],
+        "median": statistics.median(tps),
+        "p5": pct(tps, 0.05),
+        "p95": pct(tps, 0.95),
+        "std": statistics.pstdev(tps),
+        "cache_hit": summary.get("cache_hit_pct", "-"),
+        "read_MiB_tok": (float(summary.get("read_MiB", "0")) / n) if summary.get("read_MiB") and n else 0.0,
+    }
+
+md = []
+for model, pretty in (("qwen", "Qwen3-30B-A3B-Q4_K_M (18.5 GB, 128 experts, top-8, 48 layers)"),
+                       ("gemma", "Gemma-4-26B-A4B-it-Q4_K_M (17.0 GB, fused gate+up experts)")):
+    print(f"\n===== {model.upper()} =====")
+    hdr = f"{'config':38s} {'n':>4s} {'mean':>6s} {'min':>6s} {'max':>6s} {'med':>6s} {'p5':>6s} {'p95':>6s} {'hit%':>5s} {'MiB/t':>7s}"
+    print(hdr)
+    md.append(f"\n### {pretty}\n")
+    md.append("| Config | mean | min | max | median | p5 | p95 | cache hit | flash read/token |")
+    md.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for key in ORDER:
+        p = os.path.join(BENCH, f"{model}_{key}.csv")
+        if not os.path.exists(p):
+            print(f"{LABEL[key]:38s}  (no CSV)")
+            md.append(f"| {LABEL[key]} | — | — | — | — | — | — | — | — |")
+            continue
+        r = analyze(p)
+        if r is None:
+            continue
+        hit = f"{float(r['cache_hit']):.0f}%" if r['cache_hit'] not in ("-", "-1.0") else "—"
+        print(f"{LABEL[key]:38s} {r['n']:4d} {r['mean']:6.2f} {r['min']:6.2f} {r['max']:6.2f} "
+              f"{r['median']:6.2f} {r['p5']:6.2f} {r['p95']:6.2f} {hit:>5s} {r['read_MiB_tok']:6.0f}M")
+        md.append(f"| {LABEL[key]} | **{r['mean']:.2f}** | {r['min']:.2f} | {r['max']:.2f} | "
+                  f"{r['median']:.2f} | {r['p5']:.2f} | {r['p95']:.2f} | {hit} | {r['read_MiB_tok']:.0f} MiB |")
+
+out = os.path.join(BENCH, "summary.md")
+with open(out, "w", encoding="utf-8") as f:
+    f.write("\n".join(md) + "\n")
+print(f"\nmarkdown -> {out}")
+print("tok/s: mean=aggregate throughput  min/max=slowest/fastest single token  med/p5/p95=steady-state distribution")

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
-# Parse the benchmark CSVs and emit mean/min/max (+ median, p5, p95) tok/s tables,
-# both as a console table and as a markdown file for the docs.
+# Parse the benchmark CSVs (+ sibling .metrics) and emit two tables:
+#   1. Throughput  — decode tok/s (mean/min/max/median/p5/p95), prefill tok/s, TTFT.
+#   2. Pressure    — peak RSS, free-RAM floor, CPU temperature rise (thermal cost).
+# Writes both as markdown to .bench/summary.md for the docs.
 #
-# tok/s per token = 1000 / wall_ms (wall_ms is the per-token decode time).
-#   mean = aggregate n_tokens / total_seconds (the throughput a user actually sees)
-#   min  = slowest single token = 1000 / max(wall_ms)   (worst-case stall)
-#   max  = fastest single token = 1000 / min(wall_ms)   (best-case, cache-warm)
-# min/max are single-token extremes; median and p5/p95 describe the steady state.
-import glob, os, sys, statistics
+# decode tok/s per token = 1000 / wall_ms (wall_ms = per-token decode time).
+#   mean = aggregate n_tokens / total_seconds ; min/max = slowest/fastest single token.
+import os, sys, statistics
 
 BENCH = sys.argv[1] if len(sys.argv) > 1 else r"C:\Users\raffa\Documents\BigMoeOnEdge\.bench"
-
 ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4"]
 LABEL = {
     "mmap": "solo mmap (no streaming)",
@@ -21,17 +19,30 @@ LABEL = {
     "c4000_l4": "streaming + cache 4000 MiB, lane 4",
 }
 
-def pct(sorted_vals, q):
-    if not sorted_vals:
+def pct(v, q):
+    if not v:
         return 0.0
-    i = q * (len(sorted_vals) - 1)
-    lo = int(i)
-    hi = min(lo + 1, len(sorted_vals) - 1)
-    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (i - lo)
+    i = q * (len(v) - 1); lo = int(i); hi = min(lo + 1, len(v) - 1)
+    return v[lo] + (v[hi] - v[lo]) * (i - lo)
 
-def analyze(path):
-    walls, summary = [], {}
-    with open(path, newline="") as f:
+def read_metrics(path):
+    d = {}
+    if os.path.exists(path):
+        for line in open(path):
+            if "=" in line:
+                k, v = line.strip().split("=", 1)
+                d[k] = v
+    return d
+
+def num(d, k):
+    try:
+        return float(d.get(k, ""))
+    except ValueError:
+        return None
+
+def analyze(csv_path):
+    walls, summ = [], {}
+    with open(csv_path) as f:
         for row in f:
             row = row.strip()
             if not row or row.startswith("step,"):
@@ -39,58 +50,65 @@ def analyze(path):
             if row.startswith("# summary"):
                 for tok in row.replace("# summary", "").split():
                     if "=" in tok:
-                        k, v = tok.split("=", 1)
-                        summary[k] = v
+                        k, v = tok.split("=", 1); summ[k] = v
                 continue
-            parts = row.split(",")
             try:
-                walls.append(float(parts[2]))
+                walls.append(float(row.split(",")[2]))
             except (IndexError, ValueError):
                 pass
     if not walls:
         return None
-    n = len(walls)
-    tps = sorted(1000.0 / w for w in walls if w > 0)
+    n = len(walls); tps = sorted(1000.0 / w for w in walls if w > 0)
     total_s = sum(walls) / 1000.0
+    m = read_metrics(csv_path.replace(".csv", ".metrics"))
+    def g(k):
+        try: return float(summ.get(k, ""))
+        except ValueError: return 0.0
     return {
-        "n": n,
-        "mean": n / total_s if total_s > 0 else 0.0,
-        "min": tps[0],
-        "max": tps[-1],
-        "median": statistics.median(tps),
-        "p5": pct(tps, 0.05),
-        "p95": pct(tps, 0.95),
-        "std": statistics.pstdev(tps),
-        "cache_hit": summary.get("cache_hit_pct", "-"),
-        "read_MiB_tok": (float(summary.get("read_MiB", "0")) / n) if summary.get("read_MiB") and n else 0.0,
+        "n": n, "mean": n / total_s if total_s else 0.0, "min": tps[0], "max": tps[-1],
+        "median": statistics.median(tps), "p5": pct(tps, 0.05), "p95": pct(tps, 0.95),
+        "cache_hit": summ.get("cache_hit_pct", "-"),
+        "read_MiB_tok": (g("read_MiB") / n) if n else 0.0,
+        "prefill_tps": g("prefill_tps"), "load_s": g("load_s"),
+        "prefill_s": g("prefill_s"), "ttft": g("load_s") + g("prefill_s"),
+        "peak_rss_gb": (num(m, "peak_rss_kb") or 0) / 1048576.0,
+        "mem_floor_gb": (num(m, "mem_avail_floor_kb") or 0) / 1048576.0,
+        "cpu0": (num(m, "cpu_temp_before_mC") or 0) / 1000.0,
+        "cpu_max": (num(m, "cpu_temp_max_mC") or 0) / 1000.0,
+        "batt_max": (num(m, "batt_temp_max_dC") or 0) / 10.0,
     }
 
 md = []
 for model, pretty in (("qwen", "Qwen3-30B-A3B-Q4_K_M (18.5 GB, 128 experts, top-8, 48 layers)"),
-                       ("gemma", "Gemma-4-26B-A4B-it-Q4_K_M (17.0 GB, fused gate+up experts)")):
-    print(f"\n===== {model.upper()} =====")
-    hdr = f"{'config':38s} {'n':>4s} {'mean':>6s} {'min':>6s} {'max':>6s} {'med':>6s} {'p5':>6s} {'p95':>6s} {'hit%':>5s} {'MiB/t':>7s}"
-    print(hdr)
-    md.append(f"\n### {pretty}\n")
-    md.append("| Config | mean | min | max | median | p5 | p95 | cache hit | flash read/token |")
-    md.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+                      ("gemma", "Gemma-4-26B-A4B-it-Q4_K_M (17.0 GB, fused gate+up experts)")):
+    rows = []
     for key in ORDER:
         p = os.path.join(BENCH, f"{model}_{key}.csv")
-        if not os.path.exists(p):
-            print(f"{LABEL[key]:38s}  (no CSV)")
-            md.append(f"| {LABEL[key]} | — | — | — | — | — | — | — | — |")
-            continue
-        r = analyze(p)
+        rows.append((key, analyze(p) if os.path.exists(p) else None))
+
+    print(f"\n===== {model.upper()} — throughput =====")
+    print(f"{'config':36s} {'mean':>6s} {'min':>6s} {'max':>6s} {'med':>6s} {'p95':>6s} {'pref':>6s} {'TTFT':>6s} {'hit':>5s} {'MiB/t':>6s}")
+    md.append(f"\n### {pretty}\n\n**Throughput** (tok/s; mean = aggregate decode, prefill = prompt-processing):\n")
+    md.append("| Config | decode mean | min | max | median | p95 | prefill tok/s | TTFT (s) | cache hit | flash read/token |")
+    md.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for key, r in rows:
         if r is None:
-            continue
+            md.append(f"| {LABEL[key]} | — | — | — | — | — | — | — | — | — |"); continue
         hit = f"{float(r['cache_hit']):.0f}%" if r['cache_hit'] not in ("-", "-1.0") else "—"
-        print(f"{LABEL[key]:38s} {r['n']:4d} {r['mean']:6.2f} {r['min']:6.2f} {r['max']:6.2f} "
-              f"{r['median']:6.2f} {r['p5']:6.2f} {r['p95']:6.2f} {hit:>5s} {r['read_MiB_tok']:6.0f}M")
-        md.append(f"| {LABEL[key]} | **{r['mean']:.2f}** | {r['min']:.2f} | {r['max']:.2f} | "
-                  f"{r['median']:.2f} | {r['p5']:.2f} | {r['p95']:.2f} | {hit} | {r['read_MiB_tok']:.0f} MiB |")
+        print(f"{LABEL[key]:36s} {r['mean']:6.2f} {r['min']:6.2f} {r['max']:6.2f} {r['median']:6.2f} {r['p95']:6.2f} {r['prefill_tps']:6.2f} {r['ttft']:6.1f} {hit:>5s} {r['read_MiB_tok']:5.0f}M")
+        md.append(f"| {LABEL[key]} | **{r['mean']:.2f}** | {r['min']:.2f} | {r['max']:.2f} | {r['median']:.2f} | {r['p95']:.2f} | {r['prefill_tps']:.2f} | {r['ttft']:.1f} | {hit} | {r['read_MiB_tok']:.0f} MiB |")
+
+    print(f"\n===== {model.upper()} — device pressure =====")
+    print(f"{'config':36s} {'peakRSS':>8s} {'RAMfloor':>9s} {'CPU0':>6s} {'CPUmax':>7s} {'battMax':>8s}")
+    md.append(f"\n**Device pressure** (peak process RSS, free-RAM floor, SoC/battery temperature):\n")
+    md.append("| Config | peak RSS | free-RAM floor | CPU start | CPU max | battery max |")
+    md.append("|---|---:|---:|---:|---:|---:|")
+    for key, r in rows:
+        if r is None:
+            md.append(f"| {LABEL[key]} | — | — | — | — | — |"); continue
+        print(f"{LABEL[key]:36s} {r['peak_rss_gb']:6.2f}GB {r['mem_floor_gb']:7.2f}GB {r['cpu0']:5.1f}C {r['cpu_max']:6.1f}C {r['batt_max']:7.1f}C")
+        md.append(f"| {LABEL[key]} | {r['peak_rss_gb']:.2f} GB | {r['mem_floor_gb']:.2f} GB | {r['cpu0']:.1f} °C | {r['cpu_max']:.1f} °C | {r['batt_max']:.1f} °C |")
 
 out = os.path.join(BENCH, "summary.md")
-with open(out, "w", encoding="utf-8") as f:
-    f.write("\n".join(md) + "\n")
+open(out, "w", encoding="utf-8").write("\n".join(md) + "\n")
 print(f"\nmarkdown -> {out}")
-print("tok/s: mean=aggregate throughput  min/max=slowest/fastest single token  med/p5/p95=steady-state distribution")

--- a/scripts/bench-matrix.ps1
+++ b/scripts/bench-matrix.ps1
@@ -1,0 +1,36 @@
+# On-device benchmark matrix driver. Invokes the instrumented device-side bench-run.sh.
+param(
+  [string]$OutDir = "C:\Users\raffa\Documents\BigMoeOnEdge\.bench",
+  [int]$NPred = 256
+)
+$ErrorActionPreference = "Continue"
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$DEV = "/data/local/tmp"
+
+$QWEN  = "/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf"
+$GEMMA = "/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf"
+
+function Run-Cfg($tag, $model, $flags) {
+  Write-Host "==================== $tag ===================="
+  $t0 = Get-Date
+  $log = & adb shell "sh $DEV/bench-run.sh $NPred $model $DEV/$tag.csv $DEV/$tag.metrics $flags" 2>&1
+  $dt = [math]::Round(((Get-Date) - $t0).TotalSeconds, 1)
+  $log | Where-Object { $_ -match "generation:|prefill:|moe-stream:|moe-cache:|peak_rss|mem_avail_floor|batt_temp_max|cpu_temp_max|charge_" } | ForEach-Object { Write-Host "  $_" }
+  Write-Host "  wall(incl load)=${dt}s"
+  $log | Out-File -FilePath "$OutDir\$tag.log" -Encoding utf8
+  & adb pull "$DEV/$tag.csv" "$OutDir\$tag.csv" 2>&1 | Out-Null
+  & adb pull "$DEV/$tag.metrics" "$OutDir\$tag.metrics" 2>&1 | Out-Null
+  if (Test-Path "$OutDir\$tag.csv") { Write-Host "  -> $tag.csv + .metrics pulled" } else { Write-Host "  !! no CSV for $tag" }
+}
+
+$models = @{ qwen = $QWEN; gemma = $GEMMA }
+foreach ($name in @("qwen","gemma")) {
+  $m = $models[$name]
+  Run-Cfg "${name}_mmap"     $m ""
+  Run-Cfg "${name}_stream"   $m "--moe-stream"
+  Run-Cfg "${name}_c2000_l2" $m "--moe-stream --cache-mb 2000 --io-threads 2"
+  Run-Cfg "${name}_c2000_l4" $m "--moe-stream --cache-mb 2000 --io-threads 4"
+  Run-Cfg "${name}_c4000_l2" $m "--moe-stream --cache-mb 4000 --io-threads 2"
+  Run-Cfg "${name}_c4000_l4" $m "--moe-stream --cache-mb 4000 --io-threads 4"
+}
+Write-Host "ALL DONE"

--- a/scripts/bench-matrix.ps1
+++ b/scripts/bench-matrix.ps1
@@ -1,7 +1,8 @@
 # On-device benchmark matrix driver. Invokes the instrumented device-side bench-run.sh.
 param(
   [string]$OutDir = "C:\Users\raffa\Documents\BigMoeOnEdge\.bench",
-  [int]$NPred = 256
+  [int]$NPred = 256,
+  [int]$CooldownSec = 45   # let the SoC cool to a similar baseline before each run
 )
 $ErrorActionPreference = "Continue"
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
@@ -12,6 +13,7 @@ $GEMMA = "/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf"
 
 function Run-Cfg($tag, $model, $flags) {
   Write-Host "==================== $tag ===================="
+  Start-Sleep -Seconds $CooldownSec   # thermal cooldown so runs start from a similar baseline
   $t0 = Get-Date
   $log = & adb shell "sh $DEV/bench-run.sh $NPred $model $DEV/$tag.csv $DEV/$tag.metrics $flags" 2>&1
   $dt = [math]::Round(((Get-Date) - $t0).TotalSeconds, 1)

--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -1,23 +1,24 @@
 #!/system/bin/sh
 # Instrumented device-side benchmark run.
 #   args: N MODEL CSV METRICS [extra bmoe-cli flags...]
-# Runs bmoe-cli (which now reports prefill/TTFT/load itself) while sampling device
-# pressure at ~1 Hz: peak process RSS, free-RAM floor, battery + SoC temperature, and the
-# battery charge counter before/after. The prompt lives here so no quoting has to survive
-# adb/PowerShell. Energy note: over USB the phone is powered/charging, so charge deltas are
-# indicative only â€” a true joules/token needs an unplugged (wireless-adb) pass.
+# Runs bmoe-cli (which reports prefill/TTFT/load itself) while sampling device pressure at
+# ~1 Hz: peak process memory (VmHWM), free-RAM floor (MemAvailable), and battery + SoC
+# temperature. The prompt lives here so no quoting has to survive adb/PowerShell.
+# Energy note: the battery charge_counter / current_now nodes are root-only on this device,
+# and over USB the phone is powered anyway, so joules/token is not measured here -- it needs
+# a rooted, unplugged (wireless-adb) pass.
 N="$1"; MODEL="$2"; CSV="$3"; METRICS="$4"; shift 4
 cd /data/local/tmp || exit 1
 rm -f "$CSV" "$METRICS" /data/local/tmp/cli_stdout.txt
 
 batt_temp() { dumpsys battery 2>/dev/null | sed -n 's/.*temperature: *//p'; }
-charge()    { cat /sys/class/power_supply/battery/charge_counter 2>/dev/null; }
-memavail()  { sed -n 's/^MemAvailable: *\([0-9]*\).*/\1/p' /proc/meminfo; }
+memavail()  { sed -n 's/^MemAvailable:[[:space:]]*\([0-9]*\).*/\1/p' /proc/meminfo; }
+vmhwm()     { sed -n 's/^VmHWM:[[:space:]]*\([0-9]*\).*/\1/p' /proc/$1/status 2>/dev/null; }
 cpu_temp()  { for z in /sys/class/thermal/thermal_zone*; do
                 case "$(cat "$z/type" 2>/dev/null)" in cpu-0-0*|cpu-1-0*|cpu-*) cat "$z/temp" 2>/dev/null; return;; esac
               done; }
 
-MEM0=$(memavail); T0=$(batt_temp); CPU0=$(cpu_temp); CH0=$(charge)
+MEM0=$(memavail); T0=$(batt_temp); CPU0=$(cpu_temp)
 
 LD_LIBRARY_PATH=/data/local/tmp ./bmoe-cli -m "$MODEL" --chatml -n "$N" \
   -p "Write a long detailed essay about the history of computing including its origins its key milestones the people involved and the future directions of the field" \
@@ -26,15 +27,14 @@ PID=$!
 
 PEAK_RSS=0; MEM_MIN=$MEM0; TEMP_MAX=$T0; CPU_MAX=$CPU0
 while kill -0 "$PID" 2>/dev/null; do
-  R=$(sed -n 's/^VmRSS: *\([0-9]*\).*/\1/p' /proc/$PID/status 2>/dev/null)
-  [ -n "$R" ] && [ "$R" -gt "$PEAK_RSS" ] && PEAK_RSS=$R
-  M=$(memavail);  [ -n "$M" ] && [ "$M" -lt "$MEM_MIN" ] && MEM_MIN=$M
-  B=$(batt_temp); [ -n "$B" ] && [ "$B" -gt "$TEMP_MAX" ] && TEMP_MAX=$B
-  C=$(cpu_temp);  [ -n "$C" ] && [ "$C" -gt "$CPU_MAX" ] && CPU_MAX=$C
+  R=$(vmhwm "$PID");   [ -n "$R" ] && [ "$R" -gt "$PEAK_RSS" ] && PEAK_RSS=$R
+  M=$(memavail);       [ -n "$M" ] && [ "$M" -lt "$MEM_MIN" ] && MEM_MIN=$M
+  B=$(batt_temp);      [ -n "$B" ] && [ "$B" -gt "$TEMP_MAX" ] && TEMP_MAX=$B
+  C=$(cpu_temp);       [ -n "$C" ] && [ "$C" -gt "$CPU_MAX" ] && CPU_MAX=$C
   sleep 1
 done
 wait "$PID"
-MEM1=$(memavail); T1=$(batt_temp); CH1=$(charge)
+MEM1=$(memavail); T1=$(batt_temp)
 
 {
   echo "peak_rss_kb=$PEAK_RSS"
@@ -46,8 +46,6 @@ MEM1=$(memavail); T1=$(batt_temp); CH1=$(charge)
   echo "batt_temp_after_dC=$T1"
   echo "cpu_temp_before_mC=$CPU0"
   echo "cpu_temp_max_mC=$CPU_MAX"
-  echo "charge_before_uah=$CH0"
-  echo "charge_after_uah=$CH1"
 } > "$METRICS"
 
 grep -E "generation:|prefill:|moe-stream:|moe-cache:" /data/local/tmp/cli_stdout.txt

--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -1,0 +1,54 @@
+#!/system/bin/sh
+# Instrumented device-side benchmark run.
+#   args: N MODEL CSV METRICS [extra bmoe-cli flags...]
+# Runs bmoe-cli (which now reports prefill/TTFT/load itself) while sampling device
+# pressure at ~1 Hz: peak process RSS, free-RAM floor, battery + SoC temperature, and the
+# battery charge counter before/after. The prompt lives here so no quoting has to survive
+# adb/PowerShell. Energy note: over USB the phone is powered/charging, so charge deltas are
+# indicative only â€” a true joules/token needs an unplugged (wireless-adb) pass.
+N="$1"; MODEL="$2"; CSV="$3"; METRICS="$4"; shift 4
+cd /data/local/tmp || exit 1
+rm -f "$CSV" "$METRICS" /data/local/tmp/cli_stdout.txt
+
+batt_temp() { dumpsys battery 2>/dev/null | sed -n 's/.*temperature: *//p'; }
+charge()    { cat /sys/class/power_supply/battery/charge_counter 2>/dev/null; }
+memavail()  { sed -n 's/^MemAvailable: *\([0-9]*\).*/\1/p' /proc/meminfo; }
+cpu_temp()  { for z in /sys/class/thermal/thermal_zone*; do
+                case "$(cat "$z/type" 2>/dev/null)" in cpu-0-0*|cpu-1-0*|cpu-*) cat "$z/temp" 2>/dev/null; return;; esac
+              done; }
+
+MEM0=$(memavail); T0=$(batt_temp); CPU0=$(cpu_temp); CH0=$(charge)
+
+LD_LIBRARY_PATH=/data/local/tmp ./bmoe-cli -m "$MODEL" --chatml -n "$N" \
+  -p "Write a long detailed essay about the history of computing including its origins its key milestones the people involved and the future directions of the field" \
+  "$@" --csv "$CSV" > /data/local/tmp/cli_stdout.txt 2>/dev/null &
+PID=$!
+
+PEAK_RSS=0; MEM_MIN=$MEM0; TEMP_MAX=$T0; CPU_MAX=$CPU0
+while kill -0 "$PID" 2>/dev/null; do
+  R=$(sed -n 's/^VmRSS: *\([0-9]*\).*/\1/p' /proc/$PID/status 2>/dev/null)
+  [ -n "$R" ] && [ "$R" -gt "$PEAK_RSS" ] && PEAK_RSS=$R
+  M=$(memavail);  [ -n "$M" ] && [ "$M" -lt "$MEM_MIN" ] && MEM_MIN=$M
+  B=$(batt_temp); [ -n "$B" ] && [ "$B" -gt "$TEMP_MAX" ] && TEMP_MAX=$B
+  C=$(cpu_temp);  [ -n "$C" ] && [ "$C" -gt "$CPU_MAX" ] && CPU_MAX=$C
+  sleep 1
+done
+wait "$PID"
+MEM1=$(memavail); T1=$(batt_temp); CH1=$(charge)
+
+{
+  echo "peak_rss_kb=$PEAK_RSS"
+  echo "mem_avail_before_kb=$MEM0"
+  echo "mem_avail_floor_kb=$MEM_MIN"
+  echo "mem_avail_after_kb=$MEM1"
+  echo "batt_temp_before_dC=$T0"
+  echo "batt_temp_max_dC=$TEMP_MAX"
+  echo "batt_temp_after_dC=$T1"
+  echo "cpu_temp_before_mC=$CPU0"
+  echo "cpu_temp_max_mC=$CPU_MAX"
+  echo "charge_before_uah=$CH0"
+  echo "charge_after_uah=$CH1"
+} > "$METRICS"
+
+grep -E "generation:|prefill:|moe-stream:|moe-cache:" /data/local/tmp/cli_stdout.txt
+cat "$METRICS"

--- a/scripts/build-android.ps1
+++ b/scripts/build-android.ps1
@@ -52,7 +52,7 @@ New-Item -ItemType Directory -Force -Path $jni | Out-Null
 $cli = Join-Path $buildPath "cli\bmoe-cli"
 Copy-Item $cli (Join-Path $jni "libbmoe-cli.so") -Force
 Get-ChildItem -Path $buildPath -Recurse -Filter "*.so" |
-    Where-Object { $_.Name -like "libggml*" -or $_.Name -eq "libllama.so" } |
+    Where-Object { $_.Name -like "libggml*" -or $_.Name -like "libllama*" } |
     ForEach-Object { Copy-Item $_.FullName (Join-Path $jni $_.Name) -Force }
 
 # bmoe-cli links the c++_shared STL, so its runtime must ride along in the APK —


### PR DESCRIPTION
## Two independent bug fixes surfaced while testing on device.

### 1. Stop crashed the app (`fix(android)`)

Pressing **Stop** reliably crashed the app with `RuntimeException: WakeLock under-locked bmoe:gen`.

`stopEverything()` (main thread) and `runCli`'s `finally` block (reader thread) both call
`releaseWake()`. The wakelock was reference-counted and the `wake` field was not `@Volatile`,
so on Stop the two paths raced: the second `release()` hit an already-released lock and threw.

Fix: `wake`/`proc` are now `@Volatile`, `releaseWake()` is `@Synchronized`, and the wakelock is
created with `setReferenceCounted(false)` so a double release is a harmless no-op. Stop only ever
sends SIGKILL to the native CLI subprocess (which cannot crash the app), so this was the sole
crash path.

### 2. Gemma always showed its thinking, ignoring the toggle (`fix`)

The chat template was always rendered with `enable_thinking = true` (the llama.cpp default that
`runtime.cpp` never overrode), so any reasoning model kept emitting its thinking channel. Qwen3
looked fine only because the app appended the `/no_think` prompt suffix and because the display
parser (`reasoning_format = AUTO`) strips Qwen's reasoning — but it cannot strip a format it does
not recognise, so **Gemma's thinking leaked into the shown answer** regardless of the toggle.

Fix: thread a `think` flag through `RunConfig`, set `inputs.enable_thinking = cfg.think` when
applying the template, and drive it from a new `--no-think` CLI flag. The Android app now passes
`--no-think` for every architecture (replacing the Qwen-only `/no_think` prompt hack), so turning
the toggle off suppresses reasoning **at generation time** for Gemma and Qwen alike. Templates
that ignore the kwarg are unaffected; the display-time parser stays as a fallback.

## Test plan

- [x] Host gates G1–G3 green on both archs (`qwen3moe`, `gemma4`)
- [x] `bmoe-cli --no-think` parses and runs clean
- [x] clang-format clean on changed sources
- [ ] On-device: Stop mid-generation no longer crashes
- [ ] On-device: Gemma with thinking off shows no reasoning

_Independent of the `--overlap` work in #4; branches off `main` and can merge in either order._
