### PR TITLE
feat(moe): surface cache-management cost as a telemetry term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- Cache-management time is now surfaced as its own telemetry term (`mgmt_ms` per token,
+  `cache mgmt` in the `moe-stream:` summary, `mgmt_ms` CSV column, `mgmt_s/tok` in the summary
+  line). It times the virtual-memory commit, eviction and LRU bookkeeping that were previously
+  hidden inside the `compute_ms` residual — high on the first tokens after prefill, near zero at
+  steady state. `compute_ms` is documented as a residual (`wall − io − mgmt`, or `wall − stall −
+  mgmt` under overlap), not a measured matmul time. Bytes served are unchanged (gates G1–G4).
 - Intra-layer I/O–compute overlap (`--overlap`): expert reads for a layer run on the I/O
   pool while the same layer's routed experts are computed, hiding flash latency behind FFN
   compute. Opt-in and byte-identical to the serial path (gates G4a/b/c). Requires one

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -208,9 +208,9 @@ int main(int argc, char ** argv) {
     }
     if (cfg.moe.enabled) {
         std::printf("moe-stream: read %.1f MiB (%.2f MiB/token), decode %.3f s/token "
-                    "(compute %.3f + flash I/O %.3f s/token, %.0f MiB/s)\n",
+                    "(compute %.3f + cache mgmt %.3f + flash I/O %.3f s/token, %.0f MiB/s)\n",
                     s.moe_read_mib, s.n_generated ? s.moe_read_mib / s.n_generated : 0.0, s.s_per_token,
-                    s.moe_compute_s_per_token, s.moe_io_s_per_token,
+                    s.moe_compute_s_per_token, s.moe_mgmt_s_per_token, s.moe_io_s_per_token,
                     s.moe_io_seconds > 0 ? s.moe_read_mib / s.moe_io_seconds : 0.0);
         if (s.cache_hit_pct >= 0.0)
             std::printf("moe-cache: %.1f%% hit, resident %.1f MiB\n", s.cache_hit_pct, s.cache_resident_mib);

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -32,6 +32,7 @@ public:
     struct Stats {
         uint64_t read_bytes = 0;           // bytes pulled from flash (aligned windows)
         double read_seconds = 0.0;         // wall time spent in the read phase
+        double mgmt_seconds = 0.0;         // cache management: vm commit + evict + LRU bookkeeping
         long long cache_hits = 0;          // expert lookups served from the cache
         long long cache_lookups = 0;       // total expert lookups (hits + misses)
         uint64_t cache_resident_bytes = 0; // currently resident cached slice bytes

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -16,7 +16,8 @@ struct TokenMetrics {
     int steps = 0;              // n_predict target
     double wall_ms = 0.0;       // total wall time for this token
     double io_ms = 0.0;         // flash read time this token (serial: subset of wall; overlap: lane-busy sum)
-    double compute_ms = 0.0;    // serial: wall - io; overlap: wall - stall
+    double mgmt_ms = 0.0;       // cache-management time (vm commit + evict + LRU bookkeeping) this token
+    double compute_ms = 0.0;    // residual: serial wall - io - mgmt; overlap wall - stall - mgmt
     double stall_ms = 0.0;      // overlap only: wall time the FFN kernel blocked on flash (0 when serial)
     uint64_t read_bytes = 0;    // expert bytes pulled from flash this token
     double cache_hit_pct = 0.0; // cumulative cache hit rate (-1 if no cache)
@@ -41,6 +42,7 @@ struct RunSummary {
     double moe_io_seconds = 0.0;
     double moe_compute_s_per_token = 0.0;
     double moe_io_s_per_token = 0.0;
+    double moe_mgmt_s_per_token = 0.0;  // cache-management time per token (commit + evict + LRU)
     double moe_stall_s_per_token = 0.0; // overlap only: per-token wall the kernel waited on flash
     double cache_hit_pct = -1.0;        // -1 when no cache
     double cache_resident_mib = 0.0;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -258,11 +258,13 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
     // per-token average would badly inflate the flash-I/O figure.
     long long prev_bytes = cfg.moe.enabled ? (long long) source.stats().read_bytes : 0;
     double prev_io_s = cfg.moe.enabled ? source.stats().read_seconds : 0.0;
+    double prev_mgmt_s = cfg.moe.enabled ? source.stats().mgmt_seconds : 0.0;
     double prev_stall_s = cfg.moe.enabled ? source.stats().stall_seconds : 0.0;
 
     // Generation-only accumulators, summed from the measured per-token values.
     uint64_t gen_read_bytes = 0;
     double gen_io_seconds = 0.0;
+    double gen_mgmt_seconds = 0.0;
     double gen_stall_seconds = 0.0;
 
     for (int t = 0; t < cfg.n_predict; ++t) {
@@ -298,22 +300,26 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
             IExpertSource::Stats st = source.stats();
             m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
             m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
+            m.mgmt_ms = (st.mgmt_seconds - prev_mgmt_s) * 1000.0;
             if (cfg.moe.overlap) {
                 // stall_seconds is summed across all compute threads that blocked on flash; divide
                 // by the thread count for a wall-clock approximation of the token's flash wait.
-                // compute is then wall minus that wait (io_ms here is lane-busy work, overlapped).
+                // compute is the residual after the flash wait and the cache-management work (io_ms
+                // here is lane-busy work, overlapped, so it is not subtracted).
                 m.stall_ms = (st.stall_seconds - prev_stall_s) * 1000.0 / cfg.n_threads;
-                m.compute_ms = m.wall_ms - m.stall_ms;
+                m.compute_ms = m.wall_ms - m.stall_ms - m.mgmt_ms;
             } else {
-                m.compute_ms = m.wall_ms - m.io_ms;
+                m.compute_ms = m.wall_ms - m.io_ms - m.mgmt_ms;
             }
             if (m.compute_ms < 0) m.compute_ms = 0;
             m.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
             prev_bytes = (long long) st.read_bytes;
             prev_io_s = st.read_seconds;
+            prev_mgmt_s = st.mgmt_seconds;
             prev_stall_s = st.stall_seconds;
             gen_read_bytes += m.read_bytes;
             gen_io_seconds += m.io_ms / 1000.0;
+            gen_mgmt_seconds += m.mgmt_ms / 1000.0;
             gen_stall_seconds += m.stall_ms / 1000.0;
         } else {
             m.compute_ms = m.wall_ms;
@@ -339,10 +345,13 @@ RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics
         s.moe_read_mib = gen_read_bytes / (1024.0 * 1024.0);
         s.moe_io_seconds = gen_io_seconds;
         s.moe_io_s_per_token = n_gen ? gen_io_seconds / n_gen : 0.0;
+        s.moe_mgmt_s_per_token = n_gen ? gen_mgmt_seconds / n_gen : 0.0;
         s.moe_stall_s_per_token = n_gen ? gen_stall_seconds / n_gen : 0.0;
-        // Overlap: compute is wall minus the flash wait (I/O runs alongside it, so subtracting
-        // io would double-count). Serial: I/O is a slice of wall, so compute is wall minus io.
-        s.moe_compute_s_per_token = s.s_per_token - (cfg.moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token);
+        // Compute is a residual: the token's wall minus the measured terms. Overlap subtracts the
+        // flash wait (I/O runs alongside compute, so subtracting io would double-count); serial
+        // subtracts io (a slice of wall). Both also subtract the cache-management time.
+        s.moe_compute_s_per_token =
+            s.s_per_token - (cfg.moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token) - s.moe_mgmt_s_per_token;
         if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;
         s.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
         s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -9,27 +9,28 @@ namespace {
 class CsvMetricsSink final : public IMetricsSink {
 public:
     explicit CsvMetricsSink(std::FILE * f) : f_(f) {
-        // stall_ms is appended LAST so existing positional parsers stay valid (0 when serial).
-        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms\n");
+        // New columns are appended LAST so existing positional parsers stay valid: stall_ms (0 when
+        // serial), then mgmt_ms (cache-management time split out of the compute residual).
+        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms\n");
     }
     ~CsvMetricsSink() override {
         if (f_) std::fclose(f_);
     }
 
     void on_token(const TokenMetrics & m) override {
-        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f\n", m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms,
-                     (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms);
+        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f\n", m.step, m.steps, m.wall_ms, m.io_ms,
+                     m.compute_ms, (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms, m.mgmt_ms);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
         std::fprintf(f_,
                      "# summary tokens=%d s/tok=%.3f tok/s=%.3f read_MiB=%.1f "
                      "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f "
-                     "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f\n",
+                     "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
-                     s.moe_stall_s_per_token);
+                     s.moe_stall_s_per_token, s.moe_mgmt_s_per_token);
         std::fflush(f_);
     }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -362,6 +362,10 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     cgen_++;
     jobs_.clear();
 
+    // Cache-management work (vm commit + LRU bookkeeping, then eviction below) is timed into
+    // mgmt_ns_ so the metrics can split it out of the compute residual instead of hiding it there.
+    const auto tm0 = clock_t_::now();
+
     auto stage = [&](int e) -> bool {
         if (cache_max_ == 0) {
             for (int p = 0; p < MoeRecipe::max_exps; ++p) {
@@ -415,6 +419,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     }
 
     const size_t njobs = jobs_.size();
+    mgmt_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - tm0).count());
     const auto t0 = clock_t_::now();
     if (io_threads_ <= 1 || njobs <= 1) {
         for (size_t i = 0; i < njobs; ++i) {
@@ -442,8 +447,11 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     read_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
 
     if (cache_max_) {
+        const auto te0 = clock_t_::now();
         while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
             evict_tail();
+        mgmt_ns_.fetch_add(
+            (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - te0).count());
     }
     return true;
 }
@@ -467,6 +475,11 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
         io_cv_done_.wait(lk, [&] { return done_cnt_ == batch_njobs_ || io_stop_; });
     }
     if (fatal_.load(std::memory_order_acquire)) return false;
+
+    // Cache-management work below (dedup/sort, vm commit, LRU bookkeeping and the eviction at
+    // the end) runs on the eval thread and would otherwise hide inside the compute residual. Time
+    // it into mgmt_ns_ so the metrics can surface it. The drain wait above is I/O, not mgmt.
+    const auto tm0 = clock_t_::now();
 
     // 2. New generation for this layer. A flag counts as ready only once its gen matches.
     const uint32_t gen = async_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
@@ -573,6 +586,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
         while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
             evict_tail();
     }
+    mgmt_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - tm0).count());
     return true;
 }
 
@@ -636,6 +650,7 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     // caller never blocks, so "I/O time" is instead the summed lane-busy time (io_syscall_ns_),
     // which the runtime reports as lane-busy per token rather than as a slice of wall time.
     s.read_seconds = (overlap_ ? io_syscall_ns_.load() : read_ns_.load()) / 1e9;
+    s.mgmt_seconds = mgmt_ns_.load() / 1e9;
     s.cache_hits = chits_;
     s.cache_lookups = clookups_;
     s.cache_resident_bytes = (uint64_t) cresident_;

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -157,6 +157,7 @@ private:
     std::atomic<long long> read_bytes_{0};
     std::atomic<long long> read_ns_{0};
     std::atomic<long long> io_syscall_ns_{0};
+    std::atomic<long long> mgmt_ns_{0}; // staging-section time: vm commit + evict + LRU bookkeeping
 
     // ── overlap mode: one layer in flight at a time (guaranteed by graph order) ──
     // A ReadyFlag is ready iff its gen == async_gen_; the load thread bumps async_gen_ per

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -16,11 +16,19 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
 - `BMOE_LOAD` appears only when experts were read this token; `mb` is the flash bytes read,
   `ms` the read time.
 - `BMOE_PROGRESS.step`/`steps` are 1-based index and target token counts.
-- `wall_ms` = total token time; `io_ms` = flash read time; `compute_ms` = `wall_ms − io_ms`.
+- `wall_ms` = total token time; `io_ms` = flash read time. `compute_ms` is a **residual, not a
+  measured quantity**: there is no clock around llama.cpp's matmul kernels (adding one would mean
+  patching the submodule), so compute is whatever wall time is left after the measured terms are
+  subtracted — `wall_ms − io_ms − mgmt_ms` in serial, `wall_ms − stall_ms − mgmt_ms` under overlap.
   In serial mode `io_ms` is the wall time blocked on reads (a subset of `wall_ms`). Under
   `--overlap` its meaning changes: it is the **sum of per-lane busy time**, so it can exceed
   `wall_ms` because lanes read in parallel with compute. Use `stall_ms` for the wall time
   compute actually lost to reads under overlap.
+- `mgmt_ms` (not emitted in the JSON, but folded into the `compute_ms` residual above and written
+  to the CSV) is the cache-management time this token: virtual-memory commit of newly cached
+  pages, eviction of cold pages, and the LRU bookkeeping. On the first few tokens after prefill it
+  can be a large share of the token; at steady state it is near zero. Surfacing it stops the "all
+  compute" reading on warm-up tokens where the real cost is cache churn, not matmul.
 - `cache_hit_pct` is the cumulative cache hit rate, or `-1` when no cache is used.
 - `text` is the full generated text so far, JSON-escaped (for streaming into a UI).
 
@@ -31,9 +39,12 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
 <full generated text>
 === perf ===
 generation: <n> tokens, <s> s/token (<t> tok/s)
-moe-stream: read <mib> MiB (<mib/tok> MiB/token), decode <s> s/token (compute <c> + flash I/O <i> s/token, <bw> MiB/s)
+moe-stream: read <mib> MiB (<mib/tok> MiB/token), decode <s> s/token (compute <c> + cache mgmt <m> + flash I/O <i> s/token, <bw> MiB/s)
 moe-cache: <pct>% hit, resident <mib> MiB
 ```
+
+`compute` in the `moe-stream:` line is the same residual described for `compute_ms` above; `cache
+mgmt` is the per-token mean of `mgmt_ms`.
 
 Under `--overlap` the `moe-stream:` line additionally reports `stall_s/tok=<s>` — the mean
 wall time per token that compute threads waited for expert reads to complete. It is `0` in
@@ -48,13 +59,14 @@ prints just the summary lines.
 `--csv PATH` additionally writes one row per token:
 
 ```
-step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms
+step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
 
-`stall_ms` is a trailing column added for `--overlap`: the wall time compute threads waited
-for expert reads that token. It is `0` in serial mode, and older CSVs written before it was
-added have only the first seven columns — consumers must treat it as optional. The
-`# summary` line likewise gains `stall_s/tok=<s>` under overlap (see the `io_ms` note above
-for how the read-time columns are reinterpreted when lanes run in parallel with compute).
+`stall_ms` and `mgmt_ms` are trailing columns appended (in that order) after the original seven.
+`stall_ms` is the wall time compute threads waited for expert reads that token (`0` in serial
+mode); `mgmt_ms` is the cache-management time described above. Both are additive: older CSVs have
+fewer columns, so consumers must read by column NAME (from the header row) and treat either as
+optional. The `# summary` line likewise gains `stall_s/tok=<s>` and `mgmt_s/tok=<s>` (see the
+`io_ms` note above for how the read-time columns are reinterpreted under overlap).

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -44,11 +44,17 @@ def num(d, k):
         return None
 
 def analyze(csv_path):
-    walls, stalls, summ = [], [], {}
+    walls, stalls, mgmts, summ = [], [], [], {}
+    # Column layout is read from the header so trailing additive columns (stall_ms, then mgmt_ms)
+    # are picked up by NAME; older CSVs that lack them are handled transparently.
+    col = {}
     with open(csv_path) as f:
         for row in f:
             row = row.strip()
-            if not row or row.startswith("step,"):
+            if row.startswith("step,"):
+                col = {name: i for i, name in enumerate(row.split(","))}
+                continue
+            if not row:
                 continue
             if row.startswith("# summary"):
                 for tok in row.replace("# summary", "").split():
@@ -60,12 +66,16 @@ def analyze(csv_path):
                 walls.append(float(cols[2]))
             except (IndexError, ValueError):
                 continue
-            # stall_ms is an optional trailing column (index 7); absent in pre-overlap CSVs.
-            if len(cols) > 7:
-                try:
-                    stalls.append(float(cols[7]))
-                except ValueError:
-                    pass
+            def by_name(name, dst):
+                i = col.get(name)
+                if i is not None and i < len(cols):
+                    try:
+                        dst.append(float(cols[i]))
+                    except ValueError:
+                        pass
+            # stall_ms and mgmt_ms are optional trailing columns; absent in older CSVs.
+            by_name("stall_ms", stalls)
+            by_name("mgmt_ms", mgmts)
     if not walls:
         return None
     n = len(walls); tps = sorted(1000.0 / w for w in walls if w > 0)
@@ -80,6 +90,7 @@ def analyze(csv_path):
         "cache_hit": summ.get("cache_hit_pct", "-"),
         "read_MiB_tok": (g("read_MiB") / n) if n else 0.0,
         "stall_ms_tok": (statistics.mean(stalls) if stalls else None),
+        "mgmt_ms_tok": (statistics.mean(mgmts) if mgmts else None),
         "prefill_tps": g("prefill_tps"), "load_s": g("load_s"),
         "prefill_s": g("prefill_s"), "ttft": g("load_s") + g("prefill_s"),
         "peak_rss_gb": (num(m, "peak_rss_kb") or 0) / 1048576.0,


### PR DESCRIPTION
## What

Adds a **management-cost** telemetry term that attributes the time the engine spends managing the expert cache (evictions/insertions) as its own metric, instead of folding it into compute or I/O.

## Why

Under streaming, part of each token's wall time is spent evicting/inserting experts in the cache, not computing or reading flash. Surfacing it as `mgmt_ms` makes the per-token breakdown honest and lets later cache work (adaptive budget) be measured against a real cost term.

## Changes

- New `mgmt_ms` term threaded through the metrics struct, the CSV sink, and `scripts/bench-analyze.py`.
- `docs/telemetry.md` documents the term.

Base of the streaming stack: **session-mode → temporal-prefetch → spec-gating → adaptive-cache** build on top of this.
