### PR TITLE
feat(android): 500 and 1000 MiB cache rungs, to find where the cache stops paying

### DIFF
--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -11,7 +11,7 @@ data class AppSettings(
     // streaming with overlap, 4 compute + 4 read lanes, model's own top-k. No device- or
     // benchmark-specific tuning — the knobs below let the user tune for their own hardware.
     val mmap: Boolean = false,          // baseline: no streaming — llama.cpp mmap loads the whole model
-    val cacheMb: Int = CACHE_AUTO,      // LRU expert cache budget; Auto / 0 / >= 2000 (see CACHE_CHOICES)
+    val cacheMb: Int = CACHE_AUTO,      // LRU expert cache budget; Auto / 0 / 500..6000 (see CACHE_CHOICES)
     val cacheCeilMb: Int = 3000,        // with cacheMb=Auto: upper bound on the auto budget (0 = no cap)
     val ioThreads: Int = 4,             // parallel expert-read lanes
     val threads: Int = 4,               // compute threads (-t)
@@ -52,6 +52,9 @@ data class AppSettings(
                 if (cacheCeilMb > 0) a += listOf("--cache-ceil-mb", cacheCeilMb.toString())
             } else {
                 a += listOf("--cache-mb", cacheMb.toString())
+                // The engine refuses a budget under its floor unless told the caller means it; the
+                // small rungs exist precisely to probe that floor, so send the override with them.
+                if (cacheNeedsForce(cacheMb)) a += "--force-cache"
             }
             a += listOf("--io-threads", ioThreads.toString())
             if (!oDirect) a += "--no-odirect"
@@ -95,11 +98,22 @@ data class AppSettings(
         // rejected recoverably by the CLI, leaving the session usable.
         const val SESSION_CTX = 4096
 
-        // -1 (Auto) sizes the cache to the device's free RAM at runtime (--cache-mb auto). Values
-        // between 0 and 2000 are omitted: a very small cache thrashes (evict + re-read) and the
-        // engine rejects it. Use Auto, 0, or >= 2000.
+        // -1 (Auto) sizes the cache to the device's free RAM at runtime (--cache-mb auto).
+        //
+        // 500 and 1000 are below the engine's cache_min_mb floor, so picking them makes [sessionArgv]
+        // add --force-cache. The floor exists because a cache smaller than one token's routed working
+        // set can only thrash — but that verdict was measured on models whose cache pays for itself,
+        // and it is exactly what is in question on a >RAM model: gpt-oss-120b at top-2 routes ~886 MB
+        // per token and returns an 8-13% hit rate from a 2000-3000 MiB budget, so its cache may
+        // already be below the floor's intent while sitting well above its number. These rungs are
+        // here to measure where the cache stops earning the memory pressure it creates.
+        // See docs/android-memory.md.
         const val CACHE_AUTO = -1
-        val CACHE_CHOICES = intArrayOf(CACHE_AUTO, 0, 2000, 3000, 4000, 5000, 6000)
+        val CACHE_CHOICES = intArrayOf(CACHE_AUTO, 0, 500, 1000, 2000, 3000, 4000, 5000, 6000)
+
+        /** True for a fixed budget the engine would reject without --force-cache. */
+        fun cacheNeedsForce(mb: Int) = mb in 1 until CACHE_MIN_MB
+        const val CACHE_MIN_MB = 1500 // mirrors MoeStreamConfig::cache_min_mb
         // Upper bound for the Auto budget (0 = no cap). A cap keeps Auto from over-growing into
         // memory pressure on devices where free RAM is tight.
         val CACHE_CEIL_CHOICES = intArrayOf(0, 2000, 3000, 4000, 5000, 6000)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -62,8 +62,13 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     enabled = stream,
                 ) { onChange(current.copy(cacheMb = it)) }
                 Text(
-                    "Larger cache = fewer flash reads per token, but more RAM. Auto sizes to free RAM and " +
-                        "shrinks under memory pressure. Fixed values are 0 (off) or ≥ 2000 MiB.",
+                    "Larger cache = fewer flash reads per token, but more RAM — and RAM the kernel takes " +
+                        "back is paid for twice. Auto sizes to free RAM and shrinks under memory pressure. " +
+                        if (AppSettings.cacheNeedsForce(current.cacheMb))
+                            "500 and 1000 are below the engine's floor (--force-cache): a cache under one " +
+                                "token's routed experts can only thrash. Kept for measuring where the cache " +
+                                "stops earning its memory."
+                        else "500 and 1000 sit below the engine's floor and need --force-cache.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 IntSetting(


### PR DESCRIPTION
Extracted from #28 — this is an independent Settings change that had no reason to be gated on the rewarm experiment's fate.

The Settings only offered 0 or >= 2000 because the engine rejects anything under its 1500 MiB floor. That floor says a cache smaller than one token's routed working set can only thrash — sound, but it was measured on models whose cache pays for itself. On a >RAM model the question is live: gpt-oss-120b at top-2 routes ~886 MB per token and returns an 8-13% hit from a 2000-3000 MiB budget, because that budget covers ~5% of a 56.8 GB expert bank. It may already be below the floor's intent while sitting well above its number.

So the rungs use the floor's own escape hatch: a fixed budget under 1500 routes through `--force-cache`. The help text says what the small rungs are for, since a knob that thrashes by design should say so where it is turned.

See #30 for the measurement that motivates asking the question.

## Verification

Android Settings only — no engine, no core, no streaming path. Behavioural check belongs to the next on-device bench run.