### PR TITLE
feat: per-token compute decomposition (CPU occupancy + major faults) and wall-additive Android panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- **Per-token compute decomposition** (`majflt`, `cpu_ms`): the `compute_ms` residual silently
+  absorbed page-fault stalls and scheduler idle, so a large "compute" figure could mean genuine
+  matmul, a dense-weight fault storm on a >RAM model, or a throttled CPU — indistinguishable. Two
+  directly-measured counters now decompose it, sampled around `llama_decode` with no submodule
+  patch: `majflt` (major page faults this token — a mmap-resident dense weight re-faulted from flash
+  *inside* the decode) and `cpu_ms` (CPU time summed across threads; divided by wall×threads it gives
+  occupancy — near 100 % is compute-bound, well below flags a throttled or preempted core). Surfaced
+  per token in `BMOE_PROGRESS`, as run averages in `BMOE_DONE`, as `majflt`/`cpu_ms` CSV columns and
+  `majflt/tok`/`cpu_s/tok` summary keys, and as a `compute:` line in the one-shot summary. Both read
+  `0` where the platform cannot measure them (the Windows host build). `docs/telemetry.md` also now
+  documents why `stall_ms` has a structural floor above zero (the router-to-fetch dependency). See
+  `docs/telemetry.md`.
+- **Wall-additive Android telemetry panel**: the decode meters now show the three terms that *sum to*
+  the token's wall time — `compute`, `flash wait` (the read time overlap could not hide) and `cache
+  mgmt` — under a `<ms>/token → <tok/s>` headline, so the rate is read directly instead of being
+  reconciled from a compute residual against a parallel, overlapped flash-I/O figure. A diagnostic
+  line reports CPU occupancy, major faults/token and cache hit; raw byte throughput moves to a
+  secondary line. The summary token count now reflects tokens actually generated, not the `n_predict`
+  target. Backed by new `mgmt_ms`/`majflt`/`cpu_ms` fields on the session telemetry lines.
 - **Direct answers on gpt-oss (`--no-think`)**: the harmony chat template always opens an
   `analysis` (chain-of-thought) channel, so `--no-think` previously had no visible effect on
   gpt-oss — the model still reasoned before answering. It now primes the `final` channel directly

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -258,9 +258,10 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink) {
                 std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
             std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
                         "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
-                        "\"cache_hit_pct\":%.1f,\"text\":\"%s\"}\n",
+                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"text\":\"%s\"}\n",
                         m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
-                        m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, json_escape(m.text).c_str());
+                        m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
+                        json_escape(m.text).c_str());
             std::fflush(stdout);
         };
 
@@ -289,12 +290,13 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink) {
         std::printf("BMOE_DONE {\"id\":%d,\"cancelled\":%s,\"tokens\":%d,\"tok_s\":%.3f,\"prefill_s\":%.3f,"
                     "\"prefill_tps\":%.2f,\"load_s\":%.3f,\"cache_hit_pct\":%.1f,\"n_prompt\":%d,\"n_past\":%d,"
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
-                    "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"text\":\"%s\"}\n",
+                    "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"majflt_tok\":%.2f,\"cpu_s_tok\":%.4f,"
+                    "\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
-                    json_escape(r.generated_text).c_str());
+                    s.majflt_per_token, s.cpu_s_per_token, json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
 
@@ -460,9 +462,10 @@ int main(int argc, char ** argv) {
                 std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
             std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
                         "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
-                        "\"cache_hit_pct\":%.1f,\"text\":\"%s\"}\n",
+                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"text\":\"%s\"}\n",
                         m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
-                        m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, json_escape(m.text).c_str());
+                        m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
+                        json_escape(m.text).c_str());
             std::fflush(stdout);
         } else {
             std::fwrite(m.piece.data(), 1, m.piece.size(), stdout);
@@ -484,6 +487,16 @@ int main(int argc, char ** argv) {
     }
     std::printf("generation: %d tokens, %.3f s/token (%.3f tok/s)\n", s.n_generated, s.s_per_token,
                 s.tokens_per_second);
+    // Compute decomposition (0 s/tok CPU means the platform couldn't measure it — Windows host).
+    // occupancy = CPU-time ÷ (wall × threads): ~1 is compute-bound, well under 1 is a throttled or
+    // preempted core; major faults/token > 0 means dense weights re-faulted from flash inside decode.
+    if (s.cpu_s_per_token > 0.0 || s.majflt_per_token > 0.0) {
+        const double occ = s.s_per_token > 0 && cfg.n_threads > 0
+                               ? s.cpu_s_per_token / (s.s_per_token * cfg.n_threads)
+                               : 0.0;
+        std::printf("compute: %.1f%% CPU occupancy (%.4f cpu-s/token over %d threads), %.2f major faults/token\n",
+                    occ * 100.0, s.cpu_s_per_token, cfg.n_threads, s.majflt_per_token);
+    }
     if (s.n_prompt > 0) {
         double prefill_tps = s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0;
         std::printf("prefill: %d tokens, %.3f s (%.1f tok/s) | model load %.3f s | TTFT %.3f s\n", s.n_prompt,

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -21,6 +21,12 @@ struct TokenMetrics {
     double stall_ms = 0.0;      // overlap only: wall time the FFN kernel blocked on flash (0 when serial)
     uint64_t read_bytes = 0;    // expert bytes pulled from flash this token
     double cache_hit_pct = 0.0; // cumulative cache hit rate (-1 if no cache)
+    // Compute-decomposition counters, measured around llama_decode (0 if the platform can't report
+    // them). They tell WHY a token's compute residual is large: major faults = dense weight re-read
+    // from flash inside the decode; cpu_ms vs wall_ms×threads = how CPU-bound the decode really was
+    // (low occupancy ⇒ throttled/preempted, not heavy math). See docs/telemetry.md.
+    uint64_t majflt = 0;        // major page faults during this decode (backing-store reads)
+    double cpu_ms = 0.0;        // CPU time summed across all threads during this decode
     std::string piece;          // text of just this token (delta, for inline streaming)
     std::string text;           // full generated text so far (for UI streaming)
 };
@@ -48,6 +54,13 @@ struct RunSummary {
     double moe_mgmt_s_per_token = 0.0;  // cache-management time per token (commit + evict + LRU)
     double moe_stall_s_per_token = 0.0; // overlap only: per-token wall the kernel waited on flash
     double cache_hit_pct = -1.0;        // -1 when no cache
+
+    // Compute decomposition, generation phase only (measured whether or not streaming is on, since
+    // dense-weight faults appear in the mmap baseline too). majflt_per_token ≫ 0 flags a residency
+    // stall hiding in "compute"; cpu_util = cpu_s/token ÷ (s/token × threads) near 1 is compute-bound,
+    // well below 1 is a throttled/preempted core. 0 when the platform can't measure them.
+    double majflt_per_token = 0.0;
+    double cpu_s_per_token = 0.0;
     double cache_resident_mib = 0.0;
     double cache_budget_mib = 0.0; // current cache budget (moves under --cache-mb auto)
     long long cache_resizes = 0;   // runtime budget changes (0 unless auto/explicit resize)

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -3,6 +3,7 @@
 #include "../moe/router_hook.h"
 #include "../moe/expert_stream_source.h"
 #include "../moe/gguf_offsets.h"
+#include "../io/platform_io.h"
 
 #include "llama.h"
 #include "ggml.h"
@@ -463,6 +464,8 @@ RunResult Session::generate(const GenerateRequest & req,
     double gen_io_seconds = 0.0;
     double gen_mgmt_seconds = 0.0;
     double gen_stall_seconds = 0.0;
+    uint64_t gen_majflt = 0;
+    double gen_cpu_seconds = 0.0;
 
     for (int t = 0; t < req.n_predict; ++t) {
         llama_token tok = argmax(logits, im.n_vocab);
@@ -473,10 +476,16 @@ RunResult Session::generate(const GenerateRequest & req,
         std::string delta = np > 0 ? std::string(piece, np) : std::string();
         gen += delta;
 
+        // Bracket ONLY the decode: major faults and CPU-time deltas here decompose this token's
+        // compute residual into flash-fault stalls vs. genuine (or throttled) computation.
+        const uint64_t f0 = pio::major_faults();
+        const double c0 = pio::process_cpu_seconds();
         auto s0 = clock_t_::now();
         llama_batch step = llama_batch_get_one(&tok, 1);
         int dec = llama_decode(ctx, step);
         auto s1 = clock_t_::now();
+        const uint64_t f1 = pio::major_faults();
+        const double c1 = pio::process_cpu_seconds();
         if (dec != 0) {
             if (im.cancel_requested.load(std::memory_order_relaxed)) {
                 res.cancelled = true;
@@ -498,6 +507,12 @@ RunResult Session::generate(const GenerateRequest & req,
         m.wall_ms = wall * 1000.0;
         m.piece = delta;
         m.text = shown_text(gen, /*partial*/ true);
+        // Fault/CPU decomposition is independent of streaming — dense-weight faults show up in the
+        // mmap baseline too — so record it for every token before the moe/no-moe split below.
+        m.majflt = f1 - f0;
+        m.cpu_ms = (c1 - c0) * 1000.0;
+        gen_majflt += m.majflt;
+        gen_cpu_seconds += (c1 - c0);
         if (moe.enabled) {
             IExpertSource::Stats st = im.source.stats();
             m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
@@ -537,6 +552,8 @@ RunResult Session::generate(const GenerateRequest & req,
     s.n_past = chat_on ? (int) im.kv_tokens.size() : n_prompt + n_gen; // total context length now
     s.load_seconds = im.load_seconds;
     s.prefill_seconds = prefill_seconds;
+    s.majflt_per_token = n_gen ? (double) gen_majflt / n_gen : 0.0;
+    s.cpu_s_per_token = n_gen ? gen_cpu_seconds / n_gen : 0.0;
     if (moe.enabled) {
         IExpertSource::Stats st = im.source.stats();
         s.moe_read_mib = gen_read_bytes / (1024.0 * 1024.0);

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -13,6 +13,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <sys/mman.h>
+#include <sys/resource.h>
+#include <ctime>
 #ifndef O_DIRECT
 #define O_DIRECT 0
 #endif
@@ -91,6 +93,16 @@ uint64_t mem_available_bytes() {
     return GlobalMemoryStatusEx(&ms) ? (uint64_t) ms.ullAvailPhys : 0;
 }
 
+// The host build exists for the byte-identity gates, not perf measurement, so these stay
+// unmeasured (0) rather than pulling in the imperfect Windows equivalents (PageFaultCount counts
+// soft faults too; GetProcessTimes would work but there is no consumer for it here).
+uint64_t major_faults() {
+    return 0;
+}
+double process_cpu_seconds() {
+    return 0.0;
+}
+
 #else
 
 const fd_t fd_invalid = -1;
@@ -164,6 +176,23 @@ uint64_t mem_available_bytes() {
     if (pages > 0 && ps > 0) return (uint64_t) pages * (uint64_t) ps;
 #endif
     return 0;
+}
+
+uint64_t major_faults() {
+    // ru_majflt counts faults that required a backing-store read (the ones that stall on flash).
+    // RUSAGE_SELF aggregates every thread of the process, matching the multi-threaded decode.
+    struct rusage ru;
+    return getrusage(RUSAGE_SELF, &ru) == 0 ? (uint64_t) ru.ru_majflt : 0;
+}
+
+double process_cpu_seconds() {
+    // Total CPU consumed across all threads. Divided by wall×threads downstream, this is the
+    // occupancy signal that tells a frequency cap / preemption apart from genuine heavy compute.
+#if defined(CLOCK_PROCESS_CPUTIME_ID)
+    struct timespec ts;
+    if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == 0) return (double) ts.tv_sec + ts.tv_nsec * 1e-9;
+#endif
+    return 0.0;
 }
 
 #endif

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -52,4 +52,19 @@ void vm_release(void * p, size_t sz);
 // expert cache to the device (--cache-mb auto) and to shrink it under memory pressure at runtime.
 uint64_t mem_available_bytes();
 
+// Process-wide compute-decomposition counters, cumulative since process start; the caller deltas
+// them across a single decode to split the per-token "compute" residual into its real causes.
+// Both return 0 when the platform cannot report them (Windows host build), which the metrics treat
+// as "unmeasured" rather than "zero work".
+//
+//   * major_faults(): hard page faults served from backing store (getrusage ru_majflt). A non-zero
+//     per-token delta means a mmap-resident weight was re-faulted from flash *inside* the decode —
+//     the >RAM residency stall that would otherwise masquerade as compute.
+//   * process_cpu_seconds(): CPU time summed across all threads (CLOCK_PROCESS_CPUTIME_ID). Compared
+//     against wall×threads it reveals occupancy: cpu≈wall×threads is genuine compute-bound work;
+//     cpu≪wall×threads means the threads were descheduled or blocked (frequency cap, preemption,
+//     fault wait) rather than computing.
+uint64_t major_faults();
+double process_cpu_seconds();
+
 } // namespace bmoe::pio

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -10,16 +10,19 @@ class CsvMetricsSink final : public IMetricsSink {
 public:
     explicit CsvMetricsSink(std::FILE * f) : f_(f) {
         // New columns are appended LAST so existing positional parsers stay valid: stall_ms (0 when
-        // serial), then mgmt_ms (cache-management time split out of the compute residual).
-        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms\n");
+        // serial), mgmt_ms (cache-management split out of the compute residual), then majflt/cpu_ms
+        // (the fault + CPU-time decomposition of what remains of "compute").
+        std::fprintf(f_,
+                     "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms\n");
     }
     ~CsvMetricsSink() override {
         if (f_) std::fclose(f_);
     }
 
     void on_token(const TokenMetrics & m) override {
-        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f\n", m.step, m.steps, m.wall_ms, m.io_ms,
-                     m.compute_ms, (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms, m.mgmt_ms);
+        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f\n", m.step, m.steps, m.wall_ms, m.io_ms,
+                     m.compute_ms, (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms, m.mgmt_ms,
+                     (unsigned long long) m.majflt, m.cpu_ms);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -30,12 +33,14 @@ public:
                      "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f "
                      "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
-                     "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld\n",
+                     "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
+                     "majflt/tok=%.2f cpu_s/tok=%.4f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
-                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful);
+                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful,
+                     s.majflt_per_token, s.cpu_s_per_token);
         std::fflush(f_);
     }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -11,7 +11,7 @@ Emitted once per generated token, in order:
 BMOE_LOAD {"mb":<float>,"ms":<float>}
 BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
                "compute_ms":<float>,"mgmt_ms":<float>,"stall_ms":<float>,"read_mb":<float>,
-               "cache_hit_pct":<float>,"text":"<string>"}
+               "cache_hit_pct":<float>,"majflt":<int>,"cpu_ms":<float>,"text":"<string>"}
 ```
 
 - `BMOE_LOAD` appears only when experts were read this token; `mb` is the flash bytes read,
@@ -27,12 +27,30 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
   `--overlap` its meaning changes: it is the **sum of per-lane busy time**, so it can exceed
   `wall_ms` because lanes read in parallel with compute. Use `stall_ms` for the wall time
   compute actually lost to reads under overlap.
+  - **`stall_ms` has a structural floor above zero** — overlap cannot hide *all* flash. Which experts
+    a token needs is only known once the router gate runs, immediately before the FFN consumes them,
+    so on a cache miss the first missed expert's read is issued *after* routing and the FFN waits for
+    it (overlap still hides experts 2…k of that layer behind expert 1's compute). The residual stall
+    therefore tracks the miss rate: it approaches zero only at ~100 % cache hit (the whole expert set
+    resident, i.e. no streaming) or with perfect speculative `--prefetch`. Empirically it never
+    reaches zero — measured per-token minimum ≈ 5–15 ms at 76–81 % hit (Qwen/Gemma), rising to
+    hundreds of ms at 12–18 % hit (gpt-oss). A run that reads as "compute-bound" once warm is the
+    *expected* success case: streaming has hidden the bulk of I/O, leaving compute as the bottleneck.
 - `mgmt_ms` (not emitted in the JSON, but folded into the `compute_ms` residual above and written
   to the CSV) is the cache-management time this token: virtual-memory commit of newly cached
   pages, eviction of cold pages, and the LRU bookkeeping. On the first few tokens after prefill it
   can be a large share of the token; at steady state it is near zero. Surfacing it stops the "all
   compute" reading on warm-up tokens where the real cost is cache churn, not matmul.
 - `cache_hit_pct` is the cumulative cache hit rate, or `-1` when no cache is used.
+- `majflt` / `cpu_ms` **decompose the `compute_ms` residual** — the whole point being that "compute"
+  above is a catch-all that silently absorbs page faults and scheduler stalls, not just matmul.
+  They are measured directly around `llama_decode` (no submodule patch needed): `majflt` is the
+  major page faults served this token — a non-zero count means a mmap-resident (dense) weight was
+  re-faulted from flash *inside* the decode, i.e. a >RAM residency stall masquerading as compute.
+  `cpu_ms` is CPU time summed across all threads; compare it to `wall_ms × threads` for occupancy —
+  near 100% is genuinely compute-bound, well below means the cores were throttled, preempted, or
+  blocked (a low-clock frequency cap or a co-resident process), not doing more math. Both are `0`
+  when the platform can't report them (the Windows host build); treat `0` as "unmeasured".
 - `text` is the full generated text so far, JSON-escaped (for streaming into a UI).
 
 ## End-of-run lines
@@ -42,9 +60,15 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
 <full generated text>
 === perf ===
 generation: <n> tokens, <s> s/token (<t> tok/s)
+compute: <pct>% CPU occupancy (<c> cpu-s/token over <n> threads), <f> major faults/token
 moe-stream: read <mib> MiB (<mib/tok> MiB/token), decode <s> s/token (compute <c> + cache mgmt <m> + flash I/O <i> s/token, <bw> MiB/s)
 moe-cache: <pct>% hit, resident <mib> MiB
 ```
+
+The `compute:` line decomposes the residual: low CPU occupancy points at a throttled/preempted
+core (a frequency cap, a co-resident process) rather than heavy math, and non-zero major
+faults/token means dense weights were re-faulting from flash inside the decode. It is omitted on
+platforms that can't measure it (the Windows host build).
 
 `compute` in the `moe-stream:` line is the same residual described for `compute_ms` above; `cache
 mgmt` is the per-token mean of `mgmt_ms`.
@@ -72,17 +96,19 @@ prints just the summary lines.
 `--csv PATH` additionally writes one row per token:
 
 ```
-step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms
+step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
 
-`stall_ms` and `mgmt_ms` are trailing columns appended (in that order) after the original seven.
-`stall_ms` is the wall time compute threads waited for expert reads that token (`0` in serial
-mode); `mgmt_ms` is the cache-management time described above. Both are additive: older CSVs have
-fewer columns, so consumers must read by column NAME (from the header row) and treat either as
-optional. The `# summary` line likewise gains `stall_s/tok=<s>` and `mgmt_s/tok=<s>` (see the
-`io_ms` note above for how the read-time columns are reinterpreted under overlap).
+`stall_ms`, `mgmt_ms`, `majflt` and `cpu_ms` are trailing columns appended (in that order) after
+the original seven. `stall_ms` is the wall time compute threads waited for expert reads that token
+(`0` in serial mode); `mgmt_ms` is the cache-management time described above; `majflt`/`cpu_ms` are
+the fault + CPU-time decomposition of the compute residual (see the `BMOE_PROGRESS` notes above),
+`0` when unmeasured. All are additive: older CSVs have fewer columns, so consumers must read by
+column NAME (from the header row) and treat any as optional. The `# summary` line likewise gains
+`stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>` and `cpu_s/tok=<s>` (see the `io_ms` note
+above for how the read-time columns are reinterpreted under overlap).
 
 ## Session mode
 
@@ -116,7 +142,8 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "prefill_s":<float>,"prefill_tps":<float>,"load_s":<float>,"cache_hit_pct":<float>,
             "n_prompt":<int>,"n_past":<int>,"compute_s_tok":<float>,"io_s_tok":<float>,
             "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
-            "stall_s_tok":<float>,"mgmt_s_tok":<float>,"text":"<string>"}
+            "stall_s_tok":<float>,"mgmt_s_tok":<float>,"majflt_tok":<float>,"cpu_s_tok":<float>,
+            "text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
 

--- a/docs/warmup-analysis.md
+++ b/docs/warmup-analysis.md
@@ -33,12 +33,14 @@ Per-token CSV schema (one row per generated token):
 | column | meaning |
 |---|---|
 | `wall_ms` | real time for this token — the number that becomes tok/s (`1000 / wall_ms`) |
-| `compute_ms` | FFN + attention compute; **absorbs synchronous page-fault stalls** on resident weights |
+| `compute_ms` | FFN + attention compute; **absorbs synchronous page-fault stalls** on resident weights (a residual — `majflt`/`cpu_ms` below tell you which) |
 | `io_ms` | expert flash-read time, summed across the read lanes (so it can exceed `wall_ms` when overlapped) |
 | `read_bytes` | expert bytes streamed from flash this token |
 | `cache_hit_pct` | running LRU expert-cache hit rate |
 | `stall_ms` | residual flash wait not hidden by overlap |
 | `mgmt_ms` | cache bookkeeping (eviction/admission) |
+| `majflt` | major page faults this token — non-zero means dense weights re-faulted from flash *inside* the decode (the Regime 2 stall, made explicit instead of hiding in `compute_ms`) |
+| `cpu_ms` | CPU time summed across threads; `cpu_ms / (wall_ms × threads)` is occupancy — near 1 is compute-bound, well below flags a throttled/preempted core |
 
 ## Regime 1 — models near RAM: I/O-bound warm-up
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -269,7 +269,7 @@ private fun MainScreen(
                     }
                 }
 
-                TelemetryCard(ui)
+                TelemetryCard(ui, settings.threads)
             }
         }
 
@@ -448,7 +448,7 @@ private fun AddModelSection(onModelReady: () -> Unit) {
 }
 
 @Composable
-private fun TelemetryCard(ui: UiState) {
+private fun TelemetryCard(ui: UiState, threads: Int) {
     ElevatedCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             if (ui.error != null) {
@@ -468,7 +468,9 @@ private fun TelemetryCard(ui: UiState) {
             val done = t.avgTokensPerSecond > 0
             Text(
                 if (done) {
-                    String.format(Locale.US, "%.2f tok/s   avg (%d tokens)", t.avgTokensPerSecond, t.steps)
+                    // t.step is the last token's 1-based index = tokens actually generated (which can be
+                    // < t.steps, the n_predict target, when the model stops early on an end-of-text token).
+                    String.format(Locale.US, "%.2f tok/s   avg (%d tokens)", t.avgTokensPerSecond, t.step)
                 } else {
                     String.format(Locale.US, "%.2f tok/s   (token %d/%d)", t.tokensPerSecond, t.step, t.steps)
                 },
@@ -478,14 +480,47 @@ private fun TelemetryCard(ui: UiState) {
                 // The compute-vs-flash split and cache hit rate only mean anything with the streamer
                 // running. Under mmap the model faults in through the OS page cache, invisible here.
                 // Once done, show the per-token AVERAGE split; while generating, the live last token.
-                val useAvg = done && t.avgComputeMs >= 0 && t.avgIoMs >= 0
-                val compute = if (useAvg) t.avgComputeMs else t.computeMs
-                val io = if (useAvg) t.avgIoMs else t.ioMs
+                val useAvg = done && t.avgComputeMs >= 0
                 val suffix = if (useAvg) " avg" else ""
-                val hit = if (t.cacheHitPct >= 0) String.format(Locale.US, "%.0f%%", t.cacheHitPct) else "—"
-                MeterRow("compute$suffix", compute, compute + io, MaterialTheme.colorScheme.primary)
-                MeterRow("flash I/O$suffix", io, compute + io, MaterialTheme.colorScheme.tertiary)
-                Text("cache hit $hit", fontSize = 13.sp)
+                // The wall-additive breakdown: by the engine's own definition compute = wall − flash-wait
+                // − mgmt, so these three SUM to the token's wall time. That makes tok/s = 1000 / wall
+                // directly readable off the bars, instead of asking the user to reconcile a compute
+                // residual with a parallel (overlapped) flash-I/O figure that isn't a wall component.
+                val compute = if (useAvg) t.avgComputeMs else t.computeMs
+                val mgmt = if (useAvg) t.avgMgmtMs.coerceAtLeast(0.0) else t.mgmtMs
+                val wall = if (useAvg) (if (t.avgTokensPerSecond > 0) 1000.0 / t.avgTokensPerSecond else 0.0)
+                           else t.wallMs
+                // Flash wait = wall not spent computing or bookkeeping: the read time overlap couldn't
+                // hide (a stall under --overlap, the whole blocking read in serial mode).
+                val flashWait = (wall - compute - mgmt).coerceAtLeast(0.0)
+                val total = if (wall > 0.0) wall else (compute + flashWait + mgmt)
+
+                // Headline: token time and its inverse, so no mental arithmetic to get tok/s.
+                if (wall > 0.0) {
+                    Text(String.format(Locale.US, "%.0f ms/token  →  %.2f tok/s", wall, 1000.0 / wall),
+                        fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+                }
+                MeterRow("compute$suffix", compute, total, MaterialTheme.colorScheme.primary)
+                MeterRow("flash wait$suffix", flashWait, total, MaterialTheme.colorScheme.tertiary)
+                MeterRow("cache mgmt$suffix", mgmt, total, MaterialTheme.colorScheme.secondary)
+
+                // Diagnostic line: WHY compute is what it is, plus cache hit. CPU occupancy = CPU-time ÷
+                // (wall × threads); near 100% is genuinely compute-bound, well below means a throttled/
+                // preempted core (a frequency cap, a co-resident process). Major faults/token > 0 means
+                // dense weights re-faulted from flash inside the decode. Both 0 ⇒ engine couldn't measure.
+                val useAvgCpu = useAvg && t.avgCpuSPerTok >= 0
+                val cpuSTok = if (useAvgCpu) t.avgCpuSPerTok else t.cpuMs / 1000.0
+                val faults = if (useAvgCpu) t.avgMajfltPerTok else t.majflt
+                val hit = if (t.cacheHitPct >= 0) String.format(Locale.US, "hit %.0f%%", t.cacheHitPct) else "hit —"
+                val diag = buildString {
+                    if (cpuSTok > 0.0 && wall > 0.0 && threads > 0) {
+                        append(String.format(Locale.US, "CPU %.0f%% busy", cpuSTok / (wall / 1000.0 * threads) * 100.0))
+                        if (faults >= 0.0) append(String.format(Locale.US, "  ·  %.0f faults/tok", faults))
+                        append("  ·  ")
+                    }
+                    append(hit)
+                }
+                Text(diag, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 if (ui.ioMode != null) {
                     Text("I/O ${ui.ioMode}", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -220,11 +220,14 @@ class RunService : Service() {
             val nPast = o.optInt("n_past", -1)
             val avgComputeMs = o.optDouble("compute_s_tok", -0.001) * 1000.0
             val avgIoMs = o.optDouble("io_s_tok", -0.001) * 1000.0
+            val avgMgmtMs = o.optDouble("mgmt_s_tok", -0.001) * 1000.0
             val prefillTps = o.optDouble("prefill_tps", -1.0)
             val loadS = o.optDouble("load_s", -1.0)
             val readMib = o.optDouble("read_mib", -1.0)
             val cacheResidentMib = o.optDouble("cache_resident_mib", -1.0)
             val cacheBudgetMib = o.optDouble("cache_budget_mib", -1.0)
+            val majfltPerTok = o.optDouble("majflt_tok", -1.0)
+            val cpuSPerTok = o.optDouble("cpu_s_tok", -1.0)
             // Time-to-first-token: the model load plus this turn's prompt prefill.
             val ttft = if (loadS >= 0 && prefill >= 0) loadS + prefill else -1.0
             val cancelled = o.optBoolean("cancelled")
@@ -253,8 +256,10 @@ class RunService : Service() {
             }
             val tel = telemetry.current.copy(
                 avgTokensPerSecond = tokS, avgComputeMs = avgComputeMs, avgIoMs = avgIoMs,
+                avgMgmtMs = avgMgmtMs,
                 prefillTps = prefillTps, ttftS = ttft, readMib = readMib,
                 cacheResidentMib = cacheResidentMib, cacheBudgetMib = cacheBudgetMib,
+                avgMajfltPerTok = majfltPerTok, avgCpuSPerTok = cpuSPerTok,
             )
             RunBus.update {
                 val answer = if (text.isNotEmpty()) text else it.answer

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -9,7 +9,17 @@ data class Telemetry(
     var wallMs: Double = 0.0,
     var ioMs: Double = 0.0,
     var computeMs: Double = 0.0,
+    // Cache-management time this token — the third wall-additive term. wall = compute + flash-wait +
+    // mgmt exactly (the engine defines compute as that residual), so the panel can show a breakdown
+    // that sums to the token time and makes tok/s = 1000/wall self-evident.
+    var mgmtMs: Double = 0.0,
     var cacheHitPct: Double = -1.0,
+    // Compute-decomposition of the `computeMs` residual (see docs/telemetry.md). Live per-token
+    // values from BMOE_PROGRESS: `majflt` > 0 means a dense weight re-faulted from flash inside the
+    // decode; `cpuMs` ÷ (wallMs × threads) is CPU occupancy — near 1 is compute-bound, well below
+    // means a throttled/preempted core. 0 when the platform can't measure them.
+    var majflt: Double = 0.0,
+    var cpuMs: Double = 0.0,
     var text: String = "",
     // Aggregate decode rate over the whole run, parsed from the final summary line; -1 until
     // generation finishes. The per-token [tokensPerSecond] is instantaneous (last token only),
@@ -19,12 +29,16 @@ data class Telemetry(
     // the last token's instantaneous [computeMs]/[ioMs]. -1 until generation finishes.
     var avgComputeMs: Double = -1.0,
     var avgIoMs: Double = -1.0,
+    var avgMgmtMs: Double = -1.0,
     // End-of-run figures from the final summary (BMOE_DONE); -1 / 0 until generation finishes.
     var prefillTps: Double = -1.0,      // prompt prefill rate (tok/s)
     var ttftS: Double = -1.0,           // time-to-first-token = model load + prompt prefill (s)
     var readMib: Double = -1.0,         // total flash streamed this generation (MiB)
     var cacheResidentMib: Double = -1.0, // expert cache resident size (MiB)
     var cacheBudgetMib: Double = -1.0,  // current (possibly auto-adapting) cache budget (MiB)
+    // Run averages of the compute decomposition, from the final summary (BMOE_DONE); -1 until done.
+    var avgMajfltPerTok: Double = -1.0, // major page faults per token over the run
+    var avgCpuSPerTok: Double = -1.0,   // CPU-seconds per token (summed across threads) over the run
 ) {
     val tokensPerSecond: Double get() = if (wallMs > 0) 1000.0 / wallMs else 0.0
 }
@@ -58,7 +72,10 @@ class TelemetryParser {
             current.wallMs = o.optDouble("wall_ms")
             current.ioMs = o.optDouble("io_ms")
             current.computeMs = o.optDouble("compute_ms")
+            current.mgmtMs = o.optDouble("mgmt_ms", 0.0)
             current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
+            current.majflt = o.optDouble("majflt", 0.0)
+            current.cpuMs = o.optDouble("cpu_ms", 0.0)
             current.text = o.optString("text")
         }.isSuccess
     }


### PR DESCRIPTION
## What & why

The per-token `compute_ms` telemetry is a **residual** (`wall − stall − mgmt`), so it silently absorbed everything not otherwise timed. A large "compute" number could equally mean genuine matmul, a dense-weight **page-fault storm** on a >RAM model, or a **throttled CPU** — indistinguishable. This surfaced concretely while diagnosing why in-app tok/s trailed adb-shell: the answer was a per-app frequency cap plus dense-weight faults, both hiding inside "compute", and the existing telemetry couldn't show it.

This PR makes the compute residual **attributable** and makes the Android panel show data that adds up to the token time, so tok/s is read directly instead of derived.

## Engine (`feat(metrics)`)

Two directly-measured counters, sampled around `llama_decode`, **no submodule patch**:

- **`majflt`** (`getrusage` `ru_majflt`) — major page faults this token. Experts stream via `O_DIRECT` and never fault, so a non-zero count isolates a **dense-weight residency stall** re-faulting from flash *inside* the decode.
- **`cpu_ms`** (`CLOCK_PROCESS_CPUTIME_ID`) — CPU time across all threads. `cpu_ms ÷ (wall × threads)` is **occupancy**: near 100% is compute-bound; well below flags a throttled/preempted core.

Both live behind the `platform_io` seam and return `0` where unmeasurable (Windows host build) = "unmeasured". Surfaced per-token and as run averages through the CSV sink (trailing columns + summary keys), the `BMOE_PROGRESS`/`BMOE_DONE` session lines, and a `compute:` line in the one-shot summary. Measured for the mmap baseline too, where dense faults also occur.

## Android (`feat(android)`)

The decode meters showed `compute` vs `flash I/O`, which **do not sum to the token time** (under overlap `io_ms` is a per-lane busy sum running parallel to compute), so tok/s couldn't be read off the panel. Replaced with the three terms that sum to wall by construction — **`compute` + `flash wait` + `cache mgmt`** — under a **`<ms>/token → <tok/s>`** headline. A diagnostic line reports **CPU occupancy · faults/token · cache hit**, so the compute bar is qualified rather than trusted blindly. Byte throughput moves to a secondary line. Summary token count now reflects tokens actually generated, not the `n_predict` target.

## Docs (`docs(telemetry)`)

`majflt`/`cpu_ms` added to the `BMOE_PROGRESS`/`BMOE_DONE`/CSV schemas with the attribution rationale; new `compute:` summary line documented. Also documents why **`stall_ms` has a structural floor above zero**: the router picks a token's experts only just before the FFN needs them, so a cache miss forces an on-demand read overlap cannot hide — the residual stall tracks the miss rate and reaches zero only near 100% hit (empirically never zero: ~5–15 ms min at 76–81% hit, hundreds of ms at 12–18% hit).

## Verification

- **Byte-identity gates pass** (`bmoe_moe_gates`, all 4) — measurement only, generation path untouched.
- Host build (MSVC) and Android NDK build both compile clean; the new APK was installed and exercised on-device (OnePlus 15R), panel and counters confirmed working.

## Notes

- Hard rules respected: no llama.cpp patch, no env vars in `core/`, no hardcoding, repack stays off.
- No version bump / tag here — this joins the accumulated `[Unreleased]` set; cutting `vX.Y.Z` is left as a separate release step.

