### PR TITLE
feat(android): Markdown answers + a transcript scroll that lets go

### DIFF
--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 7
-        versionName '0.6.0'
+        versionCode 8
+        versionName '0.6.1'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -146,141 +147,174 @@ private fun MainScreen(
     var prompt by rememberSaveable { mutableStateOf("Explain what a mixture-of-experts model is, in two sentences.") }
     val listState = rememberLazyListState()
 
-    // Keep the newest content in view as the answer streams in and turns commit. Item 0 is the
-    // controls block; the transcript and the in-flight answer follow it.
+    // Item 0 is the controls block; the transcript and the in-flight answer follow it.
     val liveShown = ui.answer.isNotEmpty()
     val total = 1 + ui.transcript.size + (if (liveShown) 1 else 0)
-    LaunchedEffect(ui.transcript.size, liveShown, ui.answer.length) {
-        if (total > 1) runCatching { listState.animateScrollToItem(total - 1) }
+
+    // Follow the tail only while the user is parked at the bottom. A long answer streams for a
+    // long time, and scrolling back to re-read it must not fight a per-token scroll command:
+    // dragging the list detaches the follow, coming back to the bottom re-arms it.
+    var followTail by remember { mutableStateOf(true) }
+    val atBottom by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            val last = info.visibleItemsInfo.lastOrNull()
+            last == null ||
+                (last.index == info.totalItemsCount - 1 && last.offset + last.size <= info.viewportEndOffset)
+        }
+    }
+    LaunchedEffect(listState) {
+        listState.interactionSource.interactions.collect { if (it is DragInteraction.Start) followTail = false }
+    }
+    // Re-arm on settle, not the moment the bottom is touched: while an answer streams the bottom
+    // keeps moving away, so only where a scroll actually comes to rest says what the user wants.
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.isScrollInProgress }.collect { scrolling -> if (!scrolling) followTail = atBottom }
+    }
+    LaunchedEffect(total, ui.answer.length, followTail) {
+        // A long answer is taller than the viewport, so aligning the item's top would park the view
+        // on its beginning; the large offset pins the list to the newest text instead.
+        if (followTail && total > 1) runCatching { listState.scrollToItem(total - 1, Int.MAX_VALUE) }
     }
 
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        item(key = "controls") {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    Text("BigMoeOnEdge", fontSize = 22.sp, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
-                    TextButton(onClick = onOpenSettings) { Text("Settings") }
-                }
-
-                when {
-                    scanning -> Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
-                        Text("Scanning for MoE models…", fontSize = 14.sp)
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item(key = "controls") {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text("BigMoeOnEdge", fontSize = 22.sp, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                        TextButton(onClick = onOpenSettings) { Text("Settings") }
                     }
-                    models.isEmpty() -> {
-                        ElevatedCard {
-                            Text(
-                                ModelManager.pushHint(),
-                                Modifier.padding(12.dp),
-                                fontSize = 13.sp,
-                                fontFamily = FontFamily.Monospace,
-                            )
+
+                    when {
+                        scanning -> Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                            Text("Scanning for MoE models…", fontSize = 14.sp)
                         }
-                        TextButton(onClick = { requestSharedStorageAccess(context); onRefresh() }) { Text("Refresh") }
-                    }
-                    else -> LabeledDropdown(
-                        label = "Model",
-                        options = models.map { it.name },
-                        selected = modelIdx,
-                        onSelect = onSelectModel,
-                    )
-                }
-
-                // Bring a model onto the device without adb: download by URL or pick a local file.
-                // Both land in the app models dir; on completion we re-scan so it appears above.
-                AddModelSection(onModelReady = onRefresh)
-
-                OutlinedTextField(
-                    value = prompt,
-                    onValueChange = { prompt = it },
-                    label = { Text("Prompt") },
-                    modifier = Modifier.fillMaxWidth(),
-                    minLines = 2,
-                )
-
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Button(
-                        onClick = {
-                            if (models.isNotEmpty()) {
-                                // First message of a conversation clears the KV; a follow-up continues it.
-                                launchPrompt(context, models[modelIdx.coerceIn(0, models.size - 1)],
-                                    prompt.ifBlank { "The capital of Japan is" }, settings, ui.sessionSig,
-                                    clearKv = ui.transcript.isEmpty())
+                        models.isEmpty() -> {
+                            ElevatedCard {
+                                Text(
+                                    ModelManager.pushHint(),
+                                    Modifier.padding(12.dp),
+                                    fontSize = 13.sp,
+                                    fontFamily = FontFamily.Monospace,
+                                )
                             }
-                        },
-                        enabled = !ui.busy && models.isNotEmpty(),
-                        modifier = Modifier.weight(1f),
-                    ) { Text(if (ui.transcript.isNotEmpty()) "Send" else if (ui.ready) "Send" else "Run") }
-
-                    OutlinedButton(
-                        onClick = {
-                            context.startService(
-                                Intent(context, RunService::class.java).setAction(RunService.ACTION_CANCEL)
-                            )
-                        },
-                        enabled = ui.generating,
-                        modifier = Modifier.weight(1f),
-                    ) { Text("Stop") }
-                }
-
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    // Start a new conversation: the next Send clears the KV. Keeps the model loaded.
-                    TextButton(
-                        onClick = { RunBus.update { it.copy(transcript = emptyList(), answer = "", summary = "", error = null) } },
-                        enabled = ui.transcript.isNotEmpty() && !ui.busy,
-                    ) { Text("New chat") }
-
-                    // The session keeps the model resident (and the cache warm) between prompts. Free it
-                    // explicitly, or let the service auto-unload after an idle timeout.
-                    if (ui.ready || ui.loading) {
-                        TextButton(onClick = {
-                            context.startService(
-                                Intent(context, RunService::class.java).setAction(RunService.ACTION_SHUTDOWN)
-                            )
-                        }) { Text("Unload model") }
+                            TextButton(onClick = { requestSharedStorageAccess(context); onRefresh() }) { Text("Refresh") }
+                        }
+                        else -> LabeledDropdown(
+                            label = "Model",
+                            options = models.map { it.name },
+                            selected = modelIdx,
+                            onSelect = onSelectModel,
+                        )
                     }
-                }
 
-                // A quick reminder of the active config (full controls in Settings).
-                Text(configSummary(settings), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    // Bring a model onto the device without adb: download by URL or pick a local file.
+                    // Both land in the app models dir; on completion we re-scan so it appears above.
+                    AddModelSection(onModelReady = onRefresh)
 
-                if (ui.loading) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
-                        Text("Loading model…", fontSize = 14.sp)
+                    OutlinedTextField(
+                        value = prompt,
+                        onValueChange = { prompt = it },
+                        label = { Text("Prompt") },
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 2,
+                    )
+
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Button(
+                            onClick = {
+                                if (models.isNotEmpty()) {
+                                    // First message of a conversation clears the KV; a follow-up continues it.
+                                    launchPrompt(context, models[modelIdx.coerceIn(0, models.size - 1)],
+                                        prompt.ifBlank { "The capital of Japan is" }, settings, ui.sessionSig,
+                                        clearKv = ui.transcript.isEmpty())
+                                }
+                            },
+                            enabled = !ui.busy && models.isNotEmpty(),
+                            modifier = Modifier.weight(1f),
+                        ) { Text(if (ui.transcript.isNotEmpty()) "Send" else if (ui.ready) "Send" else "Run") }
+
+                        OutlinedButton(
+                            onClick = {
+                                context.startService(
+                                    Intent(context, RunService::class.java).setAction(RunService.ACTION_CANCEL)
+                                )
+                            },
+                            enabled = ui.generating,
+                            modifier = Modifier.weight(1f),
+                        ) { Text("Stop") }
                     }
-                }
-                // After the model is loaded, the prompt is prefilled before the first token streams
-                // (no BMOE_PROGRESS yet). Signal that phase so a slow prefill does not look stuck.
-                if (ui.generating && ui.telemetry.step == 0) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
-                        Text("Prefilling prompt…", fontSize = 14.sp)
-                    }
-                }
 
-                TelemetryCard(ui, settings.threads)
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        // Start a new conversation: the next Send clears the KV. Keeps the model loaded.
+                        TextButton(
+                            onClick = { RunBus.update { it.copy(transcript = emptyList(), answer = "", summary = "", error = null) } },
+                            enabled = ui.transcript.isNotEmpty() && !ui.busy,
+                        ) { Text("New chat") }
+
+                        // The session keeps the model resident (and the cache warm) between prompts. Free it
+                        // explicitly, or let the service auto-unload after an idle timeout.
+                        if (ui.ready || ui.loading) {
+                            TextButton(onClick = {
+                                context.startService(
+                                    Intent(context, RunService::class.java).setAction(RunService.ACTION_SHUTDOWN)
+                                )
+                            }) { Text("Unload model") }
+                        }
+                    }
+
+                    // A quick reminder of the active config (full controls in Settings).
+                    Text(configSummary(settings), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+                    if (ui.loading) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                            Text("Loading model…", fontSize = 14.sp)
+                        }
+                    }
+                    // After the model is loaded, the prompt is prefilled before the first token streams
+                    // (no BMOE_PROGRESS yet). Signal that phase so a slow prefill does not look stuck.
+                    if (ui.generating && ui.telemetry.step == 0) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                            Text("Prefilling prompt…", fontSize = 14.sp)
+                        }
+                    }
+
+                    TelemetryCard(ui, settings.threads)
+                }
+            }
+
+            // Committed turns.
+            items(ui.transcript.size) { i -> TurnView(ui.transcript[i]) }
+
+            // The in-flight assistant answer as it streams (its user turn is already in the transcript).
+            if (liveShown) {
+                item(key = "live") {
+                    TurnView(ChatTurn("assistant", ui.answer))
+                }
             }
         }
 
-        // Committed turns.
-        items(ui.transcript.size) { i -> TurnView(ui.transcript[i]) }
-
-        // The in-flight assistant answer as it streams (its user turn is already in the transcript).
-        if (liveShown) {
-            item(key = "live") {
-                TurnView(ChatTurn("assistant", ui.answer))
-            }
+        // Once the follow is detached, the way back to a still-growing answer is a long drag.
+        if (!followTail && !atBottom) {
+            val scope = rememberCoroutineScope()
+            FilledTonalButton(
+                onClick = { scope.launch { listState.animateScrollToItem(total - 1, Int.MAX_VALUE) } },
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 24.dp),
+            ) { Text("Jump to latest") }
         }
     }
 }
@@ -295,7 +329,10 @@ private fun TurnView(turn: ChatTurn) {
             fontSize = 12.sp, fontWeight = FontWeight.Bold,
             color = if (isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.tertiary,
         )
-        SelectionContainer { Text(turn.text, fontSize = 15.sp) }
+        // The user's own prompt is echoed verbatim; only the model's answer is read as Markdown.
+        SelectionContainer {
+            if (isUser) Text(turn.text, fontSize = 15.sp) else MarkdownText(turn.text)
+        }
         if (turn.metrics.isNotEmpty()) {
             Text(turn.metrics, fontFamily = FontFamily.Monospace, fontSize = 11.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Markdown.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Markdown.kt
@@ -1,0 +1,285 @@
+package io.bigmoeonedge.example
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * A small Markdown renderer for chat answers — headings, lists, quotes, rules, fenced code and the
+ * usual inline emphasis. Deliberately hand-rolled instead of pulling a rendering library into the
+ * demo APK: the subset a chat model actually emits is tiny, and a parser we own can render the
+ * half-finished markup of a streaming answer (an unclosed fence, a dangling `**`) as plain text
+ * rather than swallowing it.
+ */
+@Composable
+fun MarkdownText(text: String, modifier: Modifier = Modifier, fontSize: TextUnit = 15.sp) {
+    val codeBg = MaterialTheme.colorScheme.surfaceVariant
+    val blocks = remember(text) { parseBlocks(text) }
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        blocks.forEach { block ->
+            when (block) {
+                is Block.Heading -> Text(
+                    inline(block.text, codeBg),
+                    fontSize = headingSize(block.level, fontSize),
+                    fontWeight = FontWeight.Bold,
+                )
+
+                is Block.Para -> Text(inline(block.text, codeBg), fontSize = fontSize)
+
+                is Block.Item -> Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        block.marker,
+                        Modifier.padding(start = (block.indent * 12).dp).width(if (block.ordered) 22.dp else 12.dp),
+                        fontSize = fontSize,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(inline(block.text, codeBg), fontSize = fontSize, modifier = Modifier.weight(1f))
+                }
+
+                is Block.Quote -> Row(
+                    Modifier.height(IntrinsicSize.Min),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(
+                        Modifier.width(3.dp).fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(2.dp))
+                    )
+                    Text(
+                        inline(block.text, codeBg),
+                        fontSize = fontSize,
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                is Block.Code -> Surface(color = codeBg, shape = RoundedCornerShape(6.dp)) {
+                    Column(Modifier.fillMaxWidth().padding(10.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        if (block.lang.isNotEmpty()) {
+                            Text(
+                                block.lang,
+                                fontSize = 11.sp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Text(
+                            block.code,
+                            Modifier.horizontalScroll(rememberScrollState()),
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = fontSize * 0.85f,
+                        )
+                    }
+                }
+
+                Block.Rule -> HorizontalDivider()
+            }
+        }
+    }
+}
+
+private fun headingSize(level: Int, base: TextUnit): TextUnit = when (level) {
+    1 -> base * 1.5f
+    2 -> base * 1.3f
+    3 -> base * 1.15f
+    else -> base
+}
+
+private sealed interface Block {
+    data class Heading(val level: Int, val text: String) : Block
+    data class Para(val text: String) : Block
+    data class Item(val marker: String, val text: String, val indent: Int, val ordered: Boolean) : Block
+    data class Quote(val text: String) : Block
+    data class Code(val code: String, val lang: String) : Block
+    data object Rule : Block
+}
+
+private val HEADING = Regex("""^(#{1,6})\s+(.*)$""")
+private val BULLET = Regex("""^([-*+])\s+(.*)$""")
+private val ORDERED = Regex("""^(\d{1,3})[.)]\s+(.*)$""")
+private val RULE = Regex("""^(-{3,}|\*{3,}|_{3,})$""")
+private val QUOTE = Regex("""^>\s?(.*)$""")
+private val LINK = Regex("""^\[([^\]\n]*)\]\(([^)\s]*)[^)]*\)""")
+
+private fun parseBlocks(src: String): List<Block> {
+    val out = ArrayList<Block>()
+    val para = StringBuilder()
+
+    fun flushPara() {
+        if (para.isNotEmpty()) {
+            out += Block.Para(para.toString())
+            para.setLength(0)
+        }
+    }
+
+    val lines = src.split("\n")
+    var i = 0
+    while (i < lines.size) {
+        val raw = lines[i]
+        val line = raw.trim()
+        val indent = (raw.length - raw.trimStart().length) / 2
+        when {
+            line.startsWith("```") -> {
+                flushPara()
+                val lang = line.removePrefix("```").trim()
+                val code = StringBuilder()
+                i++
+                while (i < lines.size && !lines[i].trim().startsWith("```")) {
+                    code.append(lines[i]).append('\n')
+                    i++
+                }
+                i++ // The closing fence, which a still-streaming answer has not emitted yet.
+                out += Block.Code(code.toString().trimEnd('\n'), lang)
+            }
+
+            line.isEmpty() -> {
+                flushPara()
+                i++
+            }
+
+            RULE.matches(line) -> {
+                flushPara()
+                out += Block.Rule
+                i++
+            }
+
+            else -> {
+                val heading = HEADING.matchEntire(line)
+                val bullet = BULLET.matchEntire(line)
+                val ordered = ORDERED.matchEntire(line)
+                val quote = QUOTE.matchEntire(line)
+                when {
+                    heading != null -> {
+                        flushPara()
+                        out += Block.Heading(heading.groupValues[1].length, heading.groupValues[2])
+                    }
+                    bullet != null -> {
+                        flushPara()
+                        out += Block.Item("•", bullet.groupValues[2], indent, ordered = false)
+                    }
+                    ordered != null -> {
+                        flushPara()
+                        out += Block.Item(ordered.groupValues[1] + ".", ordered.groupValues[2], indent, ordered = true)
+                    }
+                    quote != null -> {
+                        flushPara()
+                        out += Block.Quote(quote.groupValues[1])
+                    }
+                    // Soft line breaks inside a paragraph are kept: chat models use them as real
+                    // breaks far more often than as reflowable wrapping.
+                    else -> para.append(if (para.isEmpty()) "" else "\n").append(line)
+                }
+                i++
+            }
+        }
+    }
+    flushPara()
+    return out
+}
+
+private fun inline(src: String, codeBg: Color): AnnotatedString = buildAnnotatedString { appendInline(src, codeBg) }
+
+/**
+ * Inline emphasis. Every marker needs a closing partner: an unmatched one is emitted verbatim, so a
+ * streaming answer shows its literal `**` for a moment instead of the rest of the text flipping
+ * bold. Single `_` is not an italic marker on purpose — it would mangle identifiers like use_mmap.
+ */
+private fun AnnotatedString.Builder.appendInline(src: String, codeBg: Color) {
+    var i = 0
+    while (i < src.length) {
+        val c = src[i]
+        val pair = when {
+            src.startsWith("**", i) -> "**"
+            src.startsWith("__", i) -> "__"
+            src.startsWith("~~", i) -> "~~"
+            else -> null
+        }
+        when {
+            c == '`' -> {
+                val end = src.indexOf('`', i + 1)
+                if (end < 0) {
+                    append(c); i++
+                } else {
+                    withStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = codeBg)) {
+                        append(src.substring(i + 1, end))
+                    }
+                    i = end + 1
+                }
+            }
+
+            pair != null -> {
+                val end = src.indexOf(pair, i + 2)
+                if (end < 0) {
+                    append(pair); i += 2
+                } else {
+                    val style = if (pair == "~~") {
+                        SpanStyle(textDecoration = TextDecoration.LineThrough)
+                    } else {
+                        SpanStyle(fontWeight = FontWeight.Bold)
+                    }
+                    withStyle(style) { appendInline(src.substring(i + 2, end), codeBg) }
+                    i = end + pair.length
+                }
+            }
+
+            // A lone '*' is italic only when it opens a run: "2 * 3" and a stray bullet stay literal.
+            c == '*' && i + 1 < src.length && !src[i + 1].isWhitespace() -> {
+                val end = src.indexOf('*', i + 1)
+                if (end < 0) {
+                    append(c); i++
+                } else {
+                    withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
+                        appendInline(src.substring(i + 1, end), codeBg)
+                    }
+                    i = end + 1
+                }
+            }
+
+            c == '[' -> {
+                val link = LINK.find(src, i)?.takeIf { it.range.first == i }
+                if (link == null) {
+                    append(c); i++
+                } else {
+                    // The target is shown, not opened: the demo has no browser intent and a model
+                    // can hallucinate a URL, so the text carries the link and the user decides.
+                    withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
+                        appendInline(link.groupValues[1], codeBg)
+                    }
+                    i = link.range.last + 1
+                }
+            }
+
+            else -> {
+                append(c); i++
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

Two things made a long answer unpleasant to read in the demo app:

- **Markdown arrived as literal syntax.** `TurnView` rendered the answer as one flat `Text`, so `##`, `**bold**`, bullets and fenced code showed their markers.
- **The scroll never let go.** The transcript scrolled to the tail on *every token* (`animateScrollToItem` keyed on `ui.answer.length`), so scrolling back to re-read was undone milliseconds later. And because the scroll aligned the item's *top*, once an answer grew past the viewport the view parked on its beginning rather than the newest text.

## What changed

- `Markdown.kt` — a small renderer: headings, bullet/ordered lists, quotes, rules, fenced code (with horizontal scroll) and inline `**bold**` / `*italic*` / `` `code` `` / `~~strike~~` / links. Hand-rolled rather than a dependency: the subset a chat model emits is tiny, and a parser we own renders the half-finished markup of a *streaming* answer (an unclosed fence, a dangling `**`) as plain text instead of swallowing it. Single `_` is deliberately not an italic marker — it would mangle identifiers like `use_mmap`. The user's own prompt is still echoed verbatim.
- `MainActivity.kt` — the tail-follow detaches on drag and re-arms only when a scroll comes to **rest** at the bottom (re-arming the moment the bottom is touched would be wrong: while streaming, the bottom keeps moving). A **Jump to latest** button is the way back. Scrolling now pins to the *end* of the last item.
- Version bumped to `0.6.1` / `versionCode 8`.

## Verification

`:app:compileDevDebugKotlin` and `:app:assembleDevDebug` pass. **The UI was not exercised on device** — no phone was attached to this session. Worth a look on the OnePlus before the tag: Markdown rendering on a real answer, and that dragging up mid-generation actually holds.

No engine, core or `third_party` code is touched.