### PR TITLE
feat(android): richer telemetry — prefill, TTFT, streamed MB, cache, temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- **Richer Android telemetry**: the live panel now also shows prefill rate (tok/s), time-to-first-token
+  (model load + prompt prefill), the flash streamed this turn (MB) and the expert-cache footprint
+  (resident/budget MiB), plus a live **device temperature** read from the battery sensor
+  (`BatteryManager`, no permission) as a proxy for thermal headroom under a long generation. The
+  engine already computed the first four; a `read_mib` field was added to the `BMOE_DONE` session
+  line to carry the streamed total (see `docs/telemetry.md`). Temperature is read on the Android side
+  and does not travel through the engine.
 - **gpt-oss recipe** (OpenAI MoE, e.g. gpt-oss-20b/120b: 128 experts, top-4): a purely routed
   MoE registered as a single row with the standard `ffn_{gate,up,down}_exps` split suffixes.
   Unlike gemma4 it keeps no shared/dense expert resident, so the streamed fraction is as high as

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -289,11 +289,11 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink) {
         std::printf("BMOE_DONE {\"id\":%d,\"cancelled\":%s,\"tokens\":%d,\"tok_s\":%.3f,\"prefill_s\":%.3f,"
                     "\"prefill_tps\":%.2f,\"load_s\":%.3f,\"cache_hit_pct\":%.1f,\"n_prompt\":%d,\"n_past\":%d,"
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
-                    "\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"text\":\"%s\"}\n",
+                    "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
-                    s.cache_budget_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
+                    s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
                     json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -115,7 +115,7 @@ BMOE_LOAD / BMOE_PROGRESS ...                                          # per tok
 BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "prefill_s":<float>,"prefill_tps":<float>,"load_s":<float>,"cache_hit_pct":<float>,
             "n_prompt":<int>,"n_past":<int>,"compute_s_tok":<float>,"io_s_tok":<float>,
-            "cache_resident_mib":<float>,"cache_budget_mib":<float>,
+            "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
             "stall_s_tok":<float>,"mgmt_s_tok":<float>,"text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
@@ -126,8 +126,8 @@ prefilled **this turn** (the suffix after any reused KV prefix), and `n_past` is
 length after the turn — so a multi-turn UI can show both per-turn prefill cost and how full the
 context is. `prefill_tps` is the prompt prefill rate; `compute_s_tok`/`io_s_tok` are the per-token
 AVERAGES over the run (so a UI can show an average compute-vs-I/O split, not just the last token).
-`cache_resident_mib`/`cache_budget_mib` track the (possibly auto-adapting) cache, and
-`stall_s_tok`/`mgmt_s_tok` the per-token overlap stall and cache-management cost. `BMOE_ERROR`
-with `fatal:false` is a rejected
+`cache_resident_mib`/`cache_budget_mib` track the (possibly auto-adapting) cache, `read_mib` is the
+total flash streamed this generation, and `stall_s_tok`/`mgmt_s_tok` the per-token overlap stall and
+cache-management cost. `BMOE_ERROR` with `fatal:false` is a rejected
 request (e.g. the prompt plus `n_predict` exceeds `n_ctx`) and leaves the session usable;
 `fatal:true` means the process is ending.

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 5
-        versionName '0.4.0'
+        versionCode 6
+        versionName '0.5.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -489,6 +489,27 @@ private fun TelemetryCard(ui: UiState) {
                 if (ui.ioMode != null) {
                     Text("I/O ${ui.ioMode}", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
+                // Battery temperature — live while generating, a proxy for thermal headroom.
+                ui.batteryTempC?.let {
+                    Text(String.format(Locale.US, "temp %.1f°C", it), fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                // End-of-run figures from the summary: prefill rate, time-to-first-token, the flash
+                // streamed this turn and the cache footprint. Only meaningful once generation finishes.
+                if (done) {
+                    if (t.prefillTps > 0 || t.ttftS >= 0) {
+                        val prefill = if (t.prefillTps > 0) String.format(Locale.US, "prefill %.1f tok/s", t.prefillTps) else ""
+                        val ttft = if (t.ttftS >= 0) String.format(Locale.US, "TTFT %.2fs", t.ttftS) else ""
+                        Text(listOf(prefill, ttft).filter { it.isNotEmpty() }.joinToString("   ·   "), fontSize = 13.sp)
+                    }
+                    if (t.readMib >= 0 || t.cacheResidentMib >= 0) {
+                        val streamed = if (t.readMib >= 0) String.format(Locale.US, "streamed %.0f MB", t.readMib) else ""
+                        val cache = if (t.cacheResidentMib >= 0)
+                            String.format(Locale.US, "cache %.0f/%.0f MiB", t.cacheResidentMib, t.cacheBudgetMib) else ""
+                        Text(listOf(streamed, cache).filter { it.isNotEmpty() }.joinToString("   ·   "),
+                            fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
             } else {
                 Text(
                     "mmap baseline — the model is read through the OS page cache, so per-token flash I/O, " +

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -23,6 +23,7 @@ data class UiState(
     val summary: String = "",
     val error: String? = null,
     val ioMode: String? = null,     // effective read mode reported by the engine (direct / buffered)
+    val batteryTempC: Double? = null, // device battery temperature (°C), sampled while generating
     val sessionSig: String? = null, // signature of the loaded session (AppSettings.sessionSignature)
     val transcript: List<ChatTurn> = emptyList(), // committed turns; the in-flight answer is `answer`
     val streaming: Boolean = true,  // is the loaded session using the MoE streamer (vs mmap baseline)?

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -6,6 +6,8 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
 import android.os.Build
 import android.os.Handler
 import android.os.IBinder
@@ -193,8 +195,11 @@ class RunService : Service() {
                 }
                 main.post { notify("Generating…") }
             }
-            telemetry.onLine(t) -> RunBus.update {
-                it.copy(telemetry = telemetry.current.copy(), answer = telemetry.current.text)
+            telemetry.onLine(t) -> {
+                sampleBatteryTemp()
+                RunBus.update {
+                    it.copy(telemetry = telemetry.current.copy(), answer = telemetry.current.text)
+                }
             }
             t.startsWith("BMOE_DONE ") -> onDone(t.removePrefix("BMOE_DONE "))
             t.startsWith("BMOE_ERROR ") -> onError(t.removePrefix("BMOE_ERROR "))
@@ -212,12 +217,23 @@ class RunService : Service() {
             val nPast = o.optInt("n_past", -1)
             val avgComputeMs = o.optDouble("compute_s_tok", -0.001) * 1000.0
             val avgIoMs = o.optDouble("io_s_tok", -0.001) * 1000.0
+            val prefillTps = o.optDouble("prefill_tps", -1.0)
+            val loadS = o.optDouble("load_s", -1.0)
+            val readMib = o.optDouble("read_mib", -1.0)
+            val cacheResidentMib = o.optDouble("cache_resident_mib", -1.0)
+            val cacheBudgetMib = o.optDouble("cache_budget_mib", -1.0)
+            // Time-to-first-token: the model load plus this turn's prompt prefill.
+            val ttft = if (loadS >= 0 && prefill >= 0) loadS + prefill else -1.0
             val cancelled = o.optBoolean("cancelled")
             val text = o.optString("text")
             val loc = java.util.Locale.US
             val summary = buildString {
                 append(String.format(loc, "generation: %d tokens (%.2f tok/s)", tokens, tokS))
-                if (prefill > 0) append(String.format(loc, " | prefill %.2fs", prefill))
+                if (prefill > 0) {
+                    append(String.format(loc, " | prefill %.2fs", prefill))
+                    if (prefillTps > 0) append(String.format(loc, " (%.1f tok/s)", prefillTps))
+                }
+                if (ttft >= 0) append(String.format(loc, " | TTFT %.2fs", ttft))
                 if (hit >= 0) append(String.format(loc, " | cache %.0f%%", hit))
                 if (cancelled) append(" | cancelled")
             }
@@ -232,7 +248,11 @@ class RunService : Service() {
                 if (hit >= 0) append(String.format(loc, " · cache %.0f%%", hit))
                 if (cancelled) append(" · cancelled")
             }
-            val tel = telemetry.current.copy(avgTokensPerSecond = tokS, avgComputeMs = avgComputeMs, avgIoMs = avgIoMs)
+            val tel = telemetry.current.copy(
+                avgTokensPerSecond = tokS, avgComputeMs = avgComputeMs, avgIoMs = avgIoMs,
+                prefillTps = prefillTps, ttftS = ttft, readMib = readMib,
+                cacheResidentMib = cacheResidentMib, cacheBudgetMib = cacheBudgetMib,
+            )
             RunBus.update {
                 val answer = if (text.isNotEmpty()) text else it.answer
                 // Commit the assistant turn (skip a cancelled empty turn); the user turn was added on send.
@@ -243,10 +263,25 @@ class RunService : Service() {
                     transcript = transcript)
             }
         }
+        sampleBatteryTemp()
         releaseWake()
         inFlightPrompt = ""
         main.post { notify("Model ready") }
         scheduleIdleUnload()
+    }
+
+    /**
+     * Sample the device battery temperature and publish it to [RunBus]. Sourced from the sticky
+     * ACTION_BATTERY_CHANGED broadcast (EXTRA_TEMPERATURE, tenths of a °C) — no permission, available
+     * on every device, and a good proxy for how hot the phone is getting under a long generation. It
+     * does not travel through the engine; it is read here on the Android side while streaming.
+     */
+    private fun sampleBatteryTemp() {
+        val tenths = runCatching {
+            registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+                ?.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, Int.MIN_VALUE) ?: Int.MIN_VALUE
+        }.getOrDefault(Int.MIN_VALUE)
+        if (tenths != Int.MIN_VALUE) RunBus.update { it.copy(batteryTempC = tenths / 10.0) }
     }
 
     private fun onError(json: String) {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -19,6 +19,12 @@ data class Telemetry(
     // the last token's instantaneous [computeMs]/[ioMs]. -1 until generation finishes.
     var avgComputeMs: Double = -1.0,
     var avgIoMs: Double = -1.0,
+    // End-of-run figures from the final summary (BMOE_DONE); -1 / 0 until generation finishes.
+    var prefillTps: Double = -1.0,      // prompt prefill rate (tok/s)
+    var ttftS: Double = -1.0,           // time-to-first-token = model load + prompt prefill (s)
+    var readMib: Double = -1.0,         // total flash streamed this generation (MiB)
+    var cacheResidentMib: Double = -1.0, // expert cache resident size (MiB)
+    var cacheBudgetMib: Double = -1.0,  // current (possibly auto-adapting) cache budget (MiB)
 ) {
     val tokensPerSecond: Double get() = if (wallMs > 0) 1000.0 / wallMs else 0.0
 }


### PR DESCRIPTION
## What

Expands the Android live telemetry panel from *decode tok/s + compute/flash split + cache hit* to also show:

- **prefill rate** (tok/s) and **time-to-first-token** (model load + prompt prefill),
- **flash streamed this turn** (MB) and the **expert-cache footprint** (resident / budget MiB),
- a live **device temperature**, read from the battery sensor as a thermal-headroom proxy under a long generation.

## How

No JNI: the app parses the CLI's `BMOE_*` stdout. Four of the five metrics were **already computed** by the engine and emitted in `BMOE_DONE` — the app simply wasn't reading them. Only the streamed total needed a new field:

- **CLI**: add `read_mib` to the `BMOE_DONE` session line (`s.moe_read_mib`, already computed), documented in `docs/telemetry.md`.
- **Kotlin**: parse `prefill_tps` / `load_s` / `read_mib` / `cache_resident_mib` / `cache_budget_mib` in `RunService.onDone`, carry them on `Telemetry`, and render them in `TelemetryCard`. Prefill rate + TTFT also fold into the per-turn transcript line and the summary.
- **Temperature**: sourced Android-side from the sticky `ACTION_BATTERY_CHANGED` broadcast (`BatteryManager.EXTRA_TEMPERATURE`, tenths of °C) — no permission, universal — and published to `UiState.batteryTempC`. It does **not** travel through the engine.

App bumped to **0.5.0** (versionCode 6).

## Verification

- Host CLI rebuilt; a `--session` smoke run confirms `BMOE_DONE` now carries a well-formed `"read_mib":<float>` (`3.2` observed on the tiny model).
- `./gradlew :app:compileDevDebugKotlin` succeeds.
- On-device validation (panel rendering + temperature rising under load, prefill/TTFT matching the CLI) is pending on a physical device before tagging `v0.5.0`.