### PR TITLE
chore: portable bench paths, and ignore the scratch at the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ cmake-build-*/
 /.bench-*/
 *.safetensors
 /*.log
+# Scratch notes and raw run samples at the root. Curated CSVs live in docs/bench-data/.
+/*.csv
+/NEXT-SESSION-PROMPT.md
 
 # Android
 examples/android/.gradle/

--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -8,7 +8,8 @@
 #   mean = aggregate n_tokens / total_seconds ; min/max = slowest/fastest single token.
 import os, sys, statistics
 
-BENCH = sys.argv[1] if len(sys.argv) > 1 else r"C:\Users\raffa\Documents\BigMoeOnEdge\.bench"
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BENCH = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, ".bench")
 ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4",
          "stream_ov", "c2000_l4_ov", "c4000_l4_ov",
          "c4000_l4_pf1", "c4000_l4_pf2", "c4000_l4_pf4",

--- a/scripts/bench-matrix-rework.ps1
+++ b/scripts/bench-matrix-rework.ps1
@@ -4,7 +4,7 @@
 # bench-analyze.py picks them up) but with today's four configs per model. Qwen uses a 4000 MiB
 # reference/ceiling, Gemma a 2000 MiB one (4000 OOMs on this device).
 param(
-  [string]$OutDir = "C:\Users\raffa\Documents\BigMoeOnEdge\.bench",
+  [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench"),
   [int]$NPred = 256,
   [int]$CooldownSec = 45
 )

--- a/scripts/bench-matrix.ps1
+++ b/scripts/bench-matrix.ps1
@@ -1,6 +1,6 @@
 # On-device benchmark matrix driver. Invokes the instrumented device-side bench-run.sh.
 param(
-  [string]$OutDir = "C:\Users\raffa\Documents\BigMoeOnEdge\.bench",
+  [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench"),
   [int]$NPred = 256,
   [int]$CooldownSec = 45   # let the SoC cool to a similar baseline before each run
 )

--- a/scripts/bench-pr23-c2000.ps1
+++ b/scripts/bench-pr23-c2000.ps1
@@ -2,7 +2,7 @@
 # ~7 tok/s compute ceiling) and test the one new feature with a real shot here — shallow prefetch
 # (depth 1, low speculative volume, unlike spec-gate). Baseline vs +prefetch 1, at lane 4 overlap.
 param(
-  [string]$OutDir = "C:\Users\raffa\Documents\BigMoeOnEdge\.bench-pr23",
+  [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench-pr23"),
   [int]$NPred = 256,
   [int]$CooldownSec = 45
 )

--- a/scripts/bench-pr23-summary.py
+++ b/scripts/bench-pr23-summary.py
@@ -3,7 +3,8 @@
 # prefetch/spec-gate lines) and .metrics (device pressure) into one markdown table per model.
 import os, re, sys, statistics
 
-BENCH = sys.argv[1] if len(sys.argv) > 1 else r"C:\Users\raffa\Documents\BigMoeOnEdge\.bench-pr23"
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BENCH = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, ".bench-pr23")
 
 CFG_FULL = [
     ("base", "baseline (overlap)"),

--- a/scripts/bench-prefetch.ps1
+++ b/scripts/bench-prefetch.ps1
@@ -2,7 +2,7 @@
 # docs/bench-data/2026-07-12 (Qwen: cache 4000, lane 4, overlap; Gemma: cache 2000, lane 4,
 # overlap). One matrix per model: base / +prefetch.
 param(
-  [string]$OutDir = "C:\Users\raffa\Documents\BigMoeOnEdge\.bench-pr23",
+  [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench-pr23"),
   [int]$NPred = 256,
   [int]$CooldownSec = 45
 )


### PR DESCRIPTION
The six oldest bench scripts defaulted their output dir to one developer's home directory, which made them unrunnable anywhere else without passing an override. They all already accept one as arg 1 / `-OutDir`, so only the default was the problem: derive it from the script's own location instead, the way `scripts/build-host.sh:6` already does.

The newer scripts (`route-analyze.py`, `route-viewer.py`) already took paths as arguments — this brings the stragglers in line rather than inventing a convention.

Also ignore the root-level scratch a working session leaves behind. Curated CSVs live under `docs/bench-data/`, so the rule is root-anchored and cannot swallow them.

## Verification

- Both Python scripts parse, and the derived default resolves to the same `.bench` path the literal used to name.
- All four PowerShell scripts parse, and `$PSScriptRoot` in a `param()` default resolves to `<repo>/.bench` when the script is invoked as a file.
- `git grep -iE 'C:[\/]Users|raffa'` over the tracked tree (excluding `third_party`) returns nothing.