### PR TITLE
feat(moe): keep the prompt tail's experts hot across prefill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Changed
+- **Prompt-tail retention across prefill**: the whole prompt is one prefill ubatch, so `load_layer`
+  sees every prompt token's routed experts at once, token-major. The in-batch dedup guard skipped
+  the LRU promotion for an expert already staged in that batch, anchoring it at the position of the
+  *first* token that used it. Promote on every touch instead, so the LRU order at the end of prefill
+  reflects the *last* prompt tokens — the experts most likely to be routed again for the first
+  generated tokens — keeping them resident rather than first in line for eviction. Bookkeeping only:
+  reads are still scheduled once per expert, and in decode the top-k ids within a token are distinct,
+  so the path is a no-op there. Byte-identity gates unaffected. **Not yet measured on device**: the
+  whole first-10-token warm-up excess is ~1.0 s (Qwen) / ~0.7 s (Gemma) over steady state, so any
+  gain is bounded by that and is expected to matter for short chat turns rather than long runs.
+
 ### Added
 - **Direct answers on gpt-oss (`--no-think`)**: the harmony chat template always opens an
   `analysis` (chain-of-thought) channel, so `--no-think` previously had no visible effect on

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -693,7 +693,20 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     std::fill(seen_.begin(), seen_.end(), (uint8_t) 0);
     for (int i = 0; i < n_ids; ++i) {
         const int e = load_all_ ? (i < n_expert_ ? i : -1) : ids[i];
-        if (e < 0 || e >= n_expert_ || seen_[e]) continue;
+        if (e < 0 || e >= n_expert_) continue;
+        if (seen_[e]) {
+            // Already staged in this batch: still promote so the LRU order reflects the LAST
+            // token that used this expert (ids arrive token-major), not its first touch — this
+            // keeps the prompt tail's experts hot across prefill. Reads are scheduled only once
+            // (the seen_ guard below), so this is bookkeeping only. In decode (n=1) the top-k ids
+            // are distinct, so this branch never runs and behaviour is unchanged.
+            if (cache_max_) {
+                const int32_t id = il * n_expert_ + e;
+                lru_unlink(id);
+                lru_push_front(id);
+            }
+            continue;
+        }
         seen_[e] = 1;
         if (!stage(e)) return false;
     }
@@ -861,6 +874,21 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
                 const int32_t flag = (int32_t) ((size_t) p * (size_t) n_expert_ + (size_t) e);
                 jobs_.push_back({(char *) lbuf_[p][il] + (uint64_t) e * slice,
                                  L.proj[p].file_off + (uint64_t) e * slice, slice, flag});
+            }
+        }
+
+        // Promote every touched expert in raw id order (token-major) so the LRU order reflects
+        // the LAST token that used it, not the sorted/first-touch order staged_ imposes — this
+        // keeps the prompt tail's experts hot across prefill. Bookkeeping only; every id staged
+        // above is now valid and linked. In decode (n=1, distinct top-k) this is a no-op reshuffle.
+        // Skipped in load_all (everything is resident, so LRU order is meaningless).
+        if (!load_all_) {
+            for (int i = 0; i < n_ids; ++i) {
+                const int e = ids[i];
+                if (e < 0 || e >= n_expert_) continue;
+                const int32_t id = il * n_expert_ + e;
+                lru_unlink(id);
+                lru_push_front(id);
             }
         }
     }


### PR DESCRIPTION
Promotes an expert on **every** touch during prefill instead of only its first, so the LRU order at the end of prefill reflects the *last* prompt tokens — the ones whose experts the first generated tokens are most likely to route to again.

The whole prompt is a single prefill ubatch, so `load_layer` sees every prompt token's routed experts at once, token-major. The in-batch dedup guard (`seen_[e]`) skipped the LRU promotion for an already-staged expert, anchoring it at its first-touch position — near the tail, first in line for eviction. Applied to both the serial (`load_layer`) and overlap (`load_layer_async`) paths; the overlap hunk sits inside the cache-on branch, so `cache_max_ != 0` is guaranteed there.

Bookkeeping only. Reads are still scheduled once per expert, and in decode the top-k ids within a token are distinct, so the new path never runs there.

### Provenance
Originally written as `b1e40c3` on an abandoned session branch (`backup/warmup-session-a31471d`, based on `f3371aa`); cherry-picked onto current `main` and re-verified. Its sibling commit's `trim_to_budget()` was **not** brought over: the budget overshoot it targeted cannot occur — the eviction guard protects only the current layer (~350 MiB for Qwen) against a multi-GB budget, and every committed run log shows `resident` at or under budget (1996/2000, 3997/4000, 4675/4675).

### Verification
- `bmoe_moe_gates`: **4/4 pass** (qwen3moe + gemma4) — streamed still byte-identical to resident.
- `clang-format` 18.1.8 clean.
- CI cannot run (Actions billing block), so this was proven locally.

### Honest caveat — not measured on device
The entire first-10-token warm-up excess over steady state is **~1002 ms (Qwen)** / **~682 ms (Gemma)** on a ~50 s run, derived from the committed CSVs in `docs/bench-data/2026-07-14-warmup/`. Any gain here is bounded by that, so it is noise on a 256-token benchmark and only plausibly relevant to the app's short chat turns (~15% of a 24-token reply). Merging on correctness; the A/B is still owed.