### PR TITLE
docs: add an index for docs/, and correct what the code overtook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ cd build && ctest --output-on-failure
 
 ## Good first contributions
 
-- A new MoE architecture recipe + its gate.
-- Support for the merged `ffn_gate_up_exps` expert layout.
+- A new MoE architecture recipe + its gate (`docs/adding-a-model.md`).
 - Read coalescing / expert-contiguous layout experiments (see `docs/roadmap.md`).
 
 ## PRs

--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ A prebuilt debug APK is attached to each [release](https://github.com/Helldez/Bi
 Details: [docs/moe-streaming.md](docs/moe-streaming.md),
 [docs/architecture.md](docs/architecture.md).
 
+## Documentation
+
+[docs/](docs/README.md) is indexed by what you are trying to do — understand the design, extend
+it, or reproduce the measurements. The entry points most people want:
+
+- [docs/architecture.md](docs/architecture.md) — the layer map, and why llama.cpp is not forked.
+- [docs/seam.md](docs/seam.md) — the exact contract with llama.cpp's public API.
+- [docs/adding-a-model.md](docs/adding-a-model.md) — supporting a new MoE architecture.
+- [docs/telemetry.md](docs/telemetry.md) — the `BMOE_*` line protocol and CSV schema.
+- [docs/benchmarks.md](docs/benchmarks.md) — measured results, and [how they were
+  produced](docs/benchmark-method.md).
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Documentation
+
+Start with [architecture.md](architecture.md) for the layer map, or [moe-streaming.md](moe-streaming.md)
+for the idea the project is built on.
+
+## Understanding the design
+
+| Doc | What it answers |
+|---|---|
+| [architecture.md](architecture.md) | How the layers fit together, and why llama.cpp is not forked. |
+| [moe-streaming.md](moe-streaming.md) | Why streaming experts from flash makes a >RAM model run at all. |
+| [seam.md](seam.md) | The exact contract with llama.cpp's public API, and how to upgrade the submodule. |
+| [limitations.md](limitations.md) | What this does not do, what it cannot do, and the prior art it builds on. |
+| [roadmap.md](roadmap.md) | Themes worth exploring next. |
+
+## Using and extending it
+
+| Doc | What it answers |
+|---|---|
+| [adding-a-model.md](adding-a-model.md) | How to support a new MoE architecture (a recipe row plus a gate). |
+| [telemetry.md](telemetry.md) | The `BMOE_*` line protocol and CSV schema — the integration contract. |
+| [session.md](session.md) | Session lifecycle, KV prefix reuse, cancellation. |
+| [adaptive-cache.md](adaptive-cache.md) | `--cache-mb auto`, the cache ceiling, and dense warm-up. |
+| [prefetch.md](prefetch.md) | `--prefetch K`: the design and why it cannot change output. |
+
+## Measurements
+
+| Doc | What it answers |
+|---|---|
+| [benchmarks.md](benchmarks.md) | Measured results per model, with device-pressure numbers. |
+| [benchmark-method.md](benchmark-method.md) | How the numbers are produced, so you can reproduce them. |
+| [warmup-analysis.md](warmup-analysis.md) | Why first tokens are slow, and the two regimes behind it. |
+| [bench-data/](bench-data/) | Raw per-run CSVs and session notes. A dated archive — see its README. |
+
+Every benchmark figure in these docs is measured on the hardware named beside it. If you
+re-measure, update [benchmark-method.md](benchmark-method.md) and the affected table together.

--- a/docs/bench-data/2026-07-12-pr23/findings.md
+++ b/docs/bench-data/2026-07-12-pr23/findings.md
@@ -1,5 +1,10 @@
 # On-device A/B for temporal prefetch (PR2) and speculative gating (PR3)
 
+> **Archived, 2026-07-12.** Speculative gating has since been removed from the engine to restore
+> the modular seam; `--spec-gate` is no longer a flag. The `spec-gate` rows and the advice about
+> tuning it below are kept as a record of why that decision was made — they are not actionable.
+> See [../README.md](../README.md).
+
 OnePlus 15R (11.3 GB), 256-token decode, prompt-processing + steady-state. Each config on top of
 its model's best measured baseline (Qwen: cache 4000, lane 4, overlap; Gemma: cache 2000, lane 4,
 overlap). See `summary.md` for the full tables. Device was cooler than the 2026-07-12 baseline run,

--- a/docs/bench-data/README.md
+++ b/docs/bench-data/README.md
@@ -1,0 +1,17 @@
+# Benchmark data archive
+
+Raw per-run CSVs and the session notes written alongside them, one directory per measurement
+session. Each directory is a **historical record of the build it was captured on**, kept for
+provenance so the tables in [../benchmarks.md](../benchmarks.md) can be traced back to data.
+
+**These files are not maintained.** They are not corrected when the code moves on, and a
+recommendation inside one is only valid for the build it was measured against. Read the
+maintained docs for current guidance; read these to check where a number came from.
+
+| Session | Captured against | Note |
+|---|---|---|
+| `2026-07-12/` | baseline cache/lane sweep | Feeds the cache-and-lanes tables in `benchmarks.md`. |
+| `2026-07-12-pr23/` | temporal prefetch + speculative gating | **Speculative gating no longer exists** — it was removed to restore the modular seam. The `--spec-gate` rows and the advice about it describe a flag the CLI no longer accepts. |
+| `2026-07-13/` | adaptive cache budget | Source of the capped-auto recipe numbers. |
+| `2026-07-14/` | per-token warm-up | Feeds `warmup-analysis.md`. |
+| `2026-07-14-warmup/` | dense warm-up A/B | Feeds `adaptive-cache.md` and `warmup-analysis.md`. |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -132,7 +132,9 @@ there is too much I/O — 1.6 s/tok of lane-busy reads — to hide behind ~0.4 s
 ### Gemma-4-26B-A4B-it-Q4_K_M
 
 - **File:** `Gemma-4-26B-A4B-it-Q4_K_M.gguf` — 17.0 GB on disk, Q4_K_M quantization.
-- **Shape:** fused gate+up expert layout, A4B (4 experts active). ≈1.51× device RAM (11.3 GB).
+- **Shape:** fused gate+up expert layout. The "A4B" label is ~4 **billion active parameters**, not
+  4 active experts — the measured I/O ratio puts the default routing width at 8 (see the
+  active-expert override section below). ≈1.51× device RAM (11.3 GB).
 
 | Config | mean | min | max | median | p5 | p95 | cache hit | flash read/token | decode: compute + I/O (s/tok) |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,37 +1,56 @@
 # Roadmap
 
-Themes, not deadlines. Ordered roughly by expected impact on the flash-I/O-bound decode.
+Themes, not deadlines. Ordered roughly by expected impact.
 
-## Read bandwidth
+The starting point has moved: with a well-sized expert cache and `--overlap`, decode on the
+reference device is **compute-bound, not I/O-bound**. Flash I/O is ~79 % of decode only with the
+cache off; at Qwen's cache 4000 it inverts, and an infinite cache would still cap at 1/compute
+≈ 6.2 tok/s — this SoC's in-RAM decode speed ([benchmarks.md](benchmarks.md#reading-the-numbers)).
+So the streaming path has already recovered most of what streaming can recover, and the themes
+below are ordered by that fact: read bandwidth still matters for the models that do not fit a
+useful cache, but throughput on the ones that do now depends on compute.
 
-Decode is ~79% flash I/O, and effective O_DIRECT bandwidth is well below the drive's
-sequential ceiling because routed expert slices are scattered. The largest untapped lever:
+## Read bandwidth, where it still binds
 
-- **Expert-contiguous gguf layout.** An offline repack that stores each layer's experts
-  contiguously (and/or groups the three projections per expert) so a routed set becomes
-  one coalesced read instead of many scattered ones.
+Effective O_DIRECT bandwidth is well below the drive's sequential ceiling because routed expert
+slices are scattered. This still dominates the models too large for a useful cache (gpt-oss-120b
+at 5.2× RAM), and the cold-cache warm-up on every model.
+
+- **Expert-contiguous gguf layout.** An offline repack storing each layer's experts contiguously
+  (and/or grouping the projections per expert) so a routed set becomes one coalesced read instead
+  of many scattered ones.
 - **Read coalescing** of adjacent routed slices at runtime.
 
-## Overlap I/O with compute
+## Warm-up
 
-Today the read phase and the expert matmul are serial. Prefetching the next layer's likely
-experts (or overlapping the read of layer N+1 with the compute of layer N) could hide a
-large share of the I/O. Requires a routing predictor or speculative prefetch.
+Dense weights are warmed into the page cache at load, which removes the >RAM fault storm. The
+expert cache still fills from cold, so the first tokens pay for it and no warm-up flag can change
+that ([warmup-analysis.md](warmup-analysis.md)). Worth exploring: preloading experts by routing
+frequency rather than by arrival, and a cross-run persistent cache so a second session starts warm.
 
 ## More architectures
 
-Beyond `qwen3moe`: other `build_moe_ffn` models are one recipe row each. The merged
-`ffn_gate_up_exps` layout and shared-expert models are supported too (`gemma4` / Gemma 4
-MoE exercises both). Remaining frontier: architectures whose routing node is not the shared
-`ffn_moe_topk` (e.g. custom gating), which the capture/stream hook would need to learn. See
-[adding-a-model.md](adding-a-model.md).
+`qwen3moe`, `gemma4` (merged `ffn_gate_up_exps` plus shared experts) and OpenAI `gpt-oss` (MXFP4,
+purely routed) are supported; other `build_moe_ffn` models are one recipe row each. The remaining
+frontier is architectures whose routing node is not the shared `ffn_moe_topk` — custom gating,
+which the capture/stream hook would need to learn. See [adding-a-model.md](adding-a-model.md).
 
 ## Expert quantization on the fly
 
-Storing streamed experts at a lower precision than the resident parts to cut read volume,
-if it can stay within an acceptable quality/lossless boundary.
+Storing streamed experts at a lower precision than the resident parts to cut read volume, if it
+can stay within an acceptable quality boundary. Most valuable exactly where read bandwidth still
+binds, above.
 
 ## Bigger, smarter cache
 
-The cache is capacity-bound, not policy-bound (reuse is broad, not skewed), so the simplest
-win is more budget. A cross-run persistent cache and admission policies are worth exploring.
+The cache is capacity-bound, not policy-bound (reuse is broad, not skewed), so the simplest win is
+more budget — which `--cache-mb auto` now takes automatically, capped by `--cache-ceil-mb`
+([adaptive-cache.md](adaptive-cache.md)). Admission policies and a persistent cross-run cache
+remain unexplored.
+
+## Not on this list
+
+Routing prediction and speculative expert gating were built and **removed**: the recall/latency
+trade never paid on-device, and the predictor coupled the streamer to model internals, which cost
+more in modularity than it returned in throughput. The archived measurements are in
+[bench-data/2026-07-12-pr23/](bench-data/2026-07-12-pr23/).


### PR DESCRIPTION
Two commits, no code changes.

### An entry point for docs/
`docs/` had no index and no table of contents. The README linked 8 of the 14 docs inline, so `telemetry.md` — the integration contract for the whole `BMOE_*` protocol — was reachable only two hops in, via `architecture.md` → `session.md`. Adds `docs/README.md` indexed by intent (understand the design / extend it / reproduce the numbers) and a Documentation section in the README pointing at it.

`bench-data/` also gets a README saying what it is: a dated archive of raw runs, kept for provenance and **not maintained**, so a recommendation inside one is read against the build it was measured on rather than as current advice.

### Corrections
- **`roadmap.md`** listed three shipped capabilities as future work: `--overlap`, `--prefetch`, and the routing predictor behind them — which was built and then removed. It also opened on "decode is ~79% flash I/O", true only with the cache off; with a sized cache and overlap decode is compute-bound, which changes what is worth doing next. Rewritten against the measurements, with an explicit note on why speculative gating is not coming back.
- **`benchmarks.md`** described Gemma as "A4B (4 experts active)" at the top and corrected that same claim 95 lines further down. Kept the correction.
- **`CONTRIBUTING.md`** offered the merged `ffn_gate_up_exps` layout as a good first contribution — it shipped as `gemma4`.
- **`bench-data/2026-07-12-pr23/findings.md`** still read "Do not enable `--spec-gate` until it caps speculative reads" — advice about a flag the CLI no longer accepts. Flagged as archived.

### Verification
All markdown links checked to resolve; one of my own was wrong (an anchor copied from the README that doesn't exist in `benchmarks.md`) and was fixed.

### Known debt, deliberately not in scope
Qwen's "best tok/s" still exists in five versions across the docs (3.98 / 4.03 / 5.01 / 5.23 / 7.01), and README:159 cites 5.23 as the winning recipe while pointing at `adaptive-cache.md`, which carries no numbers — the only source is `bench-data/2026-07-13/`. Reconciling that needs a decision on which number is canonical.