### PR TITLE
feat(moe): temporal prefetch on idle I/O lanes (experimental, default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- **Session mode**: the engine can now load a model once and serve many prompts against it, with
+  the expert LRU cache staying warm between prompts, instead of re-paying the model load and the
+  cold-cache ramp on every generation. `run()` splits into a `Session` (`open` / `generate` /
+  `close`); `generate()` can be called repeatedly and cancelled mid-flight via the abort callback.
+  `bmoe-cli --session` drives it over a stdin/stdout JSON line protocol, and the Android example
+  runs one persistent session per model (reusing the warm process across prompts, freeing it on an
+  idle timeout). Independent prompts by default (KV cleared, cache warm); multi-turn chat is a
+  `clear_kv=false` follow-up. Byte-identity gates S1/S2 prove a warm generate matches the cold
+  one-shot reference. See `docs/session.md`.
 - Cache-management time is now surfaced as its own telemetry term (`mgmt_ms` per token,
   `cache mgmt` in the `moe-stream:` summary, `mgmt_ms` CSV column, `mgmt_s/tok` in the summary
   line). It times the virtual-memory commit, eviction and LRU bookkeeping that were previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- **Temporal prefetch** (`--prefetch K`, env `BMOE_PREFETCH`): while a token computes layer *l*,
+  the experts the previous token routed at layers *l+1…l+K* are read speculatively on the idle I/O
+  lanes, so a correct guess turns the next layer's read into a cache hit. Requires the LRU cache.
+  The speculative path never delays real work (workers drain it only as spare capacity and yield
+  to real batches; all cache-state mutation stays on the eval thread) and never changes output (a
+  speculative read is the identical read a real miss would issue). Gates G5a/b/c prove
+  byte-identity, including the integrate-then-hit path. A `moe-prefetch:` summary line reports the
+  speculative bytes and useful-hit rate; an Android settings row exposes the depth. See
+  `docs/prefetch.md`.
 - **Session mode**: the engine can now load a model once and serve many prompts against it, with
   the expert LRU cache staying warm between prompts, instead of re-paying the model load and the
   cold-cache ramp on every generation. `run()` splits into a `Session` (`open` / `generate` /

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -9,14 +9,21 @@
 // engine stays env-free. The flag always wins over the env value.
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
+#include "bmoe/session.h"
 #include "bmoe/recipe.h"
 #include "bmoe/metrics.h"
 
+#include <atomic>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
+#include <iostream>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 using namespace bmoe;
 
@@ -57,6 +64,224 @@ static std::string json_escape(const std::string & s) {
     return o;
 }
 
+// ── minimal flat-JSON reading for the --session request protocol ──
+// The session request objects are flat (string/int/bool fields only), so a tiny hand-rolled
+// extractor keeps the CLI dependency-free, mirroring the hand-written JSON it already emits.
+
+static std::string json_unescape(const std::string & s) {
+    std::string o;
+    o.reserve(s.size());
+    for (size_t i = 0; i < s.size(); ++i) {
+        if (s[i] != '\\' || i + 1 >= s.size()) {
+            o += s[i];
+            continue;
+        }
+        char c = s[++i];
+        switch (c) {
+        case 'n': o += '\n'; break;
+        case 'r': o += '\r'; break;
+        case 't': o += '\t'; break;
+        case '"': o += '"'; break;
+        case '\\': o += '\\'; break;
+        case '/': o += '/'; break;
+        case 'u':
+            if (i + 4 < s.size()) {
+                int code = (int) std::strtol(s.substr(i + 1, 4).c_str(), nullptr, 16);
+                // The protocol only carries ASCII control chars as \u00xx (from json_escape);
+                // decode those directly. Anything else is passed through as the literal char.
+                o += (char) (code & 0xff);
+                i += 4;
+            }
+            break;
+        default: o += c; break;
+        }
+    }
+    return o;
+}
+
+// Find `"key"`, skip to its value. Returns the index just past the colon, or npos.
+static size_t json_value_pos(const std::string & line, const char * key) {
+    std::string pat = std::string("\"") + key + "\"";
+    size_t k = line.find(pat);
+    if (k == std::string::npos) return std::string::npos;
+    size_t c = line.find(':', k + pat.size());
+    if (c == std::string::npos) return std::string::npos;
+    return c + 1;
+}
+
+static bool json_get_string(const std::string & line, const char * key, std::string & out) {
+    size_t p = json_value_pos(line, key);
+    if (p == std::string::npos) return false;
+    while (p < line.size() && (line[p] == ' ' || line[p] == '\t')) ++p;
+    if (p >= line.size() || line[p] != '"') return false;
+    ++p;
+    std::string raw;
+    for (; p < line.size(); ++p) {
+        if (line[p] == '\\' && p + 1 < line.size()) {
+            raw += line[p];
+            raw += line[p + 1];
+            ++p;
+        } else if (line[p] == '"') {
+            break;
+        } else {
+            raw += line[p];
+        }
+    }
+    out = json_unescape(raw);
+    return true;
+}
+
+static int json_get_int(const std::string & line, const char * key, int dflt) {
+    size_t p = json_value_pos(line, key);
+    if (p == std::string::npos) return dflt;
+    return std::atoi(line.c_str() + p);
+}
+
+static bool json_get_bool(const std::string & line, const char * key, bool dflt) {
+    size_t p = json_value_pos(line, key);
+    if (p == std::string::npos) return dflt;
+    while (p < line.size() && (line[p] == ' ' || line[p] == '\t')) ++p;
+    return line.compare(p, 4, "true") == 0;
+}
+
+// A parsed stdin command. cancel is handled inline by the reader thread (it calls
+// Session::cancel directly), so only generate/close travel through the queue.
+struct SessionCmd {
+    enum Kind { kGenerate, kClose } kind;
+    std::string prompt;
+    int id = 0;
+    int n_predict = 32;
+    bool think = true;
+    bool clear_kv = true;
+};
+
+// Interactive session: keep the model loaded and the expert cache warm across prompts, reading
+// one JSON request per line from stdin and emitting the BMOE_* line protocol on stdout. See
+// docs/telemetry.md. Returns the process exit code.
+static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink) {
+    SessionConfig sc;
+    sc.model_path = cfg.model_path;
+    sc.n_threads = cfg.n_threads;
+    sc.n_ctx = cfg.n_ctx;
+    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
+    sc.chatml = cfg.chatml;
+    sc.moe = cfg.moe;
+
+    std::string error;
+    std::unique_ptr<Session> session = Session::open(sc, error);
+    if (!session) {
+        std::printf("BMOE_ERROR {\"id\":0,\"fatal\":true,\"msg\":\"%s\"}\n", json_escape(error).c_str());
+        std::fflush(stdout);
+        return 1;
+    }
+    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d}\n", session->load_seconds(),
+                json_escape(session->arch()).c_str(), session->n_ctx());
+    std::fflush(stdout);
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::deque<SessionCmd> queue;
+    std::atomic<bool> stop{false};
+
+    // Reader thread: parse stdin lines. "cancel" is applied immediately (thread-safe) so it can
+    // interrupt an in-flight generate; "generate"/"close" are queued for the main loop. EOF ends
+    // the session like an explicit close.
+    std::thread reader([&] {
+        std::string line;
+        while (std::getline(std::cin, line)) {
+            std::string cmd;
+            if (!json_get_string(line, "cmd", cmd)) continue;
+            if (cmd == "cancel") {
+                session->cancel();
+                continue;
+            }
+            SessionCmd c;
+            if (cmd == "close") {
+                c.kind = SessionCmd::kClose;
+            } else if (cmd == "generate") {
+                c.kind = SessionCmd::kGenerate;
+                json_get_string(line, "prompt", c.prompt);
+                c.id = json_get_int(line, "id", 0);
+                c.n_predict = json_get_int(line, "n_predict", cfg.n_predict);
+                c.think = json_get_bool(line, "think", cfg.think);
+                c.clear_kv = json_get_bool(line, "clear_kv", true);
+            } else {
+                continue;
+            }
+            {
+                std::lock_guard<std::mutex> lk(mtx);
+                queue.push_back(std::move(c));
+            }
+            cv.notify_one();
+        }
+        {
+            std::lock_guard<std::mutex> lk(mtx);
+            stop.store(true);
+            queue.push_back({SessionCmd::kClose, "", 0, 0, true, true});
+        }
+        cv.notify_one();
+    });
+
+    int rc = 0;
+    for (;;) {
+        SessionCmd cmd;
+        {
+            std::unique_lock<std::mutex> lk(mtx);
+            cv.wait(lk, [&] { return !queue.empty(); });
+            cmd = std::move(queue.front());
+            queue.pop_front();
+        }
+        if (cmd.kind == SessionCmd::kClose) break;
+
+        std::printf("BMOE_BEGIN {\"id\":%d}\n", cmd.id);
+        std::fflush(stdout);
+
+        auto on_token = [&](const TokenMetrics & m) {
+            if (m.read_bytes || m.io_ms > 0.0)
+                std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
+            std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
+                        "\"compute_ms\":%.1f,\"cache_hit_pct\":%.1f,\"text\":\"%s\"}\n",
+                        m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.cache_hit_pct,
+                        json_escape(m.text).c_str());
+            std::fflush(stdout);
+        };
+
+        GenerateRequest req;
+        req.prompt = cmd.prompt;
+        req.n_predict = cmd.n_predict;
+        req.think = cmd.think;
+        req.clear_kv = cmd.clear_kv;
+
+        RunResult r = session->generate(req, on_token, sink);
+        if (!r) {
+            // A bad request (empty prompt, context overflow) leaves the session usable; a decode
+            // failure means the context is compromised, so end the loop.
+            bool recoverable =
+                r.error.find("exceeds the session n_ctx") != std::string::npos ||
+                r.error.find("empty prompt") != std::string::npos;
+            std::printf("BMOE_ERROR {\"id\":%d,\"fatal\":%s,\"msg\":\"%s\"}\n", cmd.id, recoverable ? "false" : "true",
+                        json_escape(r.error).c_str());
+            std::fflush(stdout);
+            if (!recoverable) {
+                rc = 1;
+                break;
+            }
+            continue;
+        }
+        const RunSummary & s = r.summary;
+        std::printf("BMOE_DONE {\"id\":%d,\"cancelled\":%s,\"tokens\":%d,\"tok_s\":%.3f,\"prefill_s\":%.3f,"
+                    "\"load_s\":%.3f,\"cache_hit_pct\":%.1f,\"text\":\"%s\"}\n",
+                    cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
+                    s.load_seconds, s.cache_hit_pct, json_escape(r.generated_text).c_str());
+        std::fflush(stdout);
+    }
+
+    // Unblock the reader if it is still waiting on stdin (it exits on EOF; on an explicit close
+    // it has usually already returned). Detach so process exit is not held up by a blocking read.
+    if (reader.joinable()) reader.detach();
+    return rc;
+}
+
 static void print_usage(const char * argv0) {
     std::printf("usage: %s -m <model.gguf> [options]\n"
                 "\n"
@@ -68,6 +293,7 @@ static void print_usage(const char * argv0) {
                 "      --chatml            wrap the prompt in the model family's chat turn (gemma/chatml)\n"
                 "      --no-think          render the chat template with reasoning disabled\n"
                 "      --progress          emit machine telemetry (one JSON line per token)\n"
+                "      --session           keep the model loaded and serve JSON prompt requests from stdin\n"
                 "      --csv PATH          also write per-token metrics as CSV\n"
                 "\n"
                 "  MoE expert streaming:\n"
@@ -87,6 +313,7 @@ static void print_usage(const char * argv0) {
 int main(int argc, char ** argv) {
     RunConfig cfg;
     std::string csv_path;
+    bool session_mode = false;
 
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
@@ -113,6 +340,8 @@ int main(int argc, char ** argv) {
             cfg.think = false;
         else if (a == "--progress")
             cfg.progress = true;
+        else if (a == "--session")
+            session_mode = true;
         else if (a == "--csv")
             csv_path = next("--csv");
         else if (a == "--moe-stream")
@@ -166,6 +395,11 @@ int main(int argc, char ** argv) {
         sink.reset(make_csv_metrics_sink(csv_path));
         if (!sink) std::fprintf(stderr, "warning: could not open csv %s\n", csv_path.c_str());
     }
+
+    // Interactive session: one persistent process serves many prompts over stdin, keeping the
+    // model loaded and the expert cache warm between them. Prompts arrive as JSON requests, not
+    // via -p. This is a superset of --progress output (BMOE_* lines), so it never streams inline.
+    if (session_mode) return run_session_loop(cfg, sink.get());
 
     if (!cfg.progress) {
         std::printf("%s", cfg.prompt.c_str());

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -304,9 +304,10 @@ static void print_usage(const char * argv0) {
                 "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
                 "      --force-cache       allow a cache-mb in the pathological band\n"
                 "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
+                "      --prefetch K        temporally prefetch the next K layers' experts (needs the cache)\n"
                 "      --list-archs        print supported MoE architectures and exit\n"
                 "\n"
-                "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP\n",
+                "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH\n",
                 argv0, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
 }
 
@@ -358,6 +359,10 @@ int main(int argc, char ** argv) {
             cfg.moe.force_cache = true;
         else if (a == "--overlap")
             cfg.moe.overlap = true;
+        else if (a == "--prefetch")
+            cfg.moe.prefetch_layers = std::atoi(next("--prefetch"));
+        else if (a == "--prefetch-sync") // debug: complete speculative reads synchronously
+            cfg.moe.prefetch_sync = true;
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)
@@ -378,6 +383,7 @@ int main(int argc, char ** argv) {
     if (cfg.moe.io_threads == 4) cfg.moe.io_threads = env_int("BMOE_IO_THREADS", 4);
     if (!cfg.progress) cfg.progress = env_int("BMOE_PROGRESS", 0) != 0;
     if (!cfg.moe.overlap) cfg.moe.overlap = env_int("BMOE_OVERLAP", 0) != 0;
+    if (cfg.moe.prefetch_layers == 0) cfg.moe.prefetch_layers = env_int("BMOE_PREFETCH", 0);
 
     if (cfg.model_path.empty()) {
         print_usage(argv[0]);
@@ -451,6 +457,10 @@ int main(int argc, char ** argv) {
         if (cfg.moe.overlap)
             std::printf("moe-overlap: stall %.3f s/token (flash reads overlapped with FFN compute)\n",
                         s.moe_stall_s_per_token);
+        if (cfg.moe.prefetch_layers > 0)
+            std::printf("moe-prefetch: %.1f MiB speculative, %lld/%lld experts useful (%.0f%%)\n",
+                        s.moe_spec_read_mib, s.moe_spec_useful, s.moe_spec_experts,
+                        s.moe_spec_experts > 0 ? 100.0 * s.moe_spec_useful / s.moe_spec_experts : 0.0);
     }
     return 0;
 }

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -21,6 +21,7 @@ if(BMOE_HAVE_LLAMA)
         src/moe/gguf_offsets.cpp
         src/moe/expert_stream_source.cpp
         src/moe/router_hook.cpp
+        src/engine/session.cpp
         src/engine/runtime.cpp
         src/metrics/csv_metrics_sink.cpp
     )

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -37,8 +37,24 @@ struct MoeStreamConfig {
     // Requires the Helldez/llama.cpp fork submodule (the hook); run() fails fast otherwise.
     bool overlap = false;
 
+    // Temporal prefetch: while a token computes layer l, speculatively read on the idle I/O
+    // lanes the experts the PREVIOUS token routed at layers l+1..l+prefetch_layers, betting on
+    // the strong temporal locality of routing. A correct guess turns the next layer's read into
+    // a cache hit; a wrong guess only wastes a read. 0 disables it. Needs the LRU cache on
+    // (speculative slices land in the per-layer cache buffers), so validate() rejects it with
+    // cache_mb == 0. See docs/prefetch.md.
+    int prefetch_layers = 0;
+
+    // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
+    // thread, before returning. This defeats the latency-hiding purpose (the reads no longer
+    // overlap compute) but makes speculative integration deterministic, so the byte-identity
+    // gates can exercise the integrate-then-hit path that a timing race otherwise seldom reaches
+    // on a fast host. Serial mode only. Never set in production.
+    bool prefetch_sync = false;
+
     static constexpr int cache_min_mb = 1500; // smallest non-pathological cache (see above)
     static constexpr int io_threads_max = 8;
+    static constexpr int prefetch_layers_max = 8;
 };
 
 // A full run: model, prompt, decoding, streaming, telemetry.

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -28,6 +28,12 @@ public:
     // Returns false on I/O failure (serial) or if a prior async batch already failed.
     virtual bool load_layer(int il, const int32_t * ids, int n_ids) = 0;
 
+    // Hint that layer `il` is likely to route `ids` (n_ids of them) on a future token, so the
+    // implementation may read them ahead on otherwise-idle lanes. Purely advisory: a correct
+    // guess makes the later load_layer(il, …) a cache hit, a wrong guess wastes a read — neither
+    // changes what load_layer produces. Default: no-op (a source without a speculative path).
+    virtual void prefetch(int /*il*/, const int32_t * /*ids*/, int /*n_ids*/) {}
+
     // Cumulative streaming statistics, for telemetry and the end-of-run summary.
     struct Stats {
         uint64_t read_bytes = 0;           // bytes pulled from flash (aligned windows)
@@ -37,6 +43,9 @@ public:
         long long cache_lookups = 0;       // total expert lookups (hits + misses)
         uint64_t cache_resident_bytes = 0; // currently resident cached slice bytes
         double stall_seconds = 0.0;        // overlap: summed across compute threads (0 when serial)
+        uint64_t spec_read_bytes = 0;      // bytes read speculatively by prefetch (subset of read_bytes)
+        long long spec_experts = 0;        // experts fully prefetched
+        long long spec_useful = 0;         // prefetched experts that a later lookup actually hit
     };
     virtual Stats stats() const = 0;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -46,6 +46,12 @@ struct RunSummary {
     double moe_stall_s_per_token = 0.0; // overlap only: per-token wall the kernel waited on flash
     double cache_hit_pct = -1.0;        // -1 when no cache
     double cache_resident_mib = 0.0;
+
+    // Temporal prefetch (zero when --prefetch is off): speculative bytes read during generation,
+    // experts successfully prefetched, and how many of those a later routing actually used.
+    double moe_spec_read_mib = 0.0;
+    long long moe_spec_experts = 0;
+    long long moe_spec_useful = 0;
 };
 
 // Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_token for each

--- a/core/include/bmoe/runtime.h
+++ b/core/include/bmoe/runtime.h
@@ -18,6 +18,7 @@ namespace bmoe {
 
 struct RunResult {
     bool ok = false;
+    bool cancelled = false; // generation was interrupted by Session::cancel() (ok stays true)
     std::string error;
     std::string generated_text;
     RunSummary summary;

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -1,0 +1,79 @@
+// A persistent engine session: load the model and warm the expert cache ONCE, then serve
+// many prompts against that resident state.
+//
+// run() (runtime.h) is the one-shot convenience — it opens a Session, generates once, and
+// closes. Session exists for the interactive case: a fresh process per prompt re-pays the
+// model load (tens of seconds) and the whole expert-cache warm-up ramp every time, which is
+// exactly what streaming was meant to avoid. Keeping the process alive amortises both:
+//
+//   auto s = Session::open(cfg, err);          // model load + capture + source.init, once
+//   s->generate({.prompt = "..."});            // prefill + decode; cache survives
+//   s->generate({.prompt = "..."});            // starts warm — no reload, no cold ramp
+//
+// This header is pure policy (no llama.cpp types) — the native state lives behind a pimpl,
+// so the CLI and tests link it without pulling in the backend headers.
+#pragma once
+
+#include "bmoe/config.h"
+#include "bmoe/metrics.h"
+#include "bmoe/runtime.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace bmoe {
+
+// Everything fixed for the model's lifetime — set once at open(). n_ctx and n_batch are
+// baked into the llama context at creation and cannot change per prompt, so size them for
+// the longest prompt+generation the session will serve.
+struct SessionConfig {
+    std::string model_path;
+    int n_threads = 4;
+    int n_ctx = 2048;
+    int n_batch = 512; // prefill chunk capacity; longer prompts are prefilled in n_batch slices
+    bool chatml = false;
+    MoeStreamConfig moe;
+};
+
+// Per-prompt request. clear_kv=true (the default) makes each prompt independent while the
+// expert cache stays warm; clear_kv=false continues the KV cache for multi-turn chat.
+struct GenerateRequest {
+    std::string prompt;
+    int n_predict = 32;
+    bool think = true;
+    bool clear_kv = true;
+};
+
+class Session {
+public:
+    ~Session();
+
+    // Load the model, discover the MoE expert tensors, and initialise the expert source.
+    // Returns nullptr and sets `error` on failure. The returned session owns all native
+    // state and must outlive every generate() call.
+    static std::unique_ptr<Session> open(const SessionConfig & cfg, std::string & error);
+
+    // Generate one response. Serialized: one generation at a time per session. `on_token`
+    // and `sink` receive the same per-token metrics as run(). Cache state carries over from
+    // the previous call. If cancel() fired, returns ok=true with cancelled=true.
+    RunResult generate(const GenerateRequest & req,
+                       const std::function<void(const TokenMetrics &)> & on_token = nullptr,
+                       IMetricsSink * sink = nullptr);
+
+    // Request the in-flight generation to stop. Thread-safe; may be called from another
+    // thread while generate() runs. Takes effect at the next decode boundary via the abort
+    // callback and leaves the model/cache intact for the next generate().
+    void cancel();
+
+    double load_seconds() const;    // model load + streaming setup, measured once at open()
+    const std::string & arch() const; // model architecture ("qwen3moe", "gemma4", …)
+    int n_ctx() const;
+
+private:
+    Session();
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace bmoe

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -46,6 +46,14 @@ ValidationResult validate(const RunConfig & cfg) {
                         "slower than no cache. Use 0 to disable the cache, a value >= " +
                         std::to_string(MoeStreamConfig::cache_min_mb) + ", or set force_cache to override.");
         }
+        if (m.prefetch_layers < 0 || m.prefetch_layers > MoeStreamConfig::prefetch_layers_max) {
+            return fail("moe.prefetch_layers must be in [0, " +
+                        std::to_string(MoeStreamConfig::prefetch_layers_max) + "]");
+        }
+        if (m.prefetch_layers > 0 && m.cache_mb == 0) {
+            return fail("moe.prefetch_layers requires the LRU cache (cache_mb > 0): speculative reads "
+                        "land in the per-layer cache buffers, which do not exist with the cache off.");
+        }
     }
 
     return r;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -1,368 +1,46 @@
 #include "bmoe/runtime.h"
-#include "bmoe/recipe.h"
-#include "../moe/router_hook.h"
-#include "../moe/expert_stream_source.h"
-#include "../moe/gguf_offsets.h"
+#include "bmoe/session.h"
 
-#include "llama.h"
-#include "ggml.h"
-
-// llama.cpp's `common` layer (NOT the stable public API): chat-template rendering and
-// reasoning parsing. See the note in the root CMakeLists / docs/seam.md.
-#include "chat.h"
-#include "common.h"
-
-#include <chrono>
-#include <cstdio>
-#include <cstring>
-#include <exception>
-#include <memory>
-#include <utility>
-#include <vector>
+#include <string>
 
 namespace bmoe {
 
-namespace {
-
-using clock_t_ = std::chrono::steady_clock;
-double secs(clock_t_::time_point a, clock_t_::time_point b) {
-    return std::chrono::duration<double>(b - a).count();
-}
-
-llama_token argmax(const float * logits, int n_vocab) {
-    llama_token best = 0;
-    float best_v = logits[0];
-    for (int v = 1; v < n_vocab; ++v)
-        if (logits[v] > best_v) {
-            best_v = logits[v];
-            best = v;
-        }
-    return best;
-}
-
-RunResult fail(std::string msg) {
-    RunResult r;
-    r.ok = false;
-    r.error = std::move(msg);
-    return r;
-}
-
-} // namespace
-
+// run() is the one-shot convenience: open a Session, generate once, close. The engine's real
+// state (model, context, warm expert cache) lives in Session (session.cpp); keeping run() as a
+// thin wrapper means the byte-identity gates exercise the exact same open/generate machinery an
+// interactive session uses. n_batch = n_ctx so the whole prompt still prefills in one batch, and
+// n_ctx is passed through untouched so the gates run at exactly the context they specify.
 RunResult run(const RunConfig & cfg, const std::function<void(const TokenMetrics &)> & on_token, IMetricsSink * sink) {
     ValidationResult v = validate(cfg);
-    if (!v) return fail(v.error);
-
-    llama_backend_init();
-    struct BackendGuard {
-        ~BackendGuard() { llama_backend_free(); }
-    } backend_guard;
-
-    // Startup timing for the TTFT / prefill metrics (additive telemetry only). load spans
-    // model load + streaming capture/init; prefill is timed separately just below.
-    auto t_load0 = clock_t_::now();
-    double load_seconds = 0.0, prefill_seconds = 0.0;
-
-    // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
-    // q4_K buffer would break the rebind), experts on CPU.
-    llama_model_params mparams = llama_model_default_params();
-    mparams.use_mmap = true;
-    mparams.use_extra_bufts = false;
-    mparams.n_gpu_layers = 0;
-
-    llama_model * model = llama_model_load_from_file(cfg.model_path.c_str(), mparams);
-    if (!model) return fail("failed to load model: " + cfg.model_path);
-    std::unique_ptr<llama_model, void (*)(llama_model *)> model_guard(model, llama_model_free);
-
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    const int n_vocab = llama_vocab_n_tokens(vocab);
-    const int n_layer = llama_model_n_layer(model);
-
-    char arch[128] = {0};
-    llama_model_meta_val_str(model, "general.architecture", arch, sizeof(arch));
-
-    const MoeRecipe * recipe = nullptr;
-    if (cfg.moe.enabled) {
-        recipe = find_moe_recipe(arch);
-        if (!recipe)
-            return fail(std::string("no MoE recipe for architecture '") + arch +
-                        "' — add one in core/src/moe/arch_registry.cpp (see docs/adding-a-model.md)");
+    if (!v) {
+        RunResult r;
+        r.error = v.error;
+        return r;
     }
 
-    // Format the prompt. With cfg.chatml, render the model's OWN chat template via llama.cpp's
-    // `common` layer — real Jinja, so it works for Gemma's channel format, Qwen ChatML, etc. —
-    // and set up reasoning parsing so a thinking model's internal reasoning is stripped from the
-    // shown answer. Without cfg.chatml the raw prompt is sent verbatim (the deterministic gates
-    // use this path). If no template is available, fall back to raw.
-    std::string prompt = cfg.prompt;
-    bool chat_on = cfg.chatml;
-    common_chat_templates_ptr chat_tmpls;
-    common_chat_parser_params parse_params;
-    if (chat_on) {
-        try {
-            chat_tmpls = common_chat_templates_init(model, "");
-            common_chat_templates_inputs inputs;
-            common_chat_msg user_msg;
-            user_msg.role = "user";
-            user_msg.content = cfg.prompt;
-            inputs.messages = {user_msg};
-            inputs.add_generation_prompt = true;
-            inputs.use_jinja = true;
-            // Suppress the model's thinking channel at the template level when reasoning is off,
-            // so a model whose reasoning format the display parser cannot strip (e.g. Gemma)
-            // simply never generates it. A template that ignores the kwarg is unaffected.
-            inputs.enable_thinking = cfg.think;
-            common_chat_params cp = common_chat_templates_apply(chat_tmpls.get(), inputs);
-            prompt = cp.prompt;
-            parse_params = common_chat_parser_params(cp);
-            // AUTO extracts reasoning into msg.reasoning_content (format-driven from the template),
-            // leaving msg.content as just the final answer.
-            //
-            // NOTE: we deliberately do NOT load the generated PEG parser (cp.parser) here. Running
-            // it over the streamed partial text mangles the content on real templates. Reasoning is
-            // suppressed at the source instead via inputs.enable_thinking above; any residual empty
-            // markers are cosmetic. A safe display-time strip is tracked separately.
-            parse_params.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
-        } catch (const std::exception & e) {
-            std::fprintf(stderr, "bmoe: chat template unavailable (%s); using raw prompt\n", e.what());
-            chat_on = false;
-        }
-    }
-    std::vector<llama_token> tokens(prompt.size() + 8);
-    int n_prompt = llama_tokenize(vocab, prompt.c_str(), (int) prompt.size(), tokens.data(), (int) tokens.size(),
-                                  /*add_special*/ true, /*parse_special*/ true);
-    if (n_prompt < 0) {
-        tokens.resize(-n_prompt);
-        n_prompt =
-            llama_tokenize(vocab, prompt.c_str(), (int) prompt.size(), tokens.data(), (int) tokens.size(), true, true);
-    }
-    if (n_prompt < 1) return fail("empty prompt after tokenization");
-    tokens.resize(n_prompt);
+    SessionConfig sc;
+    sc.model_path = cfg.model_path;
+    sc.n_threads = cfg.n_threads;
+    sc.n_ctx = cfg.n_ctx;
+    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
+    sc.chatml = cfg.chatml;
+    sc.moe = cfg.moe;
 
-    int n_ctx = cfg.n_ctx;
-    if (n_ctx < n_prompt + cfg.n_predict + 8) n_ctx = n_prompt + cfg.n_predict + 8;
-
-    RouterHook hook(recipe ? *recipe : MoeRecipe{}, n_layer);
-
-    llama_context_params cparams = llama_context_default_params();
-    cparams.n_ctx = n_ctx;
-    cparams.n_batch = n_prompt;
-    cparams.n_ubatch = n_prompt;
-    if (cfg.moe.enabled) {
-        cparams.cb_eval = &RouterHook::c_eval;
-        cparams.cb_eval_user_data = &hook;
+    std::string error;
+    std::unique_ptr<Session> session = Session::open(sc, error);
+    if (!session) {
+        RunResult r;
+        r.error = error;
+        return r;
     }
 
-    llama_context * ctx = llama_init_from_model(model, cparams);
-    if (!ctx) return fail("failed to create context");
-    std::unique_ptr<llama_context, void (*)(llama_context *)> ctx_guard(ctx, llama_free);
-    llama_set_n_threads(ctx, cfg.n_threads, cfg.n_threads);
+    GenerateRequest req;
+    req.prompt = cfg.prompt;
+    req.n_predict = cfg.n_predict;
+    req.think = cfg.think;
+    req.clear_kv = true;
 
-    ExpertStreamSource source;
-
-    if (cfg.moe.enabled) {
-        // Capture warm-up: one mmap-resident decode so the eval-callback can harvest the
-        // expert tensor pointers from the graph. KV is wiped afterwards.
-        hook.begin_capture();
-        llama_token first = tokens[0];
-        llama_batch warm = llama_batch_get_one(&first, 1);
-        if (llama_decode(ctx, warm) != 0) return fail("capture warm-up decode failed");
-        hook.end_capture();
-
-        // Resolve gguf file offsets by tensor name and count experts.
-        GgufOffsets offs = read_gguf_offsets(cfg.model_path.c_str());
-        if (!offs.ok) return fail("cannot read gguf offsets: " + cfg.model_path);
-
-        std::vector<LayerExperts> layers = hook.captured();
-        int n_expert = 0;
-        int n_bound = 0;
-        for (LayerExperts & L : layers) {
-            if (!L.bound) continue;
-            ++n_bound;
-            // Require exactly the projections the recipe names (a fused layout names fewer
-            // than max_exps); a slot the recipe declares but that capture never bound means
-            // the gguf's layout does not match the recipe — refuse rather than guess.
-            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
-                if (!recipe->exps_suffix[p]) continue; // slot unused by this architecture
-                ggml_tensor * t = L.proj[p].tensor;
-                if (!t)
-                    return fail(std::string("captured MoE layer is missing expert tensor '") + recipe->exps_suffix[p] +
-                                "'");
-                auto it = offs.off_by_name.find(t->name);
-                if (it == offs.off_by_name.end()) return fail(std::string("no gguf offset for tensor ") + t->name);
-                L.proj[p].file_off = it->second;
-                const int ne2 = (int) t->ne[2];
-                if (n_expert == 0)
-                    n_expert = ne2;
-                else if (ne2 != n_expert)
-                    return fail(std::string("inconsistent expert count: tensor ") + t->name + " has " +
-                                std::to_string(ne2) + ", expected " + std::to_string(n_expert));
-            }
-        }
-        if (n_bound == 0) return fail("no MoE expert tensors captured — is this a MoE model?");
-
-        if (!source.init(cfg.model_path, n_expert, std::move(layers), cfg.moe))
-            return fail("expert stream source init failed");
-        hook.set_source(&source);
-
-        if (cfg.moe.overlap) {
-#ifdef BMOE_HAVE_EXPERT_READY_HOOK
-            // Register the per-expert wait hook, and wire an abort callback so a mid-decode read
-            // failure tears the graph down cleanly instead of computing on a half-read expert.
-            source.enable_overlap_hook();
-            llama_set_abort_callback(
-                ctx, [](void * ud) -> bool { return static_cast<ExpertStreamSource *>(ud)->fatal(); }, &source);
-#else
-            return fail("--overlap requires the bmoe llama.cpp fork (expert-ready hook not compiled in)");
-#endif
-        }
-
-        llama_memory_clear(llama_get_memory(ctx), true); // discard warm-up KV
-    }
-
-    // ── prefill ──
-    auto t_prefill0 = clock_t_::now();
-    load_seconds = secs(t_load0, t_prefill0); // everything up to here is "load"
-    {
-        llama_batch pf = llama_batch_get_one(tokens.data(), n_prompt);
-        if (llama_decode(ctx, pf) != 0) {
-            if (cfg.moe.overlap && source.fatal()) return fail("expert stream I/O failed during overlap prefill");
-            return fail("prefill decode failed");
-        }
-    }
-    prefill_seconds = secs(t_prefill0, clock_t_::now());
-    const float * logits = llama_get_logits_ith(ctx, -1); // logits of the last output
-
-    // ── greedy generation ──
-    RunResult res;
-    res.ok = true;
-    std::string gen;
-    int n_gen = 0;
-    double gen_seconds = 0.0;
-
-    // The text to surface: with chat on, parse the raw output so a reasoning model's internal
-    // thinking is hidden (msg.reasoning_content) and only the answer (msg.content) is shown.
-    // Streaming-safe via is_partial. Generation itself always uses the raw tokens.
-    auto shown_text = [&](const std::string & raw, bool partial) -> std::string {
-        if (!chat_on) return raw;
-        try {
-            return common_chat_parse(raw, partial, parse_params).content;
-        } catch (const std::exception &) {
-            return raw;
-        }
-    };
-
-    // Baseline snapshot taken AFTER prefill: the summary reports the generation phase
-    // only, from real per-token deltas, never a total divided by n_gen. Prefill routes
-    // the union of the prompt's experts (near the whole bank), so folding it into a
-    // per-token average would badly inflate the flash-I/O figure.
-    long long prev_bytes = cfg.moe.enabled ? (long long) source.stats().read_bytes : 0;
-    double prev_io_s = cfg.moe.enabled ? source.stats().read_seconds : 0.0;
-    double prev_mgmt_s = cfg.moe.enabled ? source.stats().mgmt_seconds : 0.0;
-    double prev_stall_s = cfg.moe.enabled ? source.stats().stall_seconds : 0.0;
-
-    // Generation-only accumulators, summed from the measured per-token values.
-    uint64_t gen_read_bytes = 0;
-    double gen_io_seconds = 0.0;
-    double gen_mgmt_seconds = 0.0;
-    double gen_stall_seconds = 0.0;
-
-    for (int t = 0; t < cfg.n_predict; ++t) {
-        llama_token tok = argmax(logits, n_vocab);
-        if (llama_vocab_is_eog(vocab, tok)) break;
-
-        char piece[256];
-        int np = llama_token_to_piece(vocab, tok, piece, sizeof(piece), 0, true);
-        std::string delta = np > 0 ? std::string(piece, np) : std::string();
-        gen += delta;
-
-        auto s0 = clock_t_::now();
-        llama_batch step = llama_batch_get_one(&tok, 1);
-        int dec = llama_decode(ctx, step);
-        auto s1 = clock_t_::now();
-        if (dec != 0) {
-            if (cfg.moe.overlap && source.fatal()) return fail("expert stream I/O failed during overlap decode");
-            return fail("decode failed during generation");
-        }
-        logits = llama_get_logits_ith(ctx, -1);
-
-        ++n_gen;
-        double wall = secs(s0, s1);
-        gen_seconds += wall;
-
-        TokenMetrics m;
-        m.step = n_gen;
-        m.steps = cfg.n_predict;
-        m.wall_ms = wall * 1000.0;
-        m.piece = delta;
-        m.text = shown_text(gen, /*partial*/ true);
-        if (cfg.moe.enabled) {
-            IExpertSource::Stats st = source.stats();
-            m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
-            m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
-            m.mgmt_ms = (st.mgmt_seconds - prev_mgmt_s) * 1000.0;
-            if (cfg.moe.overlap) {
-                // stall_seconds is summed across all compute threads that blocked on flash; divide
-                // by the thread count for a wall-clock approximation of the token's flash wait.
-                // compute is the residual after the flash wait and the cache-management work (io_ms
-                // here is lane-busy work, overlapped, so it is not subtracted).
-                m.stall_ms = (st.stall_seconds - prev_stall_s) * 1000.0 / cfg.n_threads;
-                m.compute_ms = m.wall_ms - m.stall_ms - m.mgmt_ms;
-            } else {
-                m.compute_ms = m.wall_ms - m.io_ms - m.mgmt_ms;
-            }
-            if (m.compute_ms < 0) m.compute_ms = 0;
-            m.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
-            prev_bytes = (long long) st.read_bytes;
-            prev_io_s = st.read_seconds;
-            prev_mgmt_s = st.mgmt_seconds;
-            prev_stall_s = st.stall_seconds;
-            gen_read_bytes += m.read_bytes;
-            gen_io_seconds += m.io_ms / 1000.0;
-            gen_mgmt_seconds += m.mgmt_ms / 1000.0;
-            gen_stall_seconds += m.stall_ms / 1000.0;
-        } else {
-            m.compute_ms = m.wall_ms;
-            m.cache_hit_pct = -1.0;
-        }
-        if (on_token) on_token(m);
-        if (sink) sink->on_token(m);
-    }
-
-    // ── summary ──
-    RunSummary & s = res.summary;
-    s.n_generated = n_gen;
-    s.gen_seconds = gen_seconds;
-    s.s_per_token = n_gen ? gen_seconds / n_gen : 0.0;
-    s.tokens_per_second = gen_seconds > 0 ? n_gen / gen_seconds : 0.0;
-    s.n_prompt = n_prompt;
-    s.load_seconds = load_seconds;
-    s.prefill_seconds = prefill_seconds;
-    if (cfg.moe.enabled) {
-        IExpertSource::Stats st = source.stats();
-        // Generation-phase figures, summed from the measured per-token deltas (prefill
-        // excluded) — real measurements, not a contaminated total divided by n_gen.
-        s.moe_read_mib = gen_read_bytes / (1024.0 * 1024.0);
-        s.moe_io_seconds = gen_io_seconds;
-        s.moe_io_s_per_token = n_gen ? gen_io_seconds / n_gen : 0.0;
-        s.moe_mgmt_s_per_token = n_gen ? gen_mgmt_seconds / n_gen : 0.0;
-        s.moe_stall_s_per_token = n_gen ? gen_stall_seconds / n_gen : 0.0;
-        // Compute is a residual: the token's wall minus the measured terms. Overlap subtracts the
-        // flash wait (I/O runs alongside compute, so subtracting io would double-count); serial
-        // subtracts io (a slice of wall). Both also subtract the cache-management time.
-        s.moe_compute_s_per_token =
-            s.s_per_token - (cfg.moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token) - s.moe_mgmt_s_per_token;
-        if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;
-        s.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
-        s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);
-    }
-    if (sink) sink->on_summary(s);
-
-    res.generated_text = shown_text(gen, /*partial*/ false);
-
-    // Tear the source's I/O pool down before the context/model guards fire.
-    source.shutdown();
-    return res;
+    return session->generate(req, on_token, sink);
 }
 
 } // namespace bmoe

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -1,0 +1,444 @@
+#include "bmoe/session.h"
+#include "bmoe/recipe.h"
+#include "../moe/router_hook.h"
+#include "../moe/expert_stream_source.h"
+#include "../moe/gguf_offsets.h"
+
+#include "llama.h"
+#include "ggml.h"
+
+// llama.cpp's `common` layer (NOT the stable public API): chat-template rendering and
+// reasoning parsing. See the note in the root CMakeLists / docs/seam.md.
+#include "chat.h"
+#include "common.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace bmoe {
+
+namespace {
+
+using clock_t_ = std::chrono::steady_clock;
+double secs(clock_t_::time_point a, clock_t_::time_point b) {
+    return std::chrono::duration<double>(b - a).count();
+}
+
+llama_token argmax(const float * logits, int n_vocab) {
+    llama_token best = 0;
+    float best_v = logits[0];
+    for (int v = 1; v < n_vocab; ++v)
+        if (logits[v] > best_v) {
+            best_v = logits[v];
+            best = v;
+        }
+    return best;
+}
+
+} // namespace
+
+// All native state lives here, behind the pimpl. Built once by Session::open(); every
+// generate() reuses the loaded model, the live context and the warm expert cache.
+struct Session::Impl {
+    SessionConfig cfg;
+    std::string arch;
+    double load_seconds = 0.0;
+
+    // Ownership order matters at teardown: the source's I/O pool holds fds into the mmap'd
+    // file and its buffers back the rebound expert tensors, so it must be shut down before
+    // the context and model are freed. The destructor does that explicitly.
+    std::unique_ptr<llama_model, void (*)(llama_model *)> model{nullptr, llama_model_free};
+    std::unique_ptr<llama_context, void (*)(llama_context *)> ctx{nullptr, llama_free};
+    std::unique_ptr<RouterHook> hook; // heap: its address is baked into cparams.cb_eval_user_data
+    ExpertStreamSource source;
+
+    const llama_vocab * vocab = nullptr;
+    int n_vocab = 0;
+    int n_layer = 0;
+    bool chat_on = false;
+    common_chat_templates_ptr chat_tmpls;
+    bool backend_inited = false;
+
+    std::atomic<bool> cancel_requested{false};
+
+    ~Impl() {
+        // Deterministic teardown order: stop the I/O pool (it holds fds into the mmap and its
+        // buffers back the rebound expert tensors), then the context (its eval callback points
+        // at the hook), then the hook, then unmap the model, then release the backend.
+        source.shutdown();
+        ctx.reset();
+        hook.reset();
+        model.reset();
+        if (backend_inited) llama_backend_free();
+    }
+};
+
+Session::Session() : impl_(std::make_unique<Impl>()) {}
+Session::~Session() = default;
+
+double Session::load_seconds() const {
+    return impl_->load_seconds;
+}
+const std::string & Session::arch() const {
+    return impl_->arch;
+}
+int Session::n_ctx() const {
+    return impl_->cfg.n_ctx;
+}
+void Session::cancel() {
+    impl_->cancel_requested.store(true, std::memory_order_relaxed);
+}
+
+std::unique_ptr<Session> Session::open(const SessionConfig & cfg, std::string & error) {
+    auto fail = [&](std::string msg) -> std::unique_ptr<Session> {
+        error = std::move(msg);
+        return nullptr;
+    };
+
+    // Create the session first so its Impl destructor owns backend teardown from this point
+    // on: any failure below returns nullptr, destroying `self`, which frees the backend once.
+    std::unique_ptr<Session> self(new Session());
+    Impl & im = *self->impl_;
+    im.cfg = cfg;
+
+    // llama_backend_init/free is process-global and reference counted; init here, free in ~Impl.
+    llama_backend_init();
+    im.backend_inited = true;
+
+    const auto t_load0 = clock_t_::now();
+
+    // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
+    // q4_K buffer would break the rebind), experts on CPU.
+    llama_model_params mparams = llama_model_default_params();
+    mparams.use_mmap = true;
+    mparams.use_extra_bufts = false;
+    mparams.n_gpu_layers = 0;
+
+    llama_model * model = llama_model_load_from_file(cfg.model_path.c_str(), mparams);
+    if (!model) return fail("failed to load model: " + cfg.model_path);
+    im.model.reset(model);
+
+    im.vocab = llama_model_get_vocab(model);
+    im.n_vocab = llama_vocab_n_tokens(im.vocab);
+    im.n_layer = llama_model_n_layer(model);
+
+    char arch[128] = {0};
+    llama_model_meta_val_str(model, "general.architecture", arch, sizeof(arch));
+    im.arch = arch;
+
+    const MoeRecipe * recipe = nullptr;
+    if (cfg.moe.enabled) {
+        recipe = find_moe_recipe(arch);
+        if (!recipe)
+            return fail(std::string("no MoE recipe for architecture '") + arch +
+                        "' — add one in core/src/moe/arch_registry.cpp (see docs/adding-a-model.md)");
+    }
+
+    // Chat templates are model-bound: initialise once here, apply per prompt in generate().
+    if (cfg.chatml) {
+        try {
+            im.chat_tmpls = common_chat_templates_init(model, "");
+            im.chat_on = true;
+        } catch (const std::exception & e) {
+            std::fprintf(stderr, "bmoe: chat template unavailable (%s); using raw prompts\n", e.what());
+            im.chat_on = false;
+        }
+    }
+
+    im.hook = std::make_unique<RouterHook>(recipe ? *recipe : MoeRecipe{}, im.n_layer);
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx = cfg.n_ctx;
+    cparams.n_batch = cfg.n_batch;
+    cparams.n_ubatch = cfg.n_batch;
+    if (cfg.moe.enabled) {
+        cparams.cb_eval = &RouterHook::c_eval;
+        cparams.cb_eval_user_data = im.hook.get();
+    }
+
+    llama_context * ctx = llama_init_from_model(model, cparams);
+    if (!ctx) return fail("failed to create context");
+    im.ctx.reset(ctx);
+    llama_set_n_threads(ctx, cfg.n_threads, cfg.n_threads);
+
+    // One abort callback for the session's whole life, checking two independent predicates:
+    // an explicit cancel() request (any mode) and a fatal streaming I/O error (overlap only).
+    // Installing it unconditionally is what lets cancel() interrupt a serial decode too.
+    llama_set_abort_callback(
+        ctx,
+        [](void * ud) -> bool {
+            auto * p = static_cast<Impl *>(ud);
+            return p->cancel_requested.load(std::memory_order_relaxed) || p->source.fatal();
+        },
+        &im);
+
+    if (cfg.moe.enabled) {
+        // Capture warm-up: one mmap-resident decode so the eval-callback can harvest the expert
+        // tensor pointers from the graph. Any valid token builds the same graph (the expert
+        // tensor structure is prompt-independent), so use BOS; KV is wiped afterwards.
+        im.hook->begin_capture();
+        llama_token warm_tok = llama_vocab_bos(im.vocab);
+        if (warm_tok < 0) warm_tok = 0;
+        llama_batch warm = llama_batch_get_one(&warm_tok, 1);
+        if (llama_decode(ctx, warm) != 0) return fail("capture warm-up decode failed");
+        im.hook->end_capture();
+
+        GgufOffsets offs = read_gguf_offsets(cfg.model_path.c_str());
+        if (!offs.ok) return fail("cannot read gguf offsets: " + cfg.model_path);
+
+        std::vector<LayerExperts> layers = im.hook->captured();
+        int n_expert = 0;
+        int n_bound = 0;
+        for (LayerExperts & L : layers) {
+            if (!L.bound) continue;
+            ++n_bound;
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                if (!recipe->exps_suffix[p]) continue; // slot unused by this architecture
+                ggml_tensor * t = L.proj[p].tensor;
+                if (!t)
+                    return fail(std::string("captured MoE layer is missing expert tensor '") + recipe->exps_suffix[p] +
+                                "'");
+                auto it = offs.off_by_name.find(t->name);
+                if (it == offs.off_by_name.end()) return fail(std::string("no gguf offset for tensor ") + t->name);
+                L.proj[p].file_off = it->second;
+                const int ne2 = (int) t->ne[2];
+                if (n_expert == 0)
+                    n_expert = ne2;
+                else if (ne2 != n_expert)
+                    return fail(std::string("inconsistent expert count: tensor ") + t->name + " has " +
+                                std::to_string(ne2) + ", expected " + std::to_string(n_expert));
+            }
+        }
+        if (n_bound == 0) return fail("no MoE expert tensors captured — is this a MoE model?");
+
+        if (!im.source.init(cfg.model_path, n_expert, std::move(layers), cfg.moe))
+            return fail("expert stream source init failed");
+        im.hook->set_source(&im.source);
+
+        if (cfg.moe.overlap) {
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+            im.source.enable_overlap_hook();
+#else
+            return fail("--overlap requires the bmoe llama.cpp fork (expert-ready hook not compiled in)");
+#endif
+        }
+
+        llama_memory_clear(llama_get_memory(ctx), true); // discard warm-up KV
+    }
+
+    im.load_seconds = secs(t_load0, clock_t_::now());
+    return self;
+}
+
+RunResult Session::generate(const GenerateRequest & req,
+                            const std::function<void(const TokenMetrics &)> & on_token, IMetricsSink * sink) {
+    Impl & im = *impl_;
+    const MoeStreamConfig & moe = im.cfg.moe;
+    llama_context * ctx = im.ctx.get();
+
+    // Fresh cancel latch for this generation; a stale request from a prior aborted call must
+    // not carry over. (cancel() sets it; the abort callback reads it.)
+    im.cancel_requested.store(false, std::memory_order_relaxed);
+
+    RunResult res;
+    auto fail = [&](std::string msg) {
+        res.ok = false;
+        res.error = std::move(msg);
+        return res;
+    };
+
+    if (req.clear_kv) llama_memory_clear(llama_get_memory(ctx), true);
+
+    // Format the prompt. With chat on, render the model's OWN chat template (real Jinja) and
+    // set up reasoning parsing so a thinking model's internal reasoning is stripped from the
+    // shown answer. req.think drives the template's enable_thinking kwarg, per prompt.
+    std::string prompt = req.prompt;
+    bool chat_on = im.chat_on;
+    common_chat_parser_params parse_params;
+    if (chat_on) {
+        try {
+            common_chat_templates_inputs inputs;
+            common_chat_msg user_msg;
+            user_msg.role = "user";
+            user_msg.content = req.prompt;
+            inputs.messages = {user_msg};
+            inputs.add_generation_prompt = true;
+            inputs.use_jinja = true;
+            inputs.enable_thinking = req.think;
+            common_chat_params cp = common_chat_templates_apply(im.chat_tmpls.get(), inputs);
+            prompt = cp.prompt;
+            parse_params = common_chat_parser_params(cp);
+            parse_params.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+        } catch (const std::exception & e) {
+            std::fprintf(stderr, "bmoe: chat template apply failed (%s); using raw prompt\n", e.what());
+            chat_on = false;
+        }
+    }
+
+    std::vector<llama_token> tokens(prompt.size() + 8);
+    int n_prompt = llama_tokenize(im.vocab, prompt.c_str(), (int) prompt.size(), tokens.data(), (int) tokens.size(),
+                                  /*add_special*/ true, /*parse_special*/ true);
+    if (n_prompt < 0) {
+        tokens.resize(-n_prompt);
+        n_prompt = llama_tokenize(im.vocab, prompt.c_str(), (int) prompt.size(), tokens.data(), (int) tokens.size(),
+                                  true, true);
+    }
+    if (n_prompt < 1) return fail("empty prompt after tokenization");
+    tokens.resize(n_prompt);
+    if (n_prompt + req.n_predict + 8 > im.cfg.n_ctx)
+        return fail("prompt + n_predict exceeds the session n_ctx (" + std::to_string(im.cfg.n_ctx) +
+                    "); open the session with a larger n_ctx");
+
+    // The text to surface: with chat on, parse the raw output so a reasoning model's internal
+    // thinking is hidden and only the answer is shown. Generation always uses the raw tokens.
+    auto shown_text = [&](const std::string & raw, bool partial) -> std::string {
+        if (!chat_on) return raw;
+        try {
+            return common_chat_parse(raw, partial, parse_params).content;
+        } catch (const std::exception &) {
+            return raw;
+        }
+    };
+
+    // ── prefill (chunked by n_batch; positions auto-continue across chunks) ──
+    const auto t_prefill0 = clock_t_::now();
+    for (int i = 0; i < n_prompt; i += im.cfg.n_batch) {
+        const int chunk = std::min(im.cfg.n_batch, n_prompt - i);
+        llama_batch pf = llama_batch_get_one(tokens.data() + i, chunk);
+        if (llama_decode(ctx, pf) != 0) {
+            if (im.cancel_requested.load(std::memory_order_relaxed)) {
+                llama_memory_clear(llama_get_memory(ctx), true);
+                res.ok = true;
+                res.cancelled = true;
+                return res;
+            }
+            if (moe.overlap && im.source.fatal()) return fail("expert stream I/O failed during overlap prefill");
+            return fail("prefill decode failed");
+        }
+    }
+    const double prefill_seconds = secs(t_prefill0, clock_t_::now());
+    const float * logits = llama_get_logits_ith(ctx, -1);
+
+    // ── greedy generation ──
+    res.ok = true;
+    std::string gen;
+    int n_gen = 0;
+    double gen_seconds = 0.0;
+
+    // Baseline snapshot taken AFTER prefill: the summary reports the generation phase only,
+    // from real per-token deltas (prefill routes near the whole bank, so folding it into a
+    // per-token average would badly inflate the flash-I/O figure). In a warm session these
+    // counters carry the prior prompts' totals; the deltas make each prompt self-relative.
+    long long prev_bytes = moe.enabled ? (long long) im.source.stats().read_bytes : 0;
+    double prev_io_s = moe.enabled ? im.source.stats().read_seconds : 0.0;
+    double prev_mgmt_s = moe.enabled ? im.source.stats().mgmt_seconds : 0.0;
+    double prev_stall_s = moe.enabled ? im.source.stats().stall_seconds : 0.0;
+
+    uint64_t gen_read_bytes = 0;
+    double gen_io_seconds = 0.0;
+    double gen_mgmt_seconds = 0.0;
+    double gen_stall_seconds = 0.0;
+
+    for (int t = 0; t < req.n_predict; ++t) {
+        llama_token tok = argmax(logits, im.n_vocab);
+        if (llama_vocab_is_eog(im.vocab, tok)) break;
+
+        char piece[256];
+        int np = llama_token_to_piece(im.vocab, tok, piece, sizeof(piece), 0, true);
+        std::string delta = np > 0 ? std::string(piece, np) : std::string();
+        gen += delta;
+
+        auto s0 = clock_t_::now();
+        llama_batch step = llama_batch_get_one(&tok, 1);
+        int dec = llama_decode(ctx, step);
+        auto s1 = clock_t_::now();
+        if (dec != 0) {
+            if (im.cancel_requested.load(std::memory_order_relaxed)) {
+                res.cancelled = true;
+                break;
+            }
+            if (moe.overlap && im.source.fatal()) return fail("expert stream I/O failed during overlap decode");
+            return fail("decode failed during generation");
+        }
+        logits = llama_get_logits_ith(ctx, -1);
+
+        ++n_gen;
+        double wall = secs(s0, s1);
+        gen_seconds += wall;
+
+        TokenMetrics m;
+        m.step = n_gen;
+        m.steps = req.n_predict;
+        m.wall_ms = wall * 1000.0;
+        m.piece = delta;
+        m.text = shown_text(gen, /*partial*/ true);
+        if (moe.enabled) {
+            IExpertSource::Stats st = im.source.stats();
+            m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
+            m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
+            m.mgmt_ms = (st.mgmt_seconds - prev_mgmt_s) * 1000.0;
+            if (moe.overlap) {
+                m.stall_ms = (st.stall_seconds - prev_stall_s) * 1000.0 / im.cfg.n_threads;
+                m.compute_ms = m.wall_ms - m.stall_ms - m.mgmt_ms;
+            } else {
+                m.compute_ms = m.wall_ms - m.io_ms - m.mgmt_ms;
+            }
+            if (m.compute_ms < 0) m.compute_ms = 0;
+            m.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
+            prev_bytes = (long long) st.read_bytes;
+            prev_io_s = st.read_seconds;
+            prev_mgmt_s = st.mgmt_seconds;
+            prev_stall_s = st.stall_seconds;
+            gen_read_bytes += m.read_bytes;
+            gen_io_seconds += m.io_ms / 1000.0;
+            gen_mgmt_seconds += m.mgmt_ms / 1000.0;
+            gen_stall_seconds += m.stall_ms / 1000.0;
+        } else {
+            m.compute_ms = m.wall_ms;
+            m.cache_hit_pct = -1.0;
+        }
+        if (on_token) on_token(m);
+        if (sink) sink->on_token(m);
+    }
+
+    // ── summary ──
+    RunSummary & s = res.summary;
+    s.n_generated = n_gen;
+    s.gen_seconds = gen_seconds;
+    s.s_per_token = n_gen ? gen_seconds / n_gen : 0.0;
+    s.tokens_per_second = gen_seconds > 0 ? n_gen / gen_seconds : 0.0;
+    s.n_prompt = n_prompt;
+    s.load_seconds = im.load_seconds;
+    s.prefill_seconds = prefill_seconds;
+    if (moe.enabled) {
+        IExpertSource::Stats st = im.source.stats();
+        s.moe_read_mib = gen_read_bytes / (1024.0 * 1024.0);
+        s.moe_io_seconds = gen_io_seconds;
+        s.moe_io_s_per_token = n_gen ? gen_io_seconds / n_gen : 0.0;
+        s.moe_mgmt_s_per_token = n_gen ? gen_mgmt_seconds / n_gen : 0.0;
+        s.moe_stall_s_per_token = n_gen ? gen_stall_seconds / n_gen : 0.0;
+        s.moe_compute_s_per_token =
+            s.s_per_token - (moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token) - s.moe_mgmt_s_per_token;
+        if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;
+        s.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
+        s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);
+    }
+    if (sink) sink->on_summary(s);
+
+    res.generated_text = shown_text(gen, /*partial*/ false);
+
+    // A cancel left the KV cache holding a partial generation; clear it so the next prompt
+    // (which clears anyway when clear_kv=true) never continues from stale state.
+    if (res.cancelled) llama_memory_clear(llama_get_memory(ctx), true);
+    return res;
+}
+
+} // namespace bmoe

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -154,6 +154,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg, std::string & 
     }
 
     im.hook = std::make_unique<RouterHook>(recipe ? *recipe : MoeRecipe{}, im.n_layer);
+    im.hook->set_prefetch_layers(cfg.moe.prefetch_layers);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
@@ -341,6 +342,9 @@ RunResult Session::generate(const GenerateRequest & req,
     double prev_io_s = moe.enabled ? im.source.stats().read_seconds : 0.0;
     double prev_mgmt_s = moe.enabled ? im.source.stats().mgmt_seconds : 0.0;
     double prev_stall_s = moe.enabled ? im.source.stats().stall_seconds : 0.0;
+    long long prev_spec_bytes = moe.enabled ? (long long) im.source.stats().spec_read_bytes : 0;
+    long long prev_spec_experts = moe.enabled ? im.source.stats().spec_experts : 0;
+    long long prev_spec_useful = moe.enabled ? im.source.stats().spec_useful : 0;
 
     uint64_t gen_read_bytes = 0;
     double gen_io_seconds = 0.0;
@@ -430,6 +434,9 @@ RunResult Session::generate(const GenerateRequest & req,
         if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;
         s.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
         s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);
+        s.moe_spec_read_mib = ((long long) st.spec_read_bytes - prev_spec_bytes) / (1024.0 * 1024.0);
+        s.moe_spec_experts = st.spec_experts - prev_spec_experts;
+        s.moe_spec_useful = st.spec_useful - prev_spec_useful;
     }
     if (sink) sink->on_summary(s);
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -36,6 +36,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     o_direct_ = cfg.o_direct;
     load_all_ = cfg.load_all;
     overlap_ = cfg.overlap;
+    prefetch_sync_ = cfg.prefetch_sync && !cfg.overlap; // serial only: overlap lane 0 is a worker
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
 
@@ -106,6 +107,8 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         cstamp_.assign(n_entry, 0);
         cprev_.assign(n_entry, -1);
         cnext_.assign(n_entry, -1);
+        cspec_.assign(n_entry, 0);
+        spec_remaining_.assign(n_entry, 0);
         chead_ = ctail_ = -1;
         cresident_ = 0;
         cgen_ = 0;
@@ -297,15 +300,137 @@ void ExpertStreamSource::io_drain(int lane, uint64_t my_gen) {
 void ExpertStreamSource::io_worker(int lane) {
     uint64_t seen = 0;
     for (;;) {
-        uint64_t g;
         {
             std::unique_lock<std::mutex> lk(io_mtx_);
-            io_cv_.wait(lk, [&] { return io_stop_ || batch_gen_ > seen; });
+            io_cv_.wait(lk, [&] { return io_stop_ || batch_gen_ > seen || spec_next_ < spec_jobs_.size(); });
             if (io_stop_) return;
-            g = batch_gen_;
-            seen = g;
         }
-        io_drain(lane, g);
+        uint64_t g;
+        {
+            std::lock_guard<std::mutex> lk(io_mtx_);
+            g = batch_gen_;
+        }
+        if (g > seen) { // real batch first — it is latency-critical
+            seen = g;
+            io_drain(lane, g);
+        }
+        // Then use spare capacity on queued speculative reads, yielding the moment a real batch
+        // arrives (drain_spec bails when batch_gen_ advances past this worker's `seen`).
+        drain_spec(lane, seen);
+    }
+}
+
+// Prefetch: on the eval thread, commit pages and enqueue speculative per-projection reads for the
+// given experts of layer il. LRU-safe (same thread as load_layer); workers only read the bytes.
+void ExpertStreamSource::prefetch(int il, const int32_t * ids, int n_ids) {
+    if (!active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0)
+        return;
+    const LayerExperts & L = layers_[il];
+    bool any = false;
+    std::lock_guard<std::mutex> lk(io_mtx_);
+    for (int i = 0; i < n_ids; ++i) {
+        const int e = ids[i];
+        if (e < 0 || e >= n_expert_) continue;
+        const int32_t id = il * n_expert_ + e;
+        if (cvalid_[id] || spec_remaining_[id] != 0) continue; // already resident or already queued
+        int njobs = 0;
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            const uint64_t slice = L.proj[p].nb2;
+            if (slice == 0) continue;
+            char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
+            uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
+            uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
+            if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) return; // low on memory — stop quietly
+            spec_jobs_.push_back({dst, L.proj[p].file_off + (uint64_t) e * slice, slice, id});
+            ++njobs;
+        }
+        if (njobs == 0) continue;
+        spec_remaining_[id] = njobs;
+        spec_touched_.push_back(id);
+        any = true;
+    }
+    if (!any) return;
+    if (prefetch_sync_) {
+        // Test path: read the queued slices now on lane 0 (free on the eval thread in serial mode),
+        // so the next quiesce integrates them deterministically. Mirrors drain_spec's accounting.
+        for (;;) {
+            IoJob j;
+            uint64_t g;
+            if (spec_next_ >= spec_jobs_.size()) break;
+            g = spec_gen_;
+            j = spec_jobs_[spec_next_++];
+            ++spec_inflight_;
+            const bool ok = read_slice(0, j.dst, j.off, j.nbytes);
+            if (ok && g == spec_gen_) {
+                spec_read_bytes_.fetch_add((long long) j.nbytes);
+                if (--spec_remaining_[j.flag] == 0) spec_done_.push_back(j.flag);
+            }
+            --spec_inflight_;
+        }
+        return;
+    }
+    io_cv_.notify_all();
+}
+
+// Drain queued speculative reads on an idle lane. Bails as soon as a real batch this worker has
+// not served appears, so speculation never delays real work. A completed entry (all projections
+// read under the current spec generation) is handed to the eval thread via spec_done_.
+void ExpertStreamSource::drain_spec(int lane, uint64_t worker_seen) {
+    for (;;) {
+        IoJob j;
+        uint64_t g;
+        {
+            std::lock_guard<std::mutex> lk(io_mtx_);
+            if (io_stop_ || batch_gen_ > worker_seen) return; // shutting down, or real work waiting
+            if (spec_next_ >= spec_jobs_.size()) return;
+            g = spec_gen_;
+            j = spec_jobs_[spec_next_++];
+            ++spec_inflight_;
+        }
+        const bool ok = read_slice(lane, j.dst, j.off, j.nbytes);
+        {
+            std::lock_guard<std::mutex> lk(io_mtx_);
+            if (ok && g == spec_gen_) { // ignore reads from a cancelled round
+                spec_read_bytes_.fetch_add((long long) j.nbytes);
+                if (--spec_remaining_[j.flag] == 0) spec_done_.push_back(j.flag);
+            }
+            if (--spec_inflight_ == 0) io_cv_done_.notify_all();
+        }
+    }
+}
+
+// Quiesce speculation before real staging: cancel queued reads, wait out in-flight ones, then on
+// this (eval) thread integrate every fully-read entry into the cache and release the rest. All LRU
+// mutation happens here, single-threaded, so it never races the real staging that follows.
+void ExpertStreamSource::quiesce_spec() {
+    std::vector<int32_t> done, touched;
+    {
+        std::unique_lock<std::mutex> lk(io_mtx_);
+        ++spec_gen_; // cancel queued-but-unstarted reads and disown in-flight ones on completion
+        spec_jobs_.clear();
+        spec_next_ = 0;
+        io_cv_done_.wait(lk, [&] { return spec_inflight_ == 0 || io_stop_; });
+        done.swap(spec_done_);
+        touched.swap(spec_touched_);
+    }
+    // Integrate completed entries (all projections resident) into the LRU cache.
+    for (int32_t id : done) {
+        if (spec_remaining_[id] != 0 || cvalid_[id]) { // incomplete, or a real read already took it
+            spec_remaining_[id] = 0;
+            continue;
+        }
+        cvalid_[id] = 1;
+        cspec_[id] = 1; // speculative until a real lookup hits it (then counted useful)
+        cstamp_[id] = 0; // not used this generation → evictable if the budget is tight
+        cresident_ += entry_bytes(id / n_expert_);
+        lru_push_front(id);
+        spec_experts_.fetch_add(1);
+    }
+    // Release pages of entries that never finished (a cancelled or failed read).
+    for (int32_t id : touched) {
+        if (spec_remaining_[id] == 0) continue; // completed above (or already integrated)
+        release_entry_pages(id);
+        spec_remaining_[id] = 0;
     }
 }
 
@@ -338,8 +463,9 @@ size_t ExpertStreamSource::entry_bytes(int il) const {
         bytes += (size_t) L.proj[p].nb2; // absent slots contribute 0
     return bytes;
 }
-void ExpertStreamSource::evict_tail() {
-    const int32_t id = ctail_;
+// Release the physical pages fully contained in an entry's slices (never a partial page shared
+// with a neighbouring expert). Shared by eviction and by discarding an incomplete spec entry.
+void ExpertStreamSource::release_entry_pages(int32_t id) {
     const int il = id / n_expert_, e = id % n_expert_;
     for (int p = 0; p < MoeRecipe::max_exps; ++p) {
         const uint64_t slice = layers_[il].proj[p].nb2;
@@ -349,8 +475,13 @@ void ExpertStreamSource::evict_tail() {
         uintptr_t a1 = ((uintptr_t) s + slice) & ~(uintptr_t) (page_ - 1);
         if (a1 > a0) pio::vm_evict((void *) a0, (size_t) (a1 - a0));
     }
+}
+void ExpertStreamSource::evict_tail() {
+    const int32_t id = ctail_;
+    release_entry_pages(id);
     cvalid_[id] = 0;
-    cresident_ -= entry_bytes(il);
+    cspec_[id] = 0;
+    cresident_ -= entry_bytes(id / n_expert_);
     lru_unlink(id);
 }
 
@@ -365,6 +496,10 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     // Cache-management work (vm commit + LRU bookkeeping, then eviction below) is timed into
     // mgmt_ns_ so the metrics can split it out of the compute residual instead of hiding it there.
     const auto tm0 = clock_t_::now();
+
+    // Integrate / discard any speculative prefetch before this layer's real staging touches the
+    // cache. After this returns no spec read is in flight and completed ones are resident hits.
+    if (cache_max_) quiesce_spec();
 
     auto stage = [&](int e) -> bool {
         if (cache_max_ == 0) {
@@ -381,6 +516,10 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
         cstamp_[id] = cgen_;
         if (cvalid_[id]) {
             chits_++;
+            if (cspec_[id]) { // this hit was served by a speculative prefetch — count it useful once
+                spec_useful_.fetch_add(1);
+                cspec_[id] = 0;
+            }
             lru_unlink(id);
             lru_push_front(id);
             return true;
@@ -398,6 +537,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
             jobs_.push_back({dst, L.proj[p].file_off + (uint64_t) e * slice, slice});
         }
         cvalid_[id] = 1;
+        cspec_[id] = 0; // a real read, not speculative
         cresident_ += entry_bytes(il);
         lru_push_front(id);
         return true;
@@ -481,6 +621,10 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
     // it into mgmt_ns_ so the metrics can surface it. The drain wait above is I/O, not mgmt.
     const auto tm0 = clock_t_::now();
 
+    // Integrate / discard speculative prefetch before this layer's real staging (the previous
+    // batch is already drained above, so this only waits on in-flight spec reads).
+    if (cache_max_) quiesce_spec();
+
     // 2. New generation for this layer. A flag counts as ready only once its gen matches.
     const uint32_t gen = async_gen_.fetch_add(1, std::memory_order_relaxed) + 1;
     cur_il_.store(il, std::memory_order_relaxed);
@@ -531,6 +675,10 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
             cstamp_[id] = cgen_;
             if (cvalid_[id]) {
                 chits_++;
+                if (cspec_[id]) {
+                    spec_useful_.fetch_add(1);
+                    cspec_[id] = 0;
+                }
                 lru_unlink(id);
                 lru_push_front(id);
                 for (int p = 0; p < MoeRecipe::max_exps; ++p)
@@ -550,6 +698,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
                 }
             }
             cvalid_[id] = 1;
+            cspec_[id] = 0; // a real read, not speculative
             cresident_ += entry_bytes(il);
             lru_push_front(id);
             seen_[e] = 1; // this expert missed → its projections need reads
@@ -651,6 +800,9 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     // which the runtime reports as lane-busy per token rather than as a slice of wall time.
     s.read_seconds = (overlap_ ? io_syscall_ns_.load() : read_ns_.load()) / 1e9;
     s.mgmt_seconds = mgmt_ns_.load() / 1e9;
+    s.spec_read_bytes = (uint64_t) spec_read_bytes_.load();
+    s.spec_experts = spec_experts_.load();
+    s.spec_useful = spec_useful_.load();
     s.cache_hits = chits_;
     s.cache_lookups = clookups_;
     s.cache_resident_bytes = (uint64_t) cresident_;
@@ -677,12 +829,17 @@ void ExpertStreamSource::shutdown() {
     {
         std::lock_guard<std::mutex> lk(io_mtx_);
         io_stop_ = true;
+        ++spec_gen_; // disown any in-flight speculative reads
+        spec_jobs_.clear();
+        spec_next_ = 0;
     }
     io_cv_.notify_all();
     io_cv_done_.notify_all();
     for (auto & t : io_pool_)
         if (t.joinable()) t.join();
     io_pool_.clear();
+    spec_done_.clear();
+    spec_touched_.clear();
 
     for (int p = 0; p < MoeRecipe::max_exps; ++p)
         if (slot_[p]) {

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -63,6 +63,7 @@ public:
 
     // IExpertSource
     bool load_layer(int il, const int32_t * ids, int n_ids) override;
+    void prefetch(int il, const int32_t * ids, int n_ids) override;
     Stats stats() const override;
 
     // Register the process-global expert-ready hook so the CPU matmul blocks per expert
@@ -96,6 +97,12 @@ private:
     void io_drain(int lane, uint64_t my_gen);
     void io_worker(int lane);
 
+    // Speculative prefetch (temporal): drain queued spec reads on an idle lane, and integrate /
+    // discard them on the eval thread at the next real load. See docs/prefetch.md.
+    void drain_spec(int lane, uint64_t worker_seen);
+    void quiesce_spec();
+    void release_entry_pages(int32_t id);
+
     bool load_layer_async(int il, const int32_t * ids, int n_ids); // overlap path
 
     static void c_expert_ready(const ggml_tensor * src0, int expert, void * user_data);
@@ -111,6 +118,7 @@ private:
     bool o_direct_ = false;
     bool load_all_ = false;
     bool overlap_ = false;
+    bool prefetch_sync_ = false; // test only: drain prefetch reads synchronously (serial mode)
     int n_layer_ = 0;
     int n_expert_ = 0;
     uint64_t fsize_ = 0;
@@ -130,10 +138,27 @@ private:
     std::vector<uint8_t> cvalid_;
     std::vector<int32_t> cprev_, cnext_;
     std::vector<uint32_t> cstamp_;
+    std::vector<uint8_t> cspec_; // 1 if this resident entry was filled speculatively, until first hit
     int32_t chead_ = -1, ctail_ = -1;
     uint32_t cgen_ = 0;
     size_t cresident_ = 0;
     long long chits_ = 0, clookups_ = 0;
+
+    // ── speculative prefetch queue (all fields guarded by io_mtx_) ──
+    // prefetch() (eval thread) commits pages and enqueues per-projection reads tagged with the
+    // entry id; workers drain them on idle lanes; quiesce_spec() (eval thread, at the next real
+    // load) integrates fully-read entries into the cache and releases the rest. spec_gen_ bumps to
+    // cancel a round. All LRU mutation stays on the eval thread — workers only read bytes.
+    std::vector<IoJob> spec_jobs_;
+    size_t spec_next_ = 0;
+    uint64_t spec_gen_ = 0;
+    size_t spec_inflight_ = 0;
+    std::vector<int32_t> spec_done_;      // entry ids whose every projection read completed
+    std::vector<int32_t> spec_touched_;   // entry ids queued this round (for cleanup at quiesce)
+    std::vector<int32_t> spec_remaining_; // per entry id: projection reads still pending (0 = none)
+    std::atomic<long long> spec_read_bytes_{0};
+    std::atomic<long long> spec_experts_{0};
+    std::atomic<long long> spec_useful_{0};
 
     std::vector<uint8_t> seen_; // per-load dedup scratch [n_expert]
 

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -9,6 +9,7 @@ namespace bmoe {
 
 RouterHook::RouterHook(const MoeRecipe & recipe, int n_layer) : recipe_(recipe), n_layer_(n_layer) {
     captured_.assign(n_layer_ > 0 ? n_layer_ : 0, LayerExperts{});
+    prev_ids_.assign(n_layer_ > 0 ? n_layer_ : 0, std::vector<int32_t>{});
 }
 
 // Match a tensor name of the form "blk.<il>.<suffix>.weight" against the recipe's expert
@@ -82,6 +83,23 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 gathered_.push_back(
                     *(const int32_t *) ((const char *) t->data + (size_t) j * t->nb[1] + (size_t) k * t->nb[0]));
         source_->load_layer(il, gathered_.data(), (int) gathered_.size());
+
+        // Temporal prefetch: hint the next K layers with what the PREVIOUS token routed there,
+        // to be read on idle lanes while this layer computes; then record this layer's routing
+        // (the last token's row during prefill) for the next token to predict from.
+        if (prefetch_layers_ > 0 && il >= 0 && il < n_layer_) {
+            for (int k = 1; k <= prefetch_layers_; ++k) {
+                const int tl = il + k;
+                if (tl < n_layer_ && !prev_ids_[tl].empty())
+                    source_->prefetch(tl, prev_ids_[tl].data(), (int) prev_ids_[tl].size());
+            }
+            std::vector<int32_t> & rec = prev_ids_[il];
+            rec.clear();
+            const int last = nt - 1;
+            for (int k = 0; k < nu; ++k)
+                rec.push_back(*(const int32_t *) ((const char *) t->data + (size_t) last * t->nb[1] +
+                                                  (size_t) k * t->nb[0]));
+        }
     }
     return true;
 }

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -43,6 +43,10 @@ public:
 
     void set_source(IExpertSource * src) { source_ = src; } // enter stream mode
 
+    // Temporal prefetch depth K: while streaming layer l, hint the source to read ahead the
+    // experts the previous token used at layers l+1..l+K. 0 (default) disables it.
+    void set_prefetch_layers(int k) { prefetch_layers_ = k; }
+
 private:
     bool on_eval(ggml_tensor * t, bool ask);
 
@@ -56,6 +60,11 @@ private:
     IExpertSource * source_ = nullptr; // non-null → stream mode
     std::vector<LayerExperts> captured_;
     std::vector<int32_t> gathered_; // reused scratch for stream-mode id gather
+
+    // Temporal prefetch: K, and the previous token's routed experts per layer (last-token row
+    // during prefill). Empty when prefetch is off or a layer has not been seen yet.
+    int prefetch_layers_ = 0;
+    std::vector<std::vector<int32_t>> prev_ids_;
 };
 
 } // namespace bmoe

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,13 +70,18 @@ on.
 
 ## The generation loop
 
-`run()` (core/src/engine/runtime.cpp):
+The composition root is `Session` (core/src/engine/session.cpp):
 
-1. Load model (mmap on, repack off, experts on CPU).
-2. If streaming: resolve the architecture recipe, install the router hook, do the capture
-   warm-up, bind the expert source, clear the warm-up KV.
-3. Prefill the prompt, then greedily decode `n_predict` tokens, reporting per-token
-   metrics.
+1. `open()` — load model (mmap on, repack off, experts on CPU); if streaming, resolve the
+   architecture recipe, install the router hook, do the capture warm-up, bind the expert
+   source, clear the warm-up KV. Done **once** per model.
+2. `generate()` — prefill the prompt, then greedily decode `n_predict` tokens, reporting
+   per-token metrics. Callable repeatedly; the expert cache stays warm between calls (see
+   [session.md](session.md)). Cancellable mid-flight via the abort callback.
+3. Destructor — tear down in order: I/O pool, context, hook, model, backend.
+
+`run()` (core/src/engine/runtime.cpp) is a thin one-shot wrapper — open, one generate, close —
+so the gates and the interactive session share the same code path.
 
 Greedy sampling makes the output a deterministic function of the graph — the property the
 [byte-identity gates](../tests/moe_gates.cpp) assert.

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -1,0 +1,50 @@
+# Temporal prefetch
+
+The expert LRU cache is filled reactively: a layer's experts are read only once its router has
+selected them. That leaves the read on the critical path — the first tokens of a generation miss
+often and stall on flash (see [benchmarks.md](benchmarks.md)). Temporal prefetch reads ahead.
+
+## The bet
+
+MoE routing has strong temporal locality: the experts a token selects at layer *l* overlap
+heavily with the experts the **previous** token selected at the same layer. So while a token
+computes layer *l*, we speculatively read — on the otherwise-idle I/O lanes — the experts the
+previous token routed at layers *l+1 … l+K* (`--prefetch K`). A correct guess turns the next
+layer's read into a cache hit; a wrong guess only wastes a read. For the very first generated
+token, the predictor is the last prompt token's routing, recorded during prefill.
+
+`K` is a depth, not a certainty: recall falls as you look further ahead, so small `K` (1–2)
+captures most of the benefit. Prefetch requires the LRU cache (`--cache-mb > 0`); the speculative
+slices land in the per-layer cache buffers.
+
+## How it stays correct and out of the way
+
+The speculative path never delays real work and never changes output:
+
+- **Same bytes.** A speculative read is the *identical* read a real miss would issue — same file
+  offset, same destination buffer (`lbuf_[p][il] + e*slice`). A prefetched expert is therefore
+  bit-for-bit what a real read would produce; a later routing that hits it gets identical bytes.
+  Integration cannot change output by construction. Gates **G5a/b/c** assert this.
+- **One writer of cache state.** All LRU mutation stays on the eval-callback thread.
+  `prefetch()` (eval thread) commits pages and enqueues per-projection reads; **workers only read
+  bytes**; `quiesce_spec()` (eval thread, at the next real `load_layer`) integrates the entries
+  whose every projection finished and releases the rest. No lock on the hot path.
+- **Real work wins.** Workers drain the real batch first and only spend spare capacity on the
+  speculative queue, yielding the instant a real batch appears. At each real load, in-flight
+  speculation is cancelled (its reads disowned) before staging touches the cache, so speculation
+  can never race the reads a token actually depends on, nor hold a page an eviction wants.
+
+Because speculation only pays off when there is real flash latency to hide, it does nothing on a
+fast host with the model in page cache (the reads are cancelled before they start) — which is
+exactly correct. It is measured on-device.
+
+## Telemetry
+
+With `--prefetch K` the summary gains a `moe-prefetch:` line: speculative MiB read this
+generation, and how many prefetched experts a later routing actually used (`useful / prefetched`).
+A low useful rate means the look-ahead is too deep for this model, or the cache is too small to
+hold the speculation alongside the working set.
+
+`--prefetch-sync` (debug) completes speculative reads synchronously on the eval thread — it
+defeats the latency hiding but makes integration deterministic, which the gates use to exercise
+the integrate-then-hit path on a host where the timing race otherwise never fires.

--- a/docs/session.md
+++ b/docs/session.md
@@ -1,0 +1,51 @@
+# Session mode
+
+A fresh `bmoe-cli` process per prompt re-pays two fixed costs every time: the model load (tens
+of seconds for a >RAM model) and the expert-cache warm-up ramp (the LRU cache starts empty, so
+the first tokens miss often and read far more from flash than the steady state — see
+[benchmarks.md](benchmarks.md)). Streaming was meant to avoid exactly this kind of repeated work.
+
+Session mode amortises both. `Session` (`core/include/bmoe/session.h`) loads the model, discovers
+the MoE expert tensors, and initialises the expert source **once**; each `generate()` then runs a
+prompt against that resident state, and the expert LRU cache **survives between calls**, so a
+second prompt starts warm.
+
+```cpp
+std::string err;
+auto s = Session::open(cfg, err);      // model load + capture + source.init — once
+s->generate({.prompt = "..."});        // prefill + decode; cache filled
+s->generate({.prompt = "..."});        // starts warm — no reload, no cold ramp
+```
+
+`run()` (`runtime.h`) is a thin one-shot wrapper over `Session` — open, one generate, close — so
+the byte-identity gates exercise the same machinery an interactive session uses. Gates **S1/S2**
+assert that a second, warm generate produces output identical to the cold one-shot reference:
+warming the cache changes latency, never the bytes.
+
+## Independent prompts vs chat
+
+`GenerateRequest::clear_kv` (default `true`) clears the KV cache before each prompt, so prompts
+are independent while the expert cache stays warm. Setting it `false` continues the KV cache for
+multi-turn chat (the caller renders the running conversation into the prompt). The default keeps
+the two concerns separate: the KV cache is per-conversation, the expert cache is per-model.
+
+## Cancel
+
+`Session::cancel()` is thread-safe and interrupts an in-flight `generate()` at the next decode
+boundary via llama's abort callback (installed unconditionally at open, so it works in serial and
+overlap alike). It leaves the model and cache intact; the returned `RunResult` has `cancelled =
+true`. Cancel is distinct from a fatal streaming error, which is sticky and ends the session.
+
+## Fixed context
+
+`n_ctx` and `n_batch` are baked into the llama context at `open()`, before any prompt is known, so
+size them for the longest prompt + generation the session will serve. A request that would overflow
+`n_ctx` is rejected without tearing the session down.
+
+## CLI and app
+
+`bmoe-cli --session` exposes this over a line protocol (requests on stdin, `BMOE_*` responses on
+stdout — see [telemetry.md](telemetry.md)). The Android example runs one such process per model:
+the first prompt loads the model, later prompts reuse the warm process, and the session is freed on
+an explicit **Unload** or after an idle timeout. Changing the model or any streaming setting
+reopens the session; changing only the prompt, `n_predict`, or the thinking toggle does not.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -70,3 +70,38 @@ mode); `mgmt_ms` is the cache-management time described above. Both are additive
 fewer columns, so consumers must read by column NAME (from the header row) and treat either as
 optional. The `# summary` line likewise gains `stall_s/tok=<s>` and `mgmt_s/tok=<s>` (see the
 `io_ms` note above for how the read-time columns are reinterpreted under overlap).
+
+## Session mode
+
+With `--session`, `bmoe-cli` keeps the model loaded and the expert cache warm across prompts
+instead of exiting after one generation (see [session.md](session.md)). Requests arrive as one
+JSON object per line on **stdin**; responses interleave control lines with the same per-token
+lines above on **stdout**. The control lines are also `BMOE_<TAG> {json}`, so a per-token parser
+extends to them naturally.
+
+Requests (stdin):
+
+```
+{"cmd":"generate","id":<int>,"prompt":"<string>","n_predict":<int>,"think":<bool>,"clear_kv":<bool>}
+{"cmd":"cancel"}          # interrupt the in-flight generation; the session stays loaded
+{"cmd":"close"}           # end the session (EOF on stdin does the same)
+```
+
+`prompt` is JSON-escaped (newlines as `\n`); `n_predict`/`think`/`clear_kv` are optional and
+default to the process's flags / `true`. `cancel` may arrive at any time, including mid-generation.
+
+Responses (stdout):
+
+```
+BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>}          # once, after the model loads
+BMOE_BEGIN {"id":<int>}                                                # a generation started
+BMOE_LOAD / BMOE_PROGRESS ...                                          # per token, as above
+BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
+            "prefill_s":<float>,"load_s":<float>,"cache_hit_pct":<float>,"text":"<string>"}
+BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
+```
+
+`BMOE_DONE` carries the end-of-generation summary (the one-shot mode's `generation:` /
+`moe-stream:` text lines are not emitted in session mode). `BMOE_ERROR` with `fatal:false` is a
+rejected request (e.g. the prompt plus `n_predict` exceeds `n_ctx`) and leaves the session usable;
+`fatal:true` means the process is ending.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -46,6 +46,16 @@ moe-cache: <pct>% hit, resident <mib> MiB
 `compute` in the `moe-stream:` line is the same residual described for `compute_ms` above; `cache
 mgmt` is the per-token mean of `mgmt_ms`.
 
+With `--prefetch K` a `moe-prefetch:` line is added:
+
+```
+moe-prefetch: <mib> MiB speculative, <useful>/<prefetched> experts useful (<pct>%)
+```
+
+`<mib>` is the flash read done speculatively this generation (a subset of the total read),
+`<prefetched>` the experts fully read ahead, and `<useful>` how many of those a later routing
+actually hit. See [prefetch.md](prefetch.md).
+
 Under `--overlap` the `moe-stream:` line additionally reports `stall_s/tok=<s>` — the mean
 wall time per token that compute threads waited for expert reads to complete. It is `0` in
 serial mode (where the read wait is already folded into decode time).

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -14,6 +14,7 @@ data class AppSettings(
     val nPredict: Int = 48,
     val oDirect: Boolean = true, // bypass the page cache
     val overlap: Boolean = false,// prefetch experts while the layer computes (experimental)
+    val prefetchLayers: Int = 0, // temporal prefetch depth K (0 = off); needs the cache
     val thinking: Boolean = false,// reasoning; off passes --no-think (enable_thinking=false)
     val loadAll: Boolean = false,// debug: read ALL experts each token (A/B baseline)
 ) {
@@ -42,6 +43,7 @@ data class AppSettings(
             a += listOf("--io-threads", ioThreads.toString())
             if (!oDirect) a += "--no-odirect"
             if (overlap) a += "--overlap"
+            if (prefetchLayers > 0 && cacheMb > 0) a += listOf("--prefetch", prefetchLayers.toString())
             if (loadAll) a += "--load-all"
         }
         return a
@@ -54,14 +56,15 @@ data class AppSettings(
      * excluded — they vary per request without touching the loaded model.
      */
     fun sessionSignature(modelPath: String): String =
-        listOf(modelPath, mmap, cacheMb, ioThreads, threads, oDirect, overlap, loadAll).joinToString("|")
+        listOf(modelPath, mmap, cacheMb, ioThreads, threads, oDirect, overlap, prefetchLayers, loadAll)
+            .joinToString("|")
 
     fun save(ctx: Context) {
         ctx.prefs().edit()
             .putBoolean("mmap", mmap)
             .putInt("cacheMb", cacheMb).putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
-            .putBoolean("overlap", overlap)
+            .putBoolean("overlap", overlap).putInt("prefetchLayers", prefetchLayers)
             .putBoolean("thinking", thinking).putBoolean("loadAll", loadAll)
             .apply()
     }
@@ -76,6 +79,7 @@ data class AppSettings(
         // thrashes and is slower than no cache — the engine rejects it. Use 0 or >= 2000.
         val CACHE_CHOICES = intArrayOf(0, 2000, 3000, 4000, 5000, 6000)
         val IO_CHOICES = intArrayOf(1, 2, 4, 8)
+        val PREFETCH_CHOICES = intArrayOf(0, 1, 2, 4)
         val THREAD_CHOICES = intArrayOf(2, 4, 6, 8)
         val NPREDICT_CHOICES = intArrayOf(16, 32, 48, 64, 128, 256, 512, 1024, 2048)
 
@@ -90,6 +94,7 @@ data class AppSettings(
                 nPredict = p.getInt("nPredict", d.nPredict),
                 oDirect = p.getBoolean("oDirect", d.oDirect),
                 overlap = p.getBoolean("overlap", d.overlap),
+                prefetchLayers = p.getInt("prefetchLayers", d.prefetchLayers),
                 thinking = p.getBoolean("thinking", d.thinking),
                 loadAll = p.getBoolean("loadAll", d.loadAll),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -18,28 +18,24 @@ data class AppSettings(
     val loadAll: Boolean = false,// debug: read ALL experts each token (A/B baseline)
 ) {
     /**
-     * Build the bmoe-cli argument list. The engine renders the model family's own chat template
-     * via --chatml; reasoning is turned off with --no-think, which the template honours through
-     * its `enable_thinking` kwarg. This is model-agnostic (works for Qwen3 and Gemma alike),
-     * unlike the old Qwen-only /no_think prompt suffix. `arch` is kept for future arch-specific
-     * handling but is no longer needed for the thinking switch.
+     * Build the argv that OPENS a persistent bmoe-cli session (`--session`): everything fixed for
+     * the model's lifetime — model path, compute threads, context, chat template, and the whole
+     * streaming configuration. Per-prompt options (the prompt itself, n_predict, and reasoning)
+     * are NOT here; they travel as JSON requests over stdin, one per generation.
      *
      * When [mmap] is set, expert streaming is turned off entirely: the CLI omits --moe-stream and
      * every streaming knob (cache / lanes / O_DIRECT / overlap / load-all), so llama.cpp loads the
-     * whole model via mmap through the page cache. This is the baseline the streaming modes are
-     * compared against; the prompt/template and compute flags still apply.
+     * whole model via mmap through the page cache — the baseline the streaming modes compare to.
      */
-    fun toArgv(cliPath: String, modelPath: String, prompt: String, arch: String?): List<String> {
+    fun sessionArgv(cliPath: String, modelPath: String): List<String> {
         val a = mutableListOf(
             cliPath,
             "-m", modelPath,
-            "-p", prompt,
-            "-n", nPredict.toString(),
             "-t", threads.toString(),
+            "-c", SESSION_CTX.toString(),
             "--chatml", // apply the model family's chat turn (gemma / chatml)
-            "--progress",
+            "--session",
         )
-        if (!thinking) a += "--no-think"
         if (!mmap) {
             a += "--moe-stream"
             a += listOf("--cache-mb", cacheMb.toString())
@@ -50,6 +46,15 @@ data class AppSettings(
         }
         return a
     }
+
+    /**
+     * Identity of the session these settings would open for [modelPath]. Two settings with the
+     * same signature can reuse one loaded process (keeping the cache warm); a change means the
+     * running session must be torn down and reopened. Per-prompt fields (n_predict, thinking) are
+     * excluded — they vary per request without touching the loaded model.
+     */
+    fun sessionSignature(modelPath: String): String =
+        listOf(modelPath, mmap, cacheMb, ioThreads, threads, oDirect, overlap, loadAll).joinToString("|")
 
     fun save(ctx: Context) {
         ctx.prefs().edit()
@@ -62,6 +67,11 @@ data class AppSettings(
     }
 
     companion object {
+        // Fixed context for a session: sized once at open (no prompt in hand), roomy enough for a
+        // long prompt plus the largest practical generation. A request that would overflow it is
+        // rejected recoverably by the CLI, leaving the session usable.
+        const val SESSION_CTX = 4096
+
         // 1000 is deliberately absent: a budget below the ~1500 MiB pathological band
         // thrashes and is slower than no cache — the engine rejects it. Use 0 or >= 2000.
         val CACHE_CHOICES = intArrayOf(0, 2000, 3000, 4000, 5000, 6000)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -197,23 +197,33 @@ private fun MainScreen(
             Button(
                 onClick = {
                     if (models.isNotEmpty()) {
-                        startRun(context, models[modelIdx.coerceIn(0, models.size - 1)],
-                            prompt.ifBlank { "The capital of Japan is" }, settings)
+                        launchPrompt(context, models[modelIdx.coerceIn(0, models.size - 1)],
+                            prompt.ifBlank { "The capital of Japan is" }, settings, ui.sessionSig)
                     }
                 },
-                enabled = !ui.running && models.isNotEmpty(),
+                enabled = !ui.busy && models.isNotEmpty(),
                 modifier = Modifier.weight(1f),
-            ) { Text("Run") }
+            ) { Text(if (ui.ready) "Send" else "Run") }
 
             OutlinedButton(
                 onClick = {
                     context.startService(
-                        Intent(context, RunService::class.java).setAction(RunService.ACTION_STOP)
+                        Intent(context, RunService::class.java).setAction(RunService.ACTION_CANCEL)
                     )
                 },
-                enabled = ui.running,
+                enabled = ui.generating,
                 modifier = Modifier.weight(1f),
             ) { Text("Stop") }
+        }
+
+        // The session keeps the model resident (and the cache warm) between prompts. Free it
+        // explicitly, or let the service auto-unload after an idle timeout.
+        if (ui.ready || ui.loading) {
+            TextButton(onClick = {
+                context.startService(
+                    Intent(context, RunService::class.java).setAction(RunService.ACTION_SHUTDOWN)
+                )
+            }) { Text("Unload model") }
         }
 
         // A quick reminder of the active config (full controls in Settings).
@@ -426,15 +436,40 @@ private fun MeterRow(label: String, value: Double, total: Double, color: android
     }
 }
 
-private fun startRun(context: android.content.Context, model: File, prompt: String, settings: AppSettings) {
-    // Read the arch (cheap header read) so the CLI applies the right chat template and skips
-    // Qwen-only prompt switches for other families.
-    val arch = GgufHeader.arch(model)
-    val argv = ArrayList(settings.toArgv(ModelManager.cliPath(context), model.absolutePath, prompt, arch))
-    val intent = Intent(context, RunService::class.java)
-        .putExtra(RunService.EXTRA_MODEL, model.absolutePath)
-        .putExtra(RunService.EXTRA_PROMPT, prompt)
-        .putStringArrayListExtra(RunService.EXTRA_ARGV, argv)
-    ContextCompat.startForegroundService(context, intent)
-    RunBus.reset()
+/**
+ * Send [prompt] to the engine. If a session is already loaded for this exact model+settings
+ * ([currentSig] matches), the prompt just goes to the warm process (no reload, cache intact);
+ * otherwise the session is (re)started with this configuration and the prompt runs as soon as it
+ * reports ready. Per-prompt options (n_predict, thinking) ride the request, not the session.
+ */
+private fun launchPrompt(
+    context: android.content.Context,
+    model: File,
+    prompt: String,
+    settings: AppSettings,
+    currentSig: String?,
+) {
+    RunBus.resetGeneration()
+    val sig = settings.sessionSignature(model.absolutePath)
+    if (currentSig == sig) {
+        context.startService(
+            Intent(context, RunService::class.java)
+                .setAction(RunService.ACTION_GENERATE)
+                .putExtra(RunService.EXTRA_PROMPT, prompt)
+                .putExtra(RunService.EXTRA_NPREDICT, settings.nPredict)
+                .putExtra(RunService.EXTRA_THINK, settings.thinking)
+        )
+    } else {
+        val argv = ArrayList(settings.sessionArgv(ModelManager.cliPath(context), model.absolutePath))
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, RunService::class.java)
+                .putExtra(RunService.EXTRA_MODEL, model.absolutePath)
+                .putStringArrayListExtra(RunService.EXTRA_ARGV, argv)
+                .putExtra(RunService.EXTRA_SIG, sig)
+                .putExtra(RunService.EXTRA_PROMPT, prompt)
+                .putExtra(RunService.EXTRA_NPREDICT, settings.nPredict)
+                .putExtra(RunService.EXTRA_THINK, settings.thinking)
+        )
+    }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -5,29 +5,43 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-/** Immutable snapshot of a run, observed by the Compose UI. */
+/**
+ * Where the engine is in its lifecycle. Unlike the old per-run boolean pair, a session process
+ * outlives a single generation: it loads once (LOADING), then sits READY between prompts, and
+ * flips to GENERATING only while a prompt is being answered.
+ */
+enum class EngineState { IDLE, LOADING, READY, GENERATING, ERROR }
+
+/** Immutable snapshot of the session + current generation, observed by the Compose UI. */
 data class UiState(
-    val running: Boolean = false,
-    val loading: Boolean = false, // model started, first token not yet emitted
+    val state: EngineState = EngineState.IDLE,
     val telemetry: Telemetry = Telemetry(),
     val answer: String = "",
     val summary: String = "",
     val error: String? = null,
-    val ioMode: String? = null, // effective read mode reported by the engine (direct / buffered)
-)
+    val ioMode: String? = null,     // effective read mode reported by the engine (direct / buffered)
+    val sessionSig: String? = null, // signature of the loaded session (AppSettings.sessionSignature)
+) {
+    val loading get() = state == EngineState.LOADING
+    val generating get() = state == EngineState.GENERATING
+    val ready get() = state == EngineState.READY
+    val busy get() = state == EngineState.LOADING || state == EngineState.GENERATING
+}
 
 /**
- * Single source of truth shared between the RunService (writer) and the UI (reader).
- * The service pushes updates as CLI output arrives; the UI collects the StateFlow. One
- * generation runs at a time, so a single flow is enough.
+ * Single source of truth shared between the RunService (writer) and the UI (reader). The service
+ * pushes updates as the session process reports progress; the UI collects the StateFlow. One
+ * session at a time, one generation at a time within it, so a single flow is enough.
  */
 object RunBus {
     private val _state = MutableStateFlow(UiState())
     val state: StateFlow<UiState> = _state.asStateFlow()
 
-    fun reset() = _state.update { UiState(running = it.running) }
-    fun setRunning(running: Boolean) =
-        _state.update { it.copy(running = running, loading = if (running) it.loading else false) }
-    fun setLoading(loading: Boolean) = _state.update { it.copy(loading = loading) }
+    /** Reset the per-generation fields for a new prompt, preserving session state and signature. */
+    fun resetGeneration() = _state.update {
+        it.copy(telemetry = Telemetry(), answer = "", summary = "", error = null)
+    }
+
+    fun setState(s: EngineState) = _state.update { it.copy(state = s) }
     fun update(block: (UiState) -> UiState) = _state.update(block)
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -7,58 +7,87 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.os.PowerManager
+import org.json.JSONObject
 import java.io.BufferedReader
+import java.io.BufferedWriter
 import java.io.File
 import java.io.InputStreamReader
+import java.io.OutputStreamWriter
 import kotlin.concurrent.thread
 
 /**
- * Runs bmoe-cli as a foreground service so generation survives screen-off. The CLI is a
- * native executable (shipped as libbmoe-cli.so); we exec it from nativeLibraryDir with
- * LD_LIBRARY_PATH pointed at the bundled libllama/libggml .so files, and stream its
- * stdout into the RunBus for the UI to render.
+ * Hosts ONE persistent bmoe-cli session as a foreground service. The native CLI (shipped as
+ * libbmoe-cli.so) is exec'd once with `--session`; the model load and the expert-cache warm-up
+ * are paid a single time, and every subsequent prompt is sent as a JSON line on the process's
+ * stdin, keeping the cache warm between prompts. Its BMOE_* stdout drives [RunBus].
+ *
+ * Lifecycle: START_SESSION spawns the process (LOADING → READY); GENERATE sends one prompt
+ * (GENERATING → READY); CANCEL interrupts the current generation without unloading; SHUTDOWN (or
+ * an idle timeout) closes the process and frees the model.
  */
 class RunService : Service() {
 
     private val telemetry = TelemetryParser()
-    @Volatile
-    private var proc: Process? = null
-    @Volatile
-    private var wake: PowerManager.WakeLock? = null
+    @Volatile private var proc: Process? = null
+    @Volatile private var procWriter: BufferedWriter? = null
+    @Volatile private var wake: PowerManager.WakeLock? = null
 
-    // Set when the user presses Stop: the CLI is then killed on purpose, so its non-zero
-    // exit code (SIGTERM) must not be surfaced as an error.
-    @Volatile
-    private var stopping = false
+    @Volatile private var sessionSig: String? = null
+    @Volatile private var shuttingDown = false
+    private var nextId = 1
+
+    // A prompt supplied with START_SESSION runs as soon as the process reports READY.
+    @Volatile private var pending: Req? = null
+
+    private val writeLock = Any()
+    private val main = Handler(Looper.getMainLooper())
+    private val idleUnload = Runnable { shutdownSession() }
+
+    private data class Req(val prompt: String, val nPredict: Int, val think: Boolean)
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action == ACTION_STOP) { stopEverything(); return START_NOT_STICKY }
-
-        startForeground(NOTIF_ID, buildNotification("Generating…"))
-
-        val model = intent?.getStringExtra(EXTRA_MODEL) ?: run { finishWithError("no model"); return START_NOT_STICKY }
-        val prompt = intent.getStringExtra(EXTRA_PROMPT) ?: ""
-        val argv = intent.getStringArrayListExtra(EXTRA_ARGV) ?: run { finishWithError("no argv"); return START_NOT_STICKY }
-
-        RunBus.reset()
-        RunBus.setRunning(true)
-        RunBus.setLoading(true) // held until the first token arrives (model load + prompt eval)
-
-        // Reference counting off so a release on an already-released lock is a harmless no-op:
-        // Stop races the reader thread's finally block, and both call releaseWake().
-        wake = (getSystemService(Context.POWER_SERVICE) as PowerManager)
-            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "bmoe:gen")
-            .apply { setReferenceCounted(false); acquire(30 * 60 * 1000L) }
-
-        thread(name = "bmoe-cli") { runCli(argv, model, prompt) }
+        when (intent?.action) {
+            ACTION_GENERATE -> sendGenerate(reqFrom(intent))
+            ACTION_CANCEL -> send("""{"cmd":"cancel"}""")
+            ACTION_SHUTDOWN -> shutdownSession()
+            else -> startSession(intent)
+        }
         return START_NOT_STICKY
     }
 
-    private fun runCli(argv: ArrayList<String>, model: String, prompt: String) {
+    // ── session lifecycle ──
+
+    private fun startSession(intent: Intent?) {
+        val model = intent?.getStringExtra(EXTRA_MODEL) ?: run { fail("no model"); return }
+        val argv = intent.getStringArrayListExtra(EXTRA_ARGV) ?: run { fail("no argv"); return }
+        val sig = intent.getStringExtra(EXTRA_SIG)
+        val req = if (intent.hasExtra(EXTRA_PROMPT)) reqFrom(intent) else null
+
+        // Already running the requested session? Just generate against the warm process.
+        if (proc != null && sig == sessionSig && !shuttingDown) {
+            if (req != null) sendGenerate(req)
+            return
+        }
+        // Different model/settings (or nothing running): tear down and start fresh.
+        killProcess()
+        shuttingDown = false
+        pending = req
+        sessionSig = sig
+        main.removeCallbacks(idleUnload)
+
+        startForeground(NOTIF_ID, buildNotification("Loading model…"))
+        RunBus.update { it.copy(state = EngineState.LOADING, error = null, sessionSig = sig, answer = "", summary = "") }
+
+        thread(name = "bmoe-session") { runSession(argv, model) }
+    }
+
+    private fun runSession(argv: ArrayList<String>, model: String) {
         try {
             val nativeDir = applicationInfo.nativeLibraryDir
             val pb = ProcessBuilder(argv)
@@ -67,18 +96,15 @@ class RunService : Service() {
             pb.directory(File(model).parentFile)
 
             val p = pb.start().also { proc = it }
+            procWriter = BufferedWriter(OutputStreamWriter(p.outputStream))
 
-            // Drain stderr so the CLI never blocks on a full pipe; surface the tail on error.
-            // Wrap in try/catch: Stop calls proc.destroy(), which closes this stream and makes
-            // forEachLine throw. Uncaught here it would kill the whole app process, not just the
-            // CLI — this is the crash the Stop button used to trigger.
+            // Drain stderr; surface the tail on unexpected exit and sniff the effective read mode.
+            // Guarded: killProcess() closes this stream and would otherwise crash the whole app.
             val errTail = StringBuilder()
-            thread(name = "bmoe-cli-err") {
+            thread(name = "bmoe-session-err") {
                 try {
                     BufferedReader(InputStreamReader(p.errorStream)).forEachLine { line ->
                         if (errTail.length < 4000) errTail.append(line).append('\n')
-                        // Surface the engine's effective read mode. The fallback notice (printed
-                        // before the "streaming ON" line) wins, so it is not overwritten after.
                         when {
                             "O_DIRECT returns wrong data" in line ->
                                 RunBus.update { it.copy(ioMode = "buffered (O_DIRECT unsupported on this storage)") }
@@ -92,54 +118,169 @@ class RunService : Service() {
                         }
                     }
                 } catch (_: Throwable) {
-                    // stream closed by destroy() on Stop — nothing to surface.
+                    // stream closed on shutdown — nothing to surface.
                 }
             }
 
             BufferedReader(InputStreamReader(p.inputStream)).useLines { lines ->
-                lines.forEach { line ->
-                    if (telemetry.onLine(line)) {
-                        RunBus.update {
-                            it.copy(
-                                loading = false, // first telemetry line means the model is up
-                                telemetry = telemetry.current.copy(),
-                                summary = telemetry.summary,
-                                answer = telemetry.current.text,
-                            )
-                        }
-                    }
-                }
+                lines.forEach { handleLine(it) }
             }
 
             val code = p.waitFor()
-            if (code != 0 && !stopping) {
+            if (!shuttingDown && code != 0) {
                 RunBus.update {
-                    if (it.error == null) it.copy(error = "bmoe-cli exited $code\n${errTail.takeLast(1200)}") else it
+                    it.copy(state = EngineState.ERROR,
+                        error = if (it.error == null) "bmoe-cli exited $code\n${errTail.takeLast(1200)}" else it.error)
                 }
             }
         } catch (t: Throwable) {
-            if (!stopping) RunBus.update { it.copy(error = t.message ?: t.toString()) }
+            if (!shuttingDown) RunBus.update { it.copy(state = EngineState.ERROR, error = t.message ?: t.toString()) }
         } finally {
-            RunBus.setRunning(false)
             releaseWake()
-            stopForegroundCompat()
-            stopSelf()
+            procWriter = null
+            proc = null
+            if (!shuttingDown) RunBus.update { if (it.state != EngineState.ERROR) it.copy(state = EngineState.IDLE, sessionSig = null) else it.copy(sessionSig = null) }
+            main.post {
+                stopForegroundCompat()
+                stopSelf()
+            }
         }
     }
 
-    private fun finishWithError(msg: String) {
-        RunBus.update { it.copy(error = msg, running = false) }
+    // ── stdout line protocol (docs/telemetry.md) ──
+
+    private fun handleLine(line: String) {
+        val t = line.trim()
+        when {
+            t.startsWith("BMOE_READY ") -> {
+                RunBus.setState(EngineState.READY)
+                main.post { notify("Model ready") }
+                pending?.let { p -> pending = null; sendGenerate(p) } ?: scheduleIdleUnload()
+            }
+            t.startsWith("BMOE_BEGIN ") -> {
+                telemetry.reset()
+                acquireWake()
+                main.removeCallbacks(idleUnload)
+                RunBus.update {
+                    it.copy(state = EngineState.GENERATING, telemetry = telemetry.current.copy(),
+                        answer = "", summary = "", error = null)
+                }
+                main.post { notify("Generating…") }
+            }
+            telemetry.onLine(t) -> RunBus.update {
+                it.copy(telemetry = telemetry.current.copy(), answer = telemetry.current.text)
+            }
+            t.startsWith("BMOE_DONE ") -> onDone(t.removePrefix("BMOE_DONE "))
+            t.startsWith("BMOE_ERROR ") -> onError(t.removePrefix("BMOE_ERROR "))
+        }
+    }
+
+    private fun onDone(json: String) {
+        runCatching {
+            val o = JSONObject(json)
+            val tokens = o.optInt("tokens")
+            val tokS = o.optDouble("tok_s")
+            val hit = o.optDouble("cache_hit_pct", -1.0)
+            val prefill = o.optDouble("prefill_s")
+            val cancelled = o.optBoolean("cancelled")
+            val text = o.optString("text")
+            val summary = buildString {
+                append(String.format(java.util.Locale.US, "generation: %d tokens (%.2f tok/s)", tokens, tokS))
+                if (prefill > 0) append(String.format(java.util.Locale.US, " | prefill %.2fs", prefill))
+                if (hit >= 0) append(String.format(java.util.Locale.US, " | cache %.0f%%", hit))
+                if (cancelled) append(" | cancelled")
+            }
+            val tel = telemetry.current.copy(avgTokensPerSecond = tokS)
+            RunBus.update {
+                it.copy(state = EngineState.READY, telemetry = tel,
+                    answer = if (text.isNotEmpty()) text else it.answer, summary = summary)
+            }
+        }
+        releaseWake()
+        main.post { notify("Model ready") }
+        scheduleIdleUnload()
+    }
+
+    private fun onError(json: String) {
+        val fatal = runCatching { JSONObject(json).optBoolean("fatal", true) }.getOrDefault(true)
+        val msg = runCatching { JSONObject(json).optString("msg") }.getOrDefault("engine error")
+        releaseWake()
+        if (fatal) {
+            RunBus.update { it.copy(state = EngineState.ERROR, error = msg) }
+            shutdownSession()
+        } else {
+            // Bad request (e.g. context overflow): the session stays loaded and usable.
+            RunBus.update { it.copy(state = EngineState.READY, error = msg) }
+            main.post { notify("Model ready") }
+            scheduleIdleUnload()
+        }
+    }
+
+    // ── requests ──
+
+    private fun reqFrom(intent: Intent): Req = Req(
+        prompt = intent.getStringExtra(EXTRA_PROMPT) ?: "",
+        nPredict = intent.getIntExtra(EXTRA_NPREDICT, 48),
+        think = intent.getBooleanExtra(EXTRA_THINK, false),
+    )
+
+    private fun sendGenerate(req: Req) {
+        val id = nextId++
+        val json = buildString {
+            append("""{"cmd":"generate","id":""").append(id)
+            append(""","n_predict":""").append(req.nPredict)
+            append(""","think":""").append(req.think)
+            append(""","clear_kv":true""")
+            append(""","prompt":"""").append(jsonEscape(req.prompt)).append("\"}")
+        }
+        if (!send(json)) fail("session not ready")
+    }
+
+    private fun send(json: String): Boolean = synchronized(writeLock) {
+        val w = procWriter ?: return false
+        return try {
+            w.write(json); w.write("\n"); w.flush(); true
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    // ── teardown ──
+
+    private fun shutdownSession() {
+        shuttingDown = true
+        main.removeCallbacks(idleUnload)
+        send("""{"cmd":"close"}""")
+        // Give the process a moment to exit cleanly on close, then force it.
+        main.postDelayed({ killProcess() }, 1500)
+        RunBus.update { it.copy(state = EngineState.IDLE, sessionSig = null) }
+    }
+
+    private fun killProcess() {
+        synchronized(writeLock) {
+            runCatching { procWriter?.close() }
+            procWriter = null
+        }
+        runCatching { proc?.destroy() }
+        proc = null
+    }
+
+    private fun scheduleIdleUnload() {
+        main.removeCallbacks(idleUnload)
+        main.postDelayed(idleUnload, IDLE_UNLOAD_MS)
+    }
+
+    private fun fail(msg: String) {
+        RunBus.update { it.copy(state = EngineState.ERROR, error = msg) }
         stopForegroundCompat()
         stopSelf()
     }
 
-    private fun stopEverything() {
-        stopping = true
-        proc?.destroy()
-        RunBus.setRunning(false)
-        releaseWake()
-        stopForegroundCompat()
-        stopSelf()
+    private fun acquireWake() {
+        if (wake?.isHeld == true) return
+        wake = (getSystemService(Context.POWER_SERVICE) as PowerManager)
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "bmoe:gen")
+            .apply { setReferenceCounted(false); acquire(30 * 60 * 1000L) }
     }
 
     @Synchronized
@@ -154,7 +295,9 @@ class RunService : Service() {
     }
 
     override fun onDestroy() {
-        proc?.destroy()
+        shuttingDown = true
+        main.removeCallbacks(idleUnload)
+        killProcess()
         releaseWake()
         super.onDestroy()
     }
@@ -174,12 +317,39 @@ class RunService : Service() {
             .build()
     }
 
+    private fun notify(text: String) {
+        (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+            .notify(NOTIF_ID, buildNotification(text))
+    }
+
     companion object {
-        const val ACTION_STOP = "io.bigmoeonedge.example.STOP"
+        const val ACTION_GENERATE = "io.bigmoeonedge.example.GENERATE"
+        const val ACTION_CANCEL = "io.bigmoeonedge.example.CANCEL"
+        const val ACTION_SHUTDOWN = "io.bigmoeonedge.example.SHUTDOWN"
         const val EXTRA_MODEL = "model"
-        const val EXTRA_PROMPT = "prompt"
         const val EXTRA_ARGV = "argv"
+        const val EXTRA_SIG = "sig"
+        const val EXTRA_PROMPT = "prompt"
+        const val EXTRA_NPREDICT = "n_predict"
+        const val EXTRA_THINK = "think"
         private const val CHANNEL = "gen"
         private const val NOTIF_ID = 1
+
+        // Free the model after this long with no generation, so an idle session does not hold
+        // ~model-sized RAM and a foreground service indefinitely. The next prompt reloads.
+        private const val IDLE_UNLOAD_MS = 10 * 60 * 1000L
+
+        private fun jsonEscape(s: String): String {
+            val o = StringBuilder(s.length + 8)
+            for (c in s) when (c) {
+                '"' -> o.append("\\\"")
+                '\\' -> o.append("\\\\")
+                '\n' -> o.append("\\n")
+                '\r' -> o.append("\\r")
+                '\t' -> o.append("\\t")
+                else -> if (c < ' ') o.append(String.format("\\u%04x", c.code)) else o.append(c)
+            }
+            return o.toString()
+        }
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -71,6 +71,16 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     "Prefetch experts while the layer computes (experimental)",
                     current.overlap, enabled = stream,
                 ) { onChange(current.copy(overlap = it)) }
+                IntSetting(
+                    "Temporal prefetch (layers)", AppSettings.PREFETCH_CHOICES, current.prefetchLayers,
+                    format = { if (it == 0) "off" else "$it" },
+                    enabled = stream && current.cacheMb > 0,
+                ) { onChange(current.copy(prefetchLayers = it)) }
+                Text(
+                    "Read the next K layers' likely experts on idle lanes, predicted from the " +
+                        "previous token. Needs the cache on.",
+                    fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
             Section("Compute") {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -20,43 +20,36 @@ data class Telemetry(
 }
 
 /**
- * Incrementally parses the CLI's telemetry contract (see docs/telemetry.md):
+ * Incrementally parses the CLI's per-token telemetry contract (see docs/telemetry.md):
  *   BMOE_LOAD     {"mb":..,"ms":..}
  *   BMOE_PROGRESS {"step":..,"steps":..,"wall_ms":..,"io_ms":..,"compute_ms":..,
  *                  "cache_hit_pct":..,"text":".."}
- * plus the trailing summary lines (generation:/moe-stream:/moe-cache:).
+ *
+ * The session control lines (BMOE_READY/BEGIN/DONE/ERROR) and the one-shot text summary lines
+ * are handled by the RunService state machine, not here.
  */
 class TelemetryParser {
-    val current = Telemetry()
-    var summary: String = ""
+    var current = Telemetry()
         private set
+
+    /** Clear the per-token state at the start of a new generation. */
+    fun reset() {
+        current = Telemetry()
+    }
 
     /** Returns true if [line] updated the token telemetry (UI should refresh). */
     fun onLine(line: String): Boolean {
         val t = line.trim()
-        return when {
-            t.startsWith("BMOE_PROGRESS ") -> {
-                runCatching {
-                    val o = JSONObject(t.removePrefix("BMOE_PROGRESS "))
-                    current.step = o.optInt("step")
-                    current.steps = o.optInt("steps")
-                    current.wallMs = o.optDouble("wall_ms")
-                    current.ioMs = o.optDouble("io_ms")
-                    current.computeMs = o.optDouble("compute_ms")
-                    current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
-                    current.text = o.optString("text")
-                }.isSuccess
-            }
-            t.startsWith("generation:") || t.startsWith("moe-stream:") || t.startsWith("moe-cache:") -> {
-                summary = if (summary.isEmpty()) t else summary + "\n" + t
-                // "generation: N tokens, X s/token (Y tok/s)" — Y is the aggregate average.
-                if (t.startsWith("generation:")) {
-                    Regex("""\(([\d.]+) tok/s\)""").find(t)?.groupValues?.get(1)?.toDoubleOrNull()
-                        ?.let { current.avgTokensPerSecond = it }
-                }
-                true
-            }
-            else -> false
-        }
+        if (!t.startsWith("BMOE_PROGRESS ")) return false
+        return runCatching {
+            val o = JSONObject(t.removePrefix("BMOE_PROGRESS "))
+            current.step = o.optInt("step")
+            current.steps = o.optInt("steps")
+            current.wallMs = o.optDouble("wall_ms")
+            current.ioMs = o.optDouble("io_ms")
+            current.computeMs = o.optDouble("compute_ms")
+            current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
+            current.text = o.optString("text")
+        }.isSuccess
     }
 }

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -10,7 +10,8 @@ import os, sys, statistics
 
 BENCH = sys.argv[1] if len(sys.argv) > 1 else r"C:\Users\raffa\Documents\BigMoeOnEdge\.bench"
 ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4",
-         "stream_ov", "c4000_l4_ov"]
+         "stream_ov", "c2000_l4_ov", "c4000_l4_ov",
+         "c4000_l4_pf1", "c4000_l4_pf2", "c4000_l4_pf4"]
 LABEL = {
     "mmap": "solo mmap (no streaming)",
     "stream": "streaming O_DIRECT, cache 0, lane 4",
@@ -19,7 +20,11 @@ LABEL = {
     "c4000_l2": "streaming + cache 4000 MiB, lane 2",
     "c4000_l4": "streaming + cache 4000 MiB, lane 4",
     "stream_ov": "streaming O_DIRECT + overlap, cache 0, lane 4",
+    "c2000_l4_ov": "streaming + cache 2000 MiB, lane 4, overlap",
     "c4000_l4_ov": "streaming + cache 4000 MiB, lane 4, overlap",
+    "c4000_l4_pf1": "streaming + cache 4000 MiB, lane 4, prefetch 1",
+    "c4000_l4_pf2": "streaming + cache 4000 MiB, lane 4, prefetch 2",
+    "c4000_l4_pf4": "streaming + cache 4000 MiB, lane 4, prefetch 4",
 }
 
 def pct(v, q):

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -18,9 +18,13 @@
 //
 //   S1  two sequential Session generates (warm cache) == one-shot resident, per prompt
 //   S2  same, under overlap
+//   G5  streaming + temporal prefetch == streaming (prefetch changes latency, not bytes)
+//         a) serial + cache + prefetch   b) overlap + cache + prefetch
 //
 // S1/S2 guard the session refactor: the expert LRU cache now survives across generate() calls,
 // so a second prompt starts warm. That must change only latency, never the produced bytes.
+// G5 guards temporal prefetch: speculatively reading the next layers' experts must only warm the
+// cache — the routed slices a token actually consumes, and thus its output, are unchanged.
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
 #include "bmoe/session.h"
@@ -207,6 +211,47 @@ int main(int argc, char ** argv) {
     }
     fails += check("S1a session generate #1 == resident", s_res, s_g1);
     fails += check("S1b session generate #2 (warm cache) == resident", s_res, s_g2);
+
+    // ── G5: temporal prefetch must not change bytes ──
+    // A forced cache (prefetch needs one) plus a couple of look-ahead layers, exercising the
+    // speculative queue, integration and eviction against the plain streamed reference.
+    RunConfig pf = base(model);
+    pf.moe.enabled = true;
+    pf.moe.cache_mb = 2;
+    pf.moe.force_cache = true;
+    pf.moe.io_threads = 4;
+    pf.moe.prefetch_layers = 2;
+    std::string s_pf;
+    if (!gen(pf, s_pf, err)) {
+        std::fprintf(stderr, "prefetch run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("G5a streaming(prefetch) == streaming(cache off)", s_s0, s_pf);
+
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+    RunConfig pf_ov = pf;
+    pf_ov.moe.overlap = true;
+    std::string s_pf_ov;
+    if (!gen(pf_ov, s_pf_ov, err)) {
+        std::fprintf(stderr, "prefetch overlap run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("G5b overlap(prefetch) == streaming(cache off)", s_s0, s_pf_ov);
+#else
+    std::printf("[SKIP] G5b (expert-ready hook not built)\n");
+#endif
+
+    // G5c forces speculative reads to complete synchronously, so the integrate-then-hit path (a
+    // prefetched expert becoming resident and a later routing hitting it) is deterministically
+    // exercised — the timing race in G5a/b rarely reaches it on a fast host.
+    RunConfig pf_sync = pf;
+    pf_sync.moe.prefetch_sync = true;
+    std::string s_pf_sync;
+    if (!gen(pf_sync, s_pf_sync, err)) {
+        std::fprintf(stderr, "prefetch(sync) run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("G5c prefetch(sync integrate+hit) == streaming(cache off)", s_s0, s_pf_sync);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     RunConfig sess_ov = sess;

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -15,10 +15,18 @@
 // If G3 passes, the streamer provably never gathers an unrouted (garbage) slice. If G4
 // passes, the async path gates each expert correctly — compute never races ahead of its read.
 // G4 is compiled only when the fork's expert-ready hook is present (BMOE_HAVE_EXPERT_READY_HOOK).
+//
+//   S1  two sequential Session generates (warm cache) == one-shot resident, per prompt
+//   S2  same, under overlap
+//
+// S1/S2 guard the session refactor: the expert LRU cache now survives across generate() calls,
+// so a second prompt starts warm. That must change only latency, never the produced bytes.
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
+#include "bmoe/session.h"
 
 #include <cstdio>
+#include <memory>
 #include <string>
 
 using namespace bmoe;
@@ -40,6 +48,41 @@ static bool gen(const RunConfig & c, std::string & out, std::string & err) {
         return false;
     }
     out = r.generated_text;
+    return true;
+}
+
+// Open a Session from a RunConfig and generate the same prompt twice. The second generate runs
+// against the cache the first left warm — the whole point of session mode — so its output is the
+// interesting one: it must still match the cold one-shot reference.
+static bool session_two_gens(const RunConfig & c, std::string & out1, std::string & out2, std::string & err) {
+    SessionConfig sc;
+    sc.model_path = c.model_path;
+    sc.n_threads = c.n_threads;
+    sc.n_ctx = c.n_ctx;
+    sc.n_batch = c.n_ctx;
+    sc.chatml = c.chatml;
+    sc.moe = c.moe;
+
+    std::unique_ptr<Session> s = Session::open(sc, err);
+    if (!s) return false;
+
+    GenerateRequest req;
+    req.prompt = c.prompt;
+    req.n_predict = c.n_predict;
+    req.clear_kv = true;
+
+    RunResult r1 = s->generate(req);
+    if (!r1) {
+        err = r1.error;
+        return false;
+    }
+    RunResult r2 = s->generate(req);
+    if (!r2) {
+        err = r2.error;
+        return false;
+    }
+    out1 = r1.generated_text;
+    out2 = r2.generated_text;
     return true;
 }
 
@@ -146,6 +189,37 @@ int main(int argc, char ** argv) {
     fails += check("G4c overlap(io_threads=1) == streaming(cache off)", s_s0, s_ov1);
 #else
     std::printf("[SKIP] G4 (expert-ready hook not built)\n");
+#endif
+
+    // ── S1/S2: warm cache across Session generates must not change bytes ──
+    // A forced small LRU cache so the first generate leaves state (resident + evicted entries)
+    // the second one reuses — exercising the "starts warm" path, not a cold re-run.
+    RunConfig sess = base(model);
+    sess.moe.enabled = true;
+    sess.moe.cache_mb = 2;
+    sess.moe.force_cache = true;
+    sess.moe.io_threads = 4;
+
+    std::string s_g1, s_g2;
+    if (!session_two_gens(sess, s_g1, s_g2, err)) {
+        std::fprintf(stderr, "session run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("S1a session generate #1 == resident", s_res, s_g1);
+    fails += check("S1b session generate #2 (warm cache) == resident", s_res, s_g2);
+
+#ifdef BMOE_HAVE_EXPERT_READY_HOOK
+    RunConfig sess_ov = sess;
+    sess_ov.moe.overlap = true;
+    std::string s_og1, s_og2;
+    if (!session_two_gens(sess_ov, s_og1, s_og2, err)) {
+        std::fprintf(stderr, "session overlap run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("S2a session+overlap generate #1 == resident", s_res, s_og1);
+    fails += check("S2b session+overlap generate #2 (warm cache) == resident", s_res, s_og2);
+#else
+    std::printf("[SKIP] S2 (expert-ready hook not built)\n");
 #endif
 
     if (fails == 0) std::printf("\nall MoE byte-identity gates passed\n");


### PR DESCRIPTION
## What

Adds **temporal prefetch**: on idle I/O lanes, speculatively fetch the *next* layers' experts to hide streaming latency. Exposed as `--prefetch N` and an Android settings row.

## Why

When the cache is small, decode stalls waiting on flash. Prefetching upcoming experts on lanes that would otherwise sit idle can hide some of that latency.

## Measured result — experimental, default off

On the OnePlus 15R (Qwen3-30B / Gemma-4-26B, both > RAM) temporal prefetch is **±1% at steady state**: overlap already hides most read latency and flash is near-saturated, so it neither helps nor hurts decode throughput here (best case ~+0.9% at prefetch 1 with a large cache, near-free). Its likely payoff is cold-start / TTFT, which this campaign did not isolate. Shipped **default `0` (off)** and labelled experimental; kept in-tree so it stays measurable and combinable from the APK.

## Changes

- `expert_stream_source` / `router_hook`: prefetch of next-layer experts on idle lanes, new config flag + telemetry counters.
- G5 byte-identity gates. Android settings row. `docs/prefetch.md`.

Stacked on `feat/session-mode`.
