### PR TITLE
Hybrid attention/SSM MoE recipe + universal armv8.2 APK baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-29 \
             -DCMAKE_BUILD_TYPE=Release -DBMOE_BUILD_TESTS=OFF \
             -DGGML_NATIVE=OFF -DGGML_OPENMP=OFF \
-            -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+i8mm+fp16" \
+            -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" \
             -DLLAMA_CURL=OFF
           cmake --build build-android -j
       - name: Stage engine binaries into jniLibs

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -25,6 +25,14 @@ static const MoeRecipe k_recipes[] = {
      "ffn_gate_inp",
      nullptr,
      RouterPre::kNone},
+    // qwen35moe (Qwen3.5 MoE, e.g. 35B-A3B) is a hybrid attention/SSM stack: some layers run
+    // full attention, others a Mamba-style SSM block, but every MoE layer names its experts
+    // with the standard split suffixes, so streaming is one row. There is also an always-on
+    // shared expert (ffn_*_shexp) that stays mmap-resident and lowers the streamed fraction.
+    // Speculative gating is left unwired (router_input_fmt=nullptr): the observed router-input
+    // node is not uniform across the hybrid layer types, so --spec-gate refuses here rather
+    // than guessing. Basic streaming and the auto cache are unaffected.
+    {"qwen35moe", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}, nullptr, nullptr, nullptr, RouterPre::kNone},
     // gemma4 (Gemma 4 MoE, e.g. 26B-A4B) fuses gate+up into blk.<il>.ffn_gate_up_exps —
     // to the streamer just an expert tensor with a 2x per-expert stride. The per-expert
     // ffn_down_exps.scale, the router (ffn_gate_inp.{weight,scale}) and the always-on


### PR DESCRIPTION
Two independent changes.

## Register a hybrid attention/SSM MoE recipe
One registry row for a MoE family that interleaves full-attention and SSM (Mamba-style) blocks. Its MoE layers name experts with the standard split suffixes, so streaming needs only the row; the always-on shared expert stays mmap-resident and lowers the streamed fraction. Speculative gating is left unwired — the router-input node is not uniform across the hybrid layer types, so `--spec-gate` refuses rather than guess. Validated on device: streamed output is byte-identical to the resident mmap path.

## Universal armv8.2 APK baseline
CI pinned the Android CPU baseline to `armv8.2-a+dotprod+i8mm`, but i8mm is an armv8.6 extension absent on armv8.2 SoCs (2020-era flagships), where the prefill GEMM traps with SIGILL. Dropped i8mm to match the documented baseline in `scripts/build-android.ps1`, so one binary runs across the full device range. Verified on both an armv8.2 SoC and a newer i8mm-capable SoC.