### PR TITLE
feat(moe): --lock-dense pins the dense weights against reclaim

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -335,6 +335,8 @@ static void print_usage(const char * argv0) {
         "      --io-threads N      parallel expert-read lanes [1..%d] (default 4)\n"
         "      --no-odirect        do not bypass the page cache\n"
         "      --no-warm-dense     skip the load-time sweep that page-caches the non-expert weights\n"
+        "      --lock-dense        pin the non-expert weights in RAM (mlock) so expert traffic cannot\n"
+        "                          evict them; costs cache budget — for >RAM models, see the docs\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -403,6 +405,8 @@ int main(int argc, char ** argv) {
             cfg.moe.o_direct = false;
         else if (a == "--no-warm-dense")
             cfg.moe.warm_dense = false;
+        else if (a == "--lock-dense")
+            cfg.moe.lock_dense = true;
         else if (a == "--load-all")
             cfg.moe.load_all = true;
         else if (a == "--force-cache")
@@ -511,9 +515,8 @@ int main(int argc, char ** argv) {
     // occupancy = CPU-time ÷ (wall × threads): ~1 is compute-bound, well under 1 is a throttled or
     // preempted core; major faults/token > 0 means dense weights re-faulted from flash inside decode.
     if (s.cpu_s_per_token > 0.0 || s.majflt_per_token > 0.0) {
-        const double occ = s.s_per_token > 0 && cfg.n_threads > 0
-                               ? s.cpu_s_per_token / (s.s_per_token * cfg.n_threads)
-                               : 0.0;
+        const double occ =
+            s.s_per_token > 0 && cfg.n_threads > 0 ? s.cpu_s_per_token / (s.s_per_token * cfg.n_threads) : 0.0;
         std::printf("compute: %.1f%% CPU occupancy (%.4f cpu-s/token over %d threads), %.2f major faults/token\n",
                     occ * 100.0, s.cpu_s_per_token, cfg.n_threads, s.majflt_per_token);
     }

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -64,6 +64,30 @@ struct MoeStreamConfig {
     // moves that cost into load_seconds at sequential-read bandwidth. Off for A/B measurements.
     bool warm_dense = true;
 
+    // Pin those same dense regions into RAM (mlock) after warming them, so the kernel cannot reclaim
+    // them again. Warming alone only fills the page cache, which is reclaimable *by definition*: on
+    // a model whose expert traffic dwarfs RAM the streamer's own reads evict the dense weights right
+    // back out and they re-fault from flash inside the next decode — measured at 6.0k→8.4k major
+    // faults per token on gpt-oss-120b, where the wait is billed to "compute" because it happens
+    // under llama_decode (see docs/bench-data/2026-07-15-route-trace/).
+    //
+    // OFF by default: this is a >RAM knob, not a free win. The pinned RAM has to come from somewhere,
+    // and on an auto budget it comes out of the expert cache — pinned pages leave MemAvailable, so
+    // the budget probe below sizes the cache around them. That trade is already measured: reserving
+    // Gemma's ~1.2 GiB of dense cost budget 4000→2909 MiB, hit 82.9→73.5 % and tok/s 4.76→3.76
+    // (docs/bench-data/2026-07-14-warmup/). Worth it only where cache hit rate is cheap to sell —
+    // gpt-oss-120b's cache holds ~5 % of a 58 GiB expert set and hits 13-32 %, so trading a slice of
+    // it for guaranteed dense residency is a good bet; Gemma/Qwen fit a useful cache, fault barely
+    // (18-49 majflt/token) and have nothing to gain. Judge it on majflt/token, not on principle.
+    //
+    // Deliberately NOT llama.cpp's mparams.use_mlock: that pins the whole mapping, experts included,
+    // which is the exact opposite of streaming (it would pin 58 GiB of gpt-oss onto an 11 GiB phone).
+    // Only the non-expert complement is locked; the expert region must stay reclaimable.
+    //
+    // Best-effort: the OS caps lockable memory (RLIMIT_MEMLOCK), so a refusal only means the pages
+    // stay merely warm, i.e. the warm_dense-only behaviour.
+    bool lock_dense = false;
+
     // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
     // thread, before returning. This defeats the latency-hiding purpose (the reads no longer
     // overlap compute) but makes speculative integration deterministic, so the byte-identity

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -69,6 +69,8 @@ public:
         long long spec_useful = 0;         // prefetched experts that a later lookup actually hit
         uint64_t cache_budget_bytes = 0;   // current cache budget (moves under --cache-mb auto)
         long long cache_resizes = 0;       // times the budget changed at runtime (auto + explicit)
+        uint64_t locked_dense_bytes = 0;   // dense weight bytes pinned into RAM (--lock-dense); 0 = none
+                                           // pinned, which is what a majflt/token reading is judged against
     };
     virtual Stats stats() const = 0;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -25,10 +25,10 @@ struct TokenMetrics {
     // them). They tell WHY a token's compute residual is large: major faults = dense weight re-read
     // from flash inside the decode; cpu_ms vs wall_ms×threads = how CPU-bound the decode really was
     // (low occupancy ⇒ throttled/preempted, not heavy math). See docs/telemetry.md.
-    uint64_t majflt = 0;        // major page faults during this decode (backing-store reads)
-    double cpu_ms = 0.0;        // CPU time summed across all threads during this decode
-    std::string piece;          // text of just this token (delta, for inline streaming)
-    std::string text;           // full generated text so far (for UI streaming)
+    uint64_t majflt = 0; // major page faults during this decode (backing-store reads)
+    double cpu_ms = 0.0; // CPU time summed across all threads during this decode
+    std::string piece;   // text of just this token (delta, for inline streaming)
+    std::string text;    // full generated text so far (for UI streaming)
 };
 
 struct RunSummary {
@@ -64,6 +64,8 @@ struct RunSummary {
     double cache_resident_mib = 0.0;
     double cache_budget_mib = 0.0; // current cache budget (moves under --cache-mb auto)
     long long cache_resizes = 0;   // runtime budget changes (0 unless auto/explicit resize)
+    double locked_dense_mib = 0.0; // dense weights pinned into RAM (--lock-dense); reads with
+                                   // majflt_per_token — pinned dense is what keeps that near zero
 
     // Temporal prefetch (zero when --prefetch is off): speculative bytes read during generation,
     // experts successfully prefetched, and how many of those a later routing actually used.

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -645,6 +645,7 @@ RunResult Session::generate(const GenerateRequest & req,
         s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);
         s.cache_budget_mib = st.cache_budget_bytes / (1024.0 * 1024.0);
         s.cache_resizes = st.cache_resizes;
+        s.locked_dense_mib = st.locked_dense_bytes / (1024.0 * 1024.0);
         s.moe_spec_read_mib = ((long long) st.spec_read_bytes - prev_spec_bytes) / (1024.0 * 1024.0);
         s.moe_spec_experts = st.spec_experts - prev_spec_experts;
         s.moe_spec_useful = st.spec_useful - prev_spec_useful;

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -87,6 +87,34 @@ void vm_release(void * p, size_t /*sz*/) {
     if (p) VirtualFree(p, 0, MEM_RELEASE);
 }
 
+size_t vm_lock(void * p, size_t sz) {
+    if (!p || !sz) return 0;
+    // VirtualLock draws from the process working set, which carries a small default quota — grow it
+    // first or the lock fails as soon as that quota is reached. Ask for the range plus slack for
+    // what the process already holds; if the grow is refused the lock loop still reports the truth.
+    SIZE_T mn = 0, mx = 0;
+    if (GetProcessWorkingSetSize(GetCurrentProcess(), &mn, &mx)) {
+        const SIZE_T want = (SIZE_T) sz + (64u << 20);
+        SetProcessWorkingSetSize(GetCurrentProcess(), mn + want, mx + want);
+    }
+    const size_t chunk = 64ull << 20; // truncate at the quota rather than fail the whole range
+    size_t done = 0;
+    while (done < sz) {
+        const size_t n = sz - done < chunk ? sz - done : chunk;
+        if (!VirtualLock((char *) p + done, n)) break;
+        done += n;
+    }
+    return done;
+}
+
+void vm_unlock(void * p, size_t sz) {
+    if (p && sz) VirtualUnlock(p, sz);
+}
+
+uint64_t vm_lock_limit_raise() {
+    return ~0ull; // no RLIMIT_MEMLOCK equivalent; the working-set quota is handled inside vm_lock
+}
+
 uint64_t mem_available_bytes() {
     MEMORYSTATUSEX ms;
     ms.dwLength = sizeof(ms);
@@ -152,6 +180,54 @@ void vm_evict(void * p, size_t sz) {
 }
 void vm_release(void * p, size_t sz) {
     if (p) munmap(p, sz);
+}
+
+size_t vm_lock(void * p, size_t sz) {
+#if defined(_POSIX_MEMLOCK_RANGE)
+    if (!p || !sz) return 0;
+    // Chunked: mlock() is all-or-nothing per call, so one call over the whole dense set would fail
+    // outright against a small RLIMIT_MEMLOCK and pin nothing. Locking in chunks pins what fits and
+    // stops at the first refusal — the remainder degrades to ordinary reclaimable page cache.
+    const size_t chunk = 64ull << 20;
+    size_t done = 0;
+    while (done < sz) {
+        const size_t n = sz - done < chunk ? sz - done : chunk;
+        if (mlock((char *) p + done, n) != 0) break;
+        done += n;
+    }
+    return done;
+#else
+    (void) p;
+    (void) sz;
+    return 0;
+#endif
+}
+
+void vm_unlock(void * p, size_t sz) {
+#if defined(_POSIX_MEMLOCK_RANGE)
+    if (p && sz) munlock(p, sz);
+#else
+    (void) p;
+    (void) sz;
+#endif
+}
+
+uint64_t vm_lock_limit_raise() {
+#if defined(RLIMIT_MEMLOCK)
+    struct rlimit rl;
+    if (getrlimit(RLIMIT_MEMLOCK, &rl) != 0) return 0;
+    if (rl.rlim_cur != rl.rlim_max) {
+        // Raising the soft limit up to the hard one needs no privilege. The hard limit is set by the
+        // OS/container (on Android it is typically generous for a shell process and tight for an
+        // app), and lifting THAT would need CAP_SYS_RESOURCE — out of scope for a library.
+        struct rlimit want = rl;
+        want.rlim_cur = rl.rlim_max;
+        if (setrlimit(RLIMIT_MEMLOCK, &want) == 0) rl = want;
+    }
+    return rl.rlim_cur == RLIM_INFINITY ? ~0ull : (uint64_t) rl.rlim_cur;
+#else
+    return ~0ull;
+#endif
 }
 
 uint64_t mem_available_bytes() {

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -48,6 +48,25 @@ bool vm_commit(void * p, size_t sz);
 void vm_evict(void * p, size_t sz);
 void vm_release(void * p, size_t sz);
 
+// Pin an already-mapped byte range into RAM so the kernel cannot reclaim it (mlock / VirtualLock),
+// and release the pin. Used to hold the model's dense weights resident: warming them only fills the
+// (reclaimable) page cache, which expert-streaming pressure then evicts, re-faulting them from
+// flash inside the next decode.
+//
+// Best-effort by contract, because the amount of lockable memory is capped by the OS (POSIX
+// RLIMIT_MEMLOCK — often small on Android) and the cap is a policy we must live with, not fail on:
+// vm_lock locks in chunks and returns the bytes it actually pinned, which may be less than `sz`
+// (0 = nothing). What is not pinned simply stays ordinary reclaimable page cache, i.e. today's
+// behaviour. `p` must be page-aligned; `sz` is rounded up to a page by the OS.
+size_t vm_lock(void * p, size_t sz);
+void vm_unlock(void * p, size_t sz);
+
+// Raise the process's lockable-memory soft limit to its hard limit and report the resulting cap in
+// bytes (UINT64_MAX = unlimited, 0 = unknown). Raising the SOFT limit needs no privilege; the hard
+// limit is what the OS/container grants, so this is the whole of what a process can do for itself.
+// Call once before a batch of vm_lock calls.
+uint64_t vm_lock_limit_raise();
+
 // Physical memory currently allocatable without paging, in bytes. 0 = unknown. Used to size the
 // expert cache to the device (--cache-mb auto) and to shrink it under memory pressure at runtime.
 uint64_t mem_available_bytes();

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -34,13 +34,13 @@ public:
                      "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
-                     "majflt/tok=%.2f cpu_s/tok=%.4f\n",
+                     "majflt/tok=%.2f cpu_s/tok=%.4f locked_dense_MiB=%.1f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
-                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful,
-                     s.majflt_per_token, s.cpu_s_per_token);
+                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
+                     s.cpu_s_per_token, s.locked_dense_mib);
         std::fflush(f_);
     }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -61,6 +61,24 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         return false;
     }
 
+    // Dense residency, before the adaptive budget below probes free RAM and before the rebind that
+    // moves the expert tensors off the mmap. Ordering is load-bearing on both sides:
+    //   * lock before the probe — pinned pages leave MemAvailable, so the cache must size itself
+    //     against the RAM that is actually left, not against RAM it is about to lose;
+    //   * lock before the rebind — the mapping base is derived from the expert tensors, which only
+    //     point into the model's mmap until then.
+    // Both steps are best-effort and independent: warming without locking is the pre-lock
+    // behaviour, and locking pages the warm sweep already pulled in costs no I/O.
+    if (cfg.warm_dense || cfg.lock_dense) {
+        pio::fd_t dfd = pio::open_read(gguf_path.c_str(), false);
+        if (pio::fd_ok(dfd)) {
+            const auto dense = dense_file_ranges(pio::file_size(dfd));
+            if (cfg.warm_dense) warm_dense_regions(dfd, dense);
+            if (cfg.lock_dense) lock_dense_regions(dense);
+            pio::close_fd(dfd);
+        }
+    }
+
     // Adaptive budget: size the cache to the device now that the full expert-set size is known.
     // (validate() guarantees cache_mb == 0 here, so this is the sole source of cache_max_ when auto.)
     if (cfg.cache_auto) {
@@ -243,12 +261,6 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         }
     }
 
-    // Warm the dense (non-expert) regions into the page cache before the first token, so the early
-    // decodes do not fault them in one scattered 4 KiB page at a time. Independent of the cache
-    // budget: it only pre-faults the mmap-resident pages, it neither pins nor reserves them. Runs on
-    // the caller's thread (the workers are not started yet).
-    if (cfg.warm_dense) warm_dense_regions(gguf_path);
-
     active_ = true;
     // Serial: lane 0 is the calling thread (it drains inline), workers own lanes 1..N-1.
     // Overlap: the caller never drains — every lane 0..N-1 gets a worker so reads proceed
@@ -262,13 +274,8 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     return true;
 }
 
-// ── dense warm-up: sequentially page-cache everything that is not an expert tensor ──
-void ExpertStreamSource::warm_dense_regions(const std::string & gguf_path) {
-    // The complement of the expert byte ranges is the dense set: gguf header/metadata plus every
-    // tensor the streamer leaves mmap-resident (embeddings, attention, norms, lm_head). Buffered
-    // reads land in the same page cache the mmap is served from, so one sequential sweep here
-    // replaces thousands of random 4 KiB major faults during the first decodes. Best-effort: a read
-    // failure only leaves the corresponding pages cold.
+// ── the dense set: everything in the file that is not an expert tensor ──────────────
+std::vector<std::pair<uint64_t, uint64_t>> ExpertStreamSource::dense_file_ranges(uint64_t fsize) const {
     std::vector<std::pair<uint64_t, uint64_t>> expert_ranges;
     for (const LayerExperts & L : layers_) {
         if (!L.bound) continue;
@@ -279,21 +286,32 @@ void ExpertStreamSource::warm_dense_regions(const std::string & gguf_path) {
     }
     std::sort(expert_ranges.begin(), expert_ranges.end());
 
-    pio::fd_t fd = pio::open_read(gguf_path.c_str(), false);
-    if (!pio::fd_ok(fd)) return;
+    // Walk the sorted expert ranges and keep the gaps between them.
+    std::vector<std::pair<uint64_t, uint64_t>> dense;
+    uint64_t pos = 0;
+    for (const auto & r : expert_ranges) {
+        if (r.first > pos) dense.push_back({pos, r.first});
+        pos = std::max(pos, r.second);
+    }
+    if (pos < fsize) dense.push_back({pos, fsize}); // trailing dense tail (lm_head et al.)
+    return dense;
+}
+
+// ── dense warm-up: sequentially page-cache everything that is not an expert tensor ──
+void ExpertStreamSource::warm_dense_regions(pio::fd_t fd, const std::vector<std::pair<uint64_t, uint64_t>> & dense) {
+    // Buffered reads land in the same page cache the mmap is served from, so one sequential sweep
+    // here replaces thousands of random 4 KiB major faults during the first decodes. Best-effort: a
+    // read failure only leaves the corresponding pages cold.
     const size_t chunk = 8ull << 20;
     void * buf = pio::alloc_aligned(align_, chunk);
-    if (!buf) {
-        pio::close_fd(fd);
-        return;
-    }
+    if (!buf) return;
 
     const auto t0 = clock_t_::now();
     uint64_t warmed = 0;
     bool ok = true;
-    auto sweep = [&](uint64_t beg, uint64_t end) {
-        for (uint64_t a = beg; a < end && ok;) {
-            const long long got = pio::pread_at(fd, buf, (size_t) std::min<uint64_t>(chunk, end - a), a);
+    for (const auto & r : dense) {
+        for (uint64_t a = r.first; a < r.second && ok;) {
+            const long long got = pio::pread_at(fd, buf, (size_t) std::min<uint64_t>(chunk, r.second - a), a);
             if (got <= 0) {
                 ok = false; // best-effort: those pages just stay cold
                 break;
@@ -301,19 +319,81 @@ void ExpertStreamSource::warm_dense_regions(const std::string & gguf_path) {
             a += (uint64_t) got;
             warmed += (uint64_t) got;
         }
-    };
-    uint64_t pos = 0;
-    for (const auto & r : expert_ranges) {
-        if (r.first > pos) sweep(pos, r.first); // gap before this expert range is dense
-        pos = std::max(pos, r.second);
+        if (!ok) break;
     }
-    if (pos < fsize_) sweep(pos, fsize_); // trailing dense tail (lm_head et al.)
 
     pio::aligned_free(buf);
-    pio::close_fd(fd);
     const double s = std::chrono::duration<double>(clock_t_::now() - t0).count();
     std::fprintf(stderr, "bmoe: dense warm-up — %llu MiB in %.1f s%s\n", (unsigned long long) (warmed >> 20), s,
                  ok ? "" : " (partial)");
+}
+
+// ── where the model's mapping starts ────────────────────────────────────────────────
+const uint8_t * ExpertStreamSource::mmap_base() const {
+    const uint8_t * base = nullptr;
+    for (const LayerExperts & L : layers_) {
+        if (!L.bound) continue;
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            const ExpertTensorRef & r = L.proj[p];
+            if (!r.tensor || !r.tensor->data) continue;
+            const uint8_t * b = (const uint8_t *) r.tensor->data - r.file_off;
+            if (!base)
+                base = b;
+            else if (base != b)
+                return nullptr; // tensors disagree → not one mapping of the whole file
+        }
+    }
+    return base;
+}
+
+// ── dense lock: hold the warmed pages against reclaim ───────────────────────────────
+void ExpertStreamSource::lock_dense_regions(const std::vector<std::pair<uint64_t, uint64_t>> & dense) {
+    const uint8_t * base = mmap_base();
+    if (!base) {
+        std::fprintf(stderr, "bmoe: dense lock — model is not a single file mapping, skipped\n");
+        return;
+    }
+    const uint64_t cap = pio::vm_lock_limit_raise();
+    const size_t page = pio::vm_page();
+
+    const auto t0 = clock_t_::now();
+    uint64_t want = 0;
+    for (const auto & r : dense) {
+        // Align outward: a dense range's edge pages are still dense data we want held. This can pull
+        // in the page an edge shares with an adjacent expert range — a few KiB per boundary, which
+        // is a rounding error against the dense set and costs nothing to pin.
+        const uint64_t beg = r.first & ~(uint64_t) (page - 1);
+        const uint64_t end = (r.second + page - 1) & ~(uint64_t) (page - 1);
+        const size_t len = (size_t) (end - beg);
+        want += len;
+        const size_t got = pio::vm_lock((void *) (base + beg), len);
+        if (got) {
+            locked_.push_back({(void *) (base + beg), got});
+            locked_bytes_ += got;
+        }
+        if (got < len) break; // the cap is reached; the rest stays warm-but-reclaimable
+    }
+
+    const double s = std::chrono::duration<double>(clock_t_::now() - t0).count();
+    if (locked_bytes_ == want) {
+        std::fprintf(stderr, "bmoe: dense lock — %llu MiB pinned in %.1f s\n",
+                     (unsigned long long) (locked_bytes_ >> 20), s);
+    } else {
+        // The common cause is RLIMIT_MEMLOCK. Say so with the numbers, because the fix lives outside
+        // the process (ulimit -l, or a launcher with a higher hard limit) and the run would
+        // otherwise silently degrade to warm-only and just look slow.
+        char capbuf[32];
+        if (cap == ~0ull)
+            std::snprintf(capbuf, sizeof(capbuf), "unlimited");
+        else if (cap)
+            std::snprintf(capbuf, sizeof(capbuf), "%llu MiB", (unsigned long long) (cap >> 20));
+        else
+            std::snprintf(capbuf, sizeof(capbuf), "unknown");
+        std::fprintf(stderr,
+                     "bmoe: dense lock — %llu of %llu MiB pinned in %.1f s (lockable cap %s)"
+                     " — the rest stays reclaimable\n",
+                     (unsigned long long) (locked_bytes_ >> 20), (unsigned long long) (want >> 20), s, capbuf);
+    }
 }
 
 // ── one aligned slice read on a lane ────────────────────────────────────────────────
@@ -1015,6 +1095,7 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     s.stall_seconds = stall_ns_.load() / 1e9;
     s.cache_budget_bytes = (uint64_t) cache_max_;
     s.cache_resizes = cache_resizes_;
+    s.locked_dense_bytes = (uint64_t) locked_bytes_;
     return s;
 }
 
@@ -1048,6 +1129,13 @@ void ExpertStreamSource::shutdown() {
     io_pool_.clear();
     spec_done_.clear();
     spec_touched_.clear();
+
+    // Unpin the dense ranges. These are addresses inside the model's mmap, which llama.cpp owns and
+    // may still be using — so release the pin only, never the mapping.
+    for (const auto & r : locked_)
+        pio::vm_unlock(r.first, r.second);
+    locked_.clear();
+    locked_bytes_ = 0;
 
     for (int p = 0; p < MoeRecipe::max_exps; ++p)
         if (slot_[p]) {

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -112,11 +112,29 @@ private:
     void quiesce_spec();
     void release_entry_pages(int32_t id);
 
-    // One sequential buffered sweep over the file's non-expert byte ranges (header, embeddings,
-    // attention, norms, lm_head) to populate the kernel page cache at load time, so the mmap'd
-    // dense tensors do not demand-fault 4 KiB at a time inside the first decodes. Best-effort:
-    // a read failure only leaves the corresponding pages cold.
-    void warm_dense_regions(const std::string & gguf_path);
+    // The file's dense byte ranges: the complement of the expert tensor ranges, i.e. the gguf
+    // header/metadata plus every tensor the streamer leaves mmap-resident (embeddings, attention,
+    // norms, lm_head). Both dense-residency steps below work off this one definition.
+    // PRECONDITION: layers_ is populated (file offsets known); safe before or after the rebind.
+    std::vector<std::pair<uint64_t, uint64_t>> dense_file_ranges(uint64_t fsize) const;
+
+    // One sequential buffered sweep over the dense ranges to populate the kernel page cache at load
+    // time, so the mmap'd dense tensors do not demand-fault 4 KiB at a time inside the first
+    // decodes. Best-effort: a read failure only leaves the corresponding pages cold.
+    void warm_dense_regions(pio::fd_t fd, const std::vector<std::pair<uint64_t, uint64_t>> & dense);
+
+    // Pin the dense ranges into RAM so expert traffic cannot evict them back to flash. Records what
+    // it pinned in locked_ for shutdown(). Best-effort: see MoeStreamConfig::lock_dense.
+    // PRECONDITION: called BEFORE the expert rebind — it derives the mapping base from the captured
+    // expert tensors, which only point into the model's mmap until then.
+    void lock_dense_regions(const std::vector<std::pair<uint64_t, uint64_t>> & dense);
+
+    // Base address of the model's file mapping, derived from the captured expert tensors: each one
+    // still points at mmap_base + its gguf file offset, so the difference is the base. Returns
+    // nullptr if the tensors disagree — i.e. this is not one contiguous mapping of the whole file
+    // (a split load, or a non-mmap load), in which case a file offset says nothing about an address
+    // and locking must be skipped rather than guessed.
+    const uint8_t * mmap_base() const;
 
     // Adaptive sizing (cache_auto): re-probe device memory (throttled) and nudge cache_max_ so it
     // tracks free RAM. Eval-thread only, called in the mgmt section of load_layer; the eviction
@@ -134,6 +152,11 @@ private:
     void lru_push_back(int32_t id);
     size_t entry_bytes(int il) const;
     void evict_tail();
+
+    // Dense ranges pinned by lock_dense_regions, unpinned at shutdown. Address ranges into the
+    // model's mmap, which the engine does not own — so this is only ever munlock'd, never unmapped.
+    std::vector<std::pair<void *, size_t>> locked_;
+    size_t locked_bytes_ = 0;
 
     bool active_ = false;
     bool o_direct_ = false;

--- a/docs/adaptive-cache.md
+++ b/docs/adaptive-cache.md
@@ -27,6 +27,14 @@ the device and keeps it there as free memory moves.
   cache-sensitive model it lowers the budget and the hit rate, e.g. Gemma budget 4000→2909 MiB, hit
   83%→73%, trading throughput for OOM headroom that the warm-up already avoids needing. See
   [bench-data/2026-07-14-warmup/](bench-data/2026-07-14-warmup/).)
+- **Pinning dense (`--lock-dense`) pays the same price, and the budget is where it is paid.** The
+  flag mlocks the dense ranges so expert traffic cannot evict them; because pinned pages leave
+  `MemAvailable`, and the lock runs *before* the probe above, the budget lands exactly where the
+  rejected reserve landed (Gemma: 2909 MiB). That is not an accounting artifact to engineer away —
+  the RAM genuinely has to come out of the cache, and probing before the lock instead would only
+  hand the same bill to the runtime re-probe. The flag earns its keep only when cache hit rate is
+  cheap to sell: gpt-oss-120b's budget holds ~5 % of its expert set and hits 13–32 %, while it faults
+  thousands of dense pages per token. Decide with `majflt/tok` and `locked_dense_MiB` in the summary.
 - **During generation**, on the eval thread inside each layer's cache-management window, a throttled
   re-probe (about every 128 layer loads, ≈2–3 tokens — one `/proc` read) tracks free RAM: if it dips
   under the floor the budget shrinks by the shortfall and the normal eviction pass drains the cache
@@ -48,6 +56,7 @@ the rest of the system.
 | `--cache-mb auto` | size the cache to the device instead of a fixed MiB (mutually exclusive with a numeric `--cache-mb`) |
 | `--cache-floor-mb N` | RAM to leave free for the rest of the system when auto-sizing (default 1536) |
 | `--no-warm-dense` | skip the load-time sweep that page-caches the non-expert weights |
+| `--lock-dense` | pin the non-expert weights in RAM so expert traffic cannot evict them (off by default; spends cache budget — see above) |
 
 `auto` is a real LRU cache, so it satisfies the cache requirement of `--prefetch`.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -108,7 +108,10 @@ the fault + CPU-time decomposition of the compute residual (see the `BMOE_PROGRE
 `0` when unmeasured. All are additive: older CSVs have fewer columns, so consumers must read by
 column NAME (from the header row) and treat any as optional. The `# summary` line likewise gains
 `stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>` and `cpu_s/tok=<s>` (see the `io_ms` note
-above for how the read-time columns are reinterpreted under overlap).
+above for how the read-time columns are reinterpreted under overlap), plus
+`locked_dense_MiB=<f>` — the dense weight bytes pinned into RAM by `--lock-dense` (`0.0` when the
+flag is off, or when the OS refused the lock). Read it together with `majflt/tok`: the pair says
+whether the dense set is actually being held, and what the run paid in cache budget to hold it.
 
 ## Route trace
 


### PR DESCRIPTION
## Why

The route trace ([bench-data/2026-07-15](docs/bench-data/2026-07-15-route-trace/)) showed gpt-oss-120b's major faults growing **267 → 8431 per token** during a run, with `compute_ms` tracking them **539 → 1767 ms**. Warming the dense weights only fills the page cache, which is reclaimable by definition — the streamer's own expert reads evict them right back out, and they re-fault from flash *inside* the next decode, where the wait is billed to "compute".

## What

`--lock-dense` mlocks the dense ranges (the complement of the expert ranges — the same set `warm_dense` already sweeps) so the kernel cannot take them back.

- **Not** llama.cpp's `mparams.use_mlock`: that pins the whole mapping, experts included, which would try to pin 58 GiB of gpt-oss onto an 11 GiB phone. Only the non-expert complement is locked; the expert region must stay reclaimable.
- The mapping base is derived from the captured expert tensors (they point into the model's mmap until the rebind), validated for consistency across every captured tensor — if they disagree it is not one contiguous mapping and locking is skipped rather than guessed.
- Ordering is load-bearing: the lock runs **before** the rebind (which moves the tensors off the mmap) and **before** the auto-budget probe (pinned pages leave `MemAvailable`).
- New `pio::vm_lock` / `vm_unlock` / `vm_lock_limit_raise` primitives, both platforms.

## Off by default — and why

The RAM has to come from somewhere, and on an auto budget it comes out of the expert cache. **That trade is already measured in this repo** ([bench-data/2026-07-14-warmup](docs/bench-data/2026-07-14-warmup/)): reserving Gemma's dense set cost budget 4000→2909 MiB, hit 82.9→73.5 % and **tok/s 4.76→3.76**. Locking reproduces that arithmetic exactly, so a default-on flag would be a ~21 % regression on the models that fit a useful cache.

It is a **>RAM knob**: worth it where hit rate is cheap to sell (gpt-oss holds ~5 % of a 58 GiB expert set and faults thousands of pages/token), not on Qwen/Gemma which fault 18–49 times/token and have nothing to gain. Judge it on `majflt/tok`, not on principle.

Best-effort by contract: `RLIMIT_MEMLOCK` caps what a process may pin, so `vm_lock` chunks the range, reports what it pinned, and the remainder degrades to warm-only.

## Verification

- Host build clean, **all 4 byte-identity gates pass** (no data-path change).
- Driven end-to-end on both gate models: lock fires and pins (`bmoe: dense lock — N MiB pinned`), `--lock-dense` off by default, warm-off/lock-on works (mlock faults the pages in itself), CSV reports `locked_dense_MiB`.
- **Still needs the device A/B on gpt-oss-120b** — that is what decides whether the default should ever flip. Compare `majflt/tok` and steady-state `compute_ms` against the committed route-trace run.

