### PR TITLE
feat(moe): register OpenAI gpt-oss (MXFP4, purely routed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- **gpt-oss recipe** (OpenAI MoE, e.g. gpt-oss-20b/120b: 128 experts, top-4): a purely routed
+  MoE registered as a single row with the standard `ffn_{gate,up,down}_exps` split suffixes.
+  Unlike gemma4 it keeps no shared/dense expert resident, so the streamed fraction is as high as
+  qwen3moe's. Weights ship in MXFP4; the streamer is quant-agnostic (the per-expert stride is read
+  from the tensor's `nb[2]`, whatever the block layout), so the native MXFP4 layout needs no special
+  handling and the existing split-layout gate already covers this streaming path. The Android
+  example's active-experts (top-k) dropdown gains 3 and 2, so gpt-oss can be run below its native
+  top-4 to trade quality for a smaller streamed working set.
 - **Speculative gating** (`--spec-gate`, env `BMOE_SPEC_GATE`): predict the next MoE layer's
   experts by running its (tiny, mmap-resident) router on the current layer's hidden state — the
   residual stream changes slowly between layers — and prefetch the top-k. Sharper than temporal

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ model-specific constants in the streaming path. Most llama.cpp MoE models share 
 | `qwen3moe` | Qwen3-30B-A3B and siblings | `ffn_{gate,up,down}_exps` (separate) | Shipped default; validated in the benchmarks below |
 | `qwen2moe` | Qwen2 MoE family | `ffn_{gate,up,down}_exps` (separate) | Same seam as qwen3moe |
 | `gemma4` | Gemma 4 MoE (e.g. 26B-A4B) | `ffn_gate_up_exps` (**fused** gate+up) + `ffn_down_exps` | Fused gate+up = 2× per-expert stride; an always-on dense/shared expert stays mmap-resident, lowering the streamed fraction |
+| `gpt-oss` | OpenAI gpt-oss-20b / 120b | `ffn_{gate,up,down}_exps` (separate) | Purely routed (no resident shared expert → high streamed fraction); MXFP4 weights stream unchanged since the stride is read from `nb[2]`, quant-agnostic |
 
 Run `bmoe-cli --list-archs` to print the compiled-in set.
 

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -47,6 +47,17 @@ static const MoeRecipe k_recipes[] = {
      "ffn_gate_inp",
      "ffn_gate_inp", // the ".scale" tail is added by the capture matcher
      RouterPre::kRmsScaled},
+    // gpt-oss (OpenAI MoE, e.g. gpt-oss-20b/120b: 24/36 layers, 128 experts, top-4) is a purely
+    // routed MoE with the standard split suffixes, so streaming is one row — and, unlike gemma4,
+    // it keeps NO shared/dense expert resident, so the streamed fraction is as high as qwen3moe's.
+    // Its weights ship in MXFP4; the streamer is quant-agnostic (the per-expert stride is read from
+    // the tensor's nb[2], whatever the block layout), so the native MXFP4 layout needs no special
+    // handling and the split-layout gate (qwen3moe) already covers this streaming path.
+    // Speculative gating is left unwired (router_input_fmt=nullptr): gpt-oss's router carries a bias
+    // (ffn_gate_inp.bias) and uses OAI-SwiGLU softmax-weight gating, neither of which the spec-gate
+    // router replay models — so it refuses here rather than mispredicting. Basic streaming and the
+    // auto cache are unaffected.
+    {"gpt-oss", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}, nullptr, nullptr, nullptr, RouterPre::kNone},
 };
 
 static const int k_n_recipes = (int) (sizeof(k_recipes) / sizeof(k_recipes[0]));

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -103,8 +103,8 @@ data class AppSettings(
         // memory pressure on devices where free RAM is tight.
         val CACHE_CEIL_CHOICES = intArrayOf(0, 2000, 3000, 4000, 5000, 6000)
         val IO_CHOICES = intArrayOf(1, 2, 4, 8)
-        // 0 = model default (top-k as trained). 6/4 trade output quality for tok/s (fewer routed experts).
-        val N_EXPERT_CHOICES = intArrayOf(0, 6, 4)
+        // 0 = model default (top-k as trained). 6/4/3/2 trade output quality for tok/s (fewer routed experts).
+        val N_EXPERT_CHOICES = intArrayOf(0, 6, 4, 3, 2)
         val PREFETCH_CHOICES = intArrayOf(0, 1, 2, 4)
         val THREAD_CHOICES = intArrayOf(2, 4, 6, 8)
         val NPREDICT_CHOICES = intArrayOf(16, 32, 48, 64, 128, 256, 512, 1024, 2048)


### PR DESCRIPTION
## What

Adds support for the OpenAI **gpt-oss** family (gpt-oss-20b / 120b) as a single registry row, plus a small settings affordance to route it more cheaply.

- **`arch_registry.cpp`** — one recipe row for `gpt-oss`: standard split expert suffixes
  `ffn_{gate,up,down}_exps`, `RouterPre::kNone`. Purely routed (no resident shared/dense expert),
  so the streamed fraction is as high as `qwen3moe`'s. Weights ship in MXFP4; the streamer is
  quant-agnostic (per-expert stride read from `nb[2]`), so the native block layout needs no special
  handling. Speculative gating is intentionally left unwired — gpt-oss's router carries a bias and
  uses OAI-SwiGLU softmax-weight gating, which the spec-gate replay does not model.
- **README** — new row in the supported-architectures table.
- **Android app** — add `3` and `2` to the active-experts (top-k) dropdown. gpt-oss routes top-4 by
  default, so 4/3/2 give a useful speed/quality sweep on it; the override flows through the existing
  `--n-expert-used` kv_override.

## Why one row is enough

gpt-oss is architecturally closest to `qwen3moe` (routed-only, split experts, no shared expert). Its
distinctive parts — MXFP4 quant, router bias, sliding-window attention, attention sinks, OAI-SwiGLU —
are all outside the expert-streaming seam, so they need no streaming-path changes. The existing
split-layout byte-identity gate (`qwen3moe`) already covers this path.

## Validation

- Host build compiles; `bmoe-cli --list-archs` reports `gpt-oss`; byte-identity gates
  (`moe_gates_qwen3moe` split + `moe_gates_gemma4` fused) pass.
- **On-device**: gpt-oss-120b-Q4_K_M (58 GB) loads and streams on an 11 GB-RAM phone — a model that
  cannot be run at all via plain mmap. Output is coherent. Note it is **compute-bound** at top-4
  (each gpt-oss expert is ~5x a Qwen expert), so decode speed depends heavily on the routing width;
  lowering top-k is the main lever (hence the dropdown addition).