### PR TITLE
Pressure-aware cache sizing: find the budget the device concedes

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -260,10 +260,11 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
                 std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
             std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
                         "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
-                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"text\":\"%s\"}\n",
+                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"resident_frac\":%.3f,"
+                        "\"text\":\"%s\"}\n",
                         m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
                         m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
-                        json_escape(m.text).c_str());
+                        m.resident_frac, json_escape(m.text).c_str());
             std::fflush(stdout);
         };
 
@@ -293,12 +294,13 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
                     "\"prefill_tps\":%.2f,\"load_s\":%.3f,\"cache_hit_pct\":%.1f,\"n_prompt\":%d,\"n_past\":%d,"
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
                     "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"majflt_tok\":%.2f,\"cpu_s_tok\":%.4f,"
-                    "\"text\":\"%s\"}\n",
+                    "\"token_demand_mib\":%.1f,\"cache_cuts\":%lld,\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
-                    s.majflt_per_token, s.cpu_s_per_token, json_escape(r.generated_text).c_str());
+                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, s.cache_cuts,
+                    json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
 
@@ -333,6 +335,9 @@ static void print_usage(const char * argv0) {
         "      --cache-mb N|auto   LRU expert cache budget in MiB (0=off, or >=%d); auto=size to device\n"
         "      --cache-floor-mb N  with --cache-mb auto: RAM to leave free (default 1536)\n"
         "      --cache-ceil-mb N   with --cache-mb auto: upper bound on the budget (0 = no cap)\n"
+        "      --cache-dynamic     treat --cache-mb as a ceiling and find the budget the device\n"
+        "                          concedes: shrink when reclaim starts taking the cache, grow back\n"
+        "                          when it stops (needs the cache; see docs/pressure.md)\n"
         "      --io-threads N      parallel expert-read lanes [1..%d] (default 4)\n"
         "      --no-odirect        do not bypass the page cache\n"
         "      --no-warm-dense     skip the load-time sweep that page-caches the non-expert weights\n"
@@ -404,6 +409,10 @@ int main(int argc, char ** argv) {
             cfg.moe.cache_floor_mb = std::atoi(next("--cache-floor-mb"));
         else if (a == "--cache-ceil-mb")
             cfg.moe.cache_ceil_mb = std::atoi(next("--cache-ceil-mb"));
+        else if (a == "--cache-dynamic")
+            cfg.moe.cache_dynamic = true;
+        else if (a == "--no-cache-dynamic")
+            cfg.moe.cache_dynamic = false;
         else if (a == "--io-threads")
             cfg.moe.io_threads = std::atoi(next("--io-threads"));
         else if (a == "--no-odirect")
@@ -508,10 +517,11 @@ int main(int argc, char ** argv) {
                 std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
             std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
                         "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
-                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"text\":\"%s\"}\n",
+                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"resident_frac\":%.3f,"
+                        "\"text\":\"%s\"}\n",
                         m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
                         m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
-                        json_escape(m.text).c_str());
+                        m.resident_frac, json_escape(m.text).c_str());
             std::fflush(stdout);
         } else {
             std::fwrite(m.piece.data(), 1, m.piece.size(), stdout);

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_library(bmoe_core STATIC
     src/config.cpp
     src/moe/arch_registry.cpp
+    src/moe/cache_governor.cpp
 )
 
 target_include_directories(bmoe_core PUBLIC

--- a/core/include/bmoe/cache_governor.h
+++ b/core/include/bmoe/cache_governor.h
@@ -1,0 +1,113 @@
+// Pressure-aware cache sizing: the policy half.
+//
+// A streaming engine on a phone competes with the kernel for RAM, and it loses. Ask for more
+// than the device concedes and reclaim becomes a standing condition: pages are taken mid-decode,
+// faulted back, taken again. Measured on a >RAM model, that war costs ~5x throughput, and
+// restoring the stolen pages does not win it — the ask itself has to shrink (docs/pressure.md).
+//
+// Nothing unprivileged can read the device's concession: MemAvailable counts our own mmap'd
+// weights as free, PSI is SELinux-blocked for apps, and onTrimMemory is late and one-sided. So
+// this does not ask the OS how much memory it has. It watches what happens to memory we already
+// hold and reacts — AIMD, the same shape TCP uses against an unobservable bottleneck. Growth is
+// additive and cheap to give back; a cut is multiplicative because the asymmetry is real: asking
+// too much costs a continuous war mid-decode, asking too little costs only a few points of hit
+// rate.
+//
+// Pure policy: no syscalls, no clocks, no config reads, no llama.cpp. The caller feeds sensor
+// readings per token and applies the returned budget. That keeps it unit-testable against a
+// synthetic device, and portable — the Android sensors are getrusage + mincore, but an iOS port
+// (os_proc_available_memory, DISPATCH_SOURCE_TYPE_MEMORYPRESSURE) only has to fill the same
+// struct.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace bmoe {
+
+// What the sensors saw during one token's decode.
+struct CacheSignals {
+    // Major page faults during this decode (getrusage ru_majflt delta). The fast reflex: it costs
+    // one syscall and it is already measured per token for the telemetry. Reads 0 on platforms
+    // that cannot report it, which reads as calm.
+    uint64_t majflt = 0;
+
+    // Sampled fraction of the cache's own pages still in RAM (mincore over the LRU cold end), or
+    // < 0 when not sampled this token (the sampler is throttled) or unsupported. This is the
+    // primary signal: it is absolute — no baseline, no device knowledge — and it sees the theft
+    // before those pages fault back and cost a read.
+    double resident_frac = -1.0;
+
+    // One token's routed working set in bytes, measured by the streamer (0 = not yet known). The
+    // floor: below it every token evicts what the next one needs, so the cache can only thrash.
+    // Measured rather than assumed, because it is a property of the model and top-k, not the device.
+    size_t floor = 0;
+};
+
+struct CacheGovernorParams {
+    size_t user_cap = 0; // never exceed: the configured budget (--cache-mb, or the auto ceiling)
+    size_t initial = 0;  // starting budget
+    size_t min_cap = 0;  // hard lower bound, used when CacheSignals::floor is still unknown
+
+    // ── tunables ──
+    // Deliberately compiled in rather than exposed: they are control-loop policy, not per-device
+    // facts. The loop discovers the device's concession at runtime; these only shape how fast.
+    // Calibrated against the traces in docs/bench-data/ (see docs/pressure.md).
+
+    // Cut when the sampled residency drops below this. Our own cache pages going missing IS the
+    // reclaim, so anything short of ~all-resident means the kernel already disagrees with the ask.
+    double resident_min = 0.90;
+
+    // Reflex threshold between residency samples: cut when majflt exceeds baseline*ratio + margin.
+    // The margin keeps a near-zero baseline from making single faults look like a war; at roughly
+    // 100 us per fault from flash, 32 faults is ~3 ms — noise against a token, not a signal.
+    double fault_ratio = 3.0;
+    uint64_t fault_margin = 32;
+    double baseline_decay = 0.9; // EWMA weight for the calm-token fault baseline
+
+    double cut_factor = 0.7;                // multiplicative decrease
+    int cut_cooldown = 4;                   // tokens to wait after a cut before another (let the shrink land)
+    int calm_tokens = 32;                   // consecutive calm tokens before growing
+    size_t grow_step = 64ull * 1024 * 1024; // additive increase
+    double ceiling_retreat = 0.9;           // grow freely only below ceiling*this
+    int probe_after = 512;                  // calm tokens pinned at the ceiling before re-testing it
+};
+
+class CacheGovernor {
+public:
+    explicit CacheGovernor(const CacheGovernorParams & p);
+
+    struct Decision {
+        size_t cap = 0;       // the budget after this tick
+        bool changed = false; // true ⇒ the caller must apply cap to the cache now
+    };
+
+    // One tick per generated token, after the decode (the only point where the cache has no
+    // decode in flight, so an evicting shrink is safe).
+    Decision on_token(const CacheSignals & s);
+
+    // Telemetry.
+    size_t cap() const { return cap_; }
+    long long cuts() const { return cuts_; }
+    double baseline() const { return baseline_; }
+    // The smallest budget observed to provoke reclaim, i.e. what the device would not concede.
+    // no_ceiling while none has been found (or after a probe forgets it).
+    size_t ceiling() const { return ceiling_; }
+
+    static constexpr size_t no_ceiling = (size_t) -1;
+
+private:
+    size_t floor_of(const CacheSignals & s) const;
+    size_t grow_limit() const;
+
+    CacheGovernorParams p_;
+    size_t cap_ = 0;
+    size_t ceiling_ = no_ceiling;
+    double baseline_ = -1.0; // EWMA of calm-token majflt; < 0 until the first calm token
+    int calm_ = 0;
+    int since_cut_ = 0;
+    int since_probe_ = 0;
+    long long cuts_ = 0;
+};
+
+} // namespace bmoe

--- a/core/include/bmoe/cache_governor.h
+++ b/core/include/bmoe/cache_governor.h
@@ -38,11 +38,29 @@ struct CacheSignals {
     // before those pages fault back and cost a read.
     double resident_frac = -1.0;
 
-    // One token's routed working set in bytes, measured by the streamer (0 = not yet known). The
-    // floor: below it every token evicts what the next one needs, so the cache can only thrash.
-    // Measured rather than assumed, because it is a property of the model and top-k, not the device.
+    // The largest single layer's routed working set in bytes, measured by the streamer (0 = not yet
+    // known). This is the floor, and it is a mechanical one: the cache must be able to hold the
+    // layer currently being staged. It is NOT "one token's working set" — see the note below.
     size_t floor = 0;
 };
+
+// A note on the floor, because the obvious choice is wrong and it was measured to be wrong.
+//
+// The tempting floor is one TOKEN's routed working set: below it, every token evicts what the next
+// one needs, so the cache stops holding anything between tokens and its hit rate collapses. That is
+// true, and it is what MoeStreamConfig::cache_min_mb encodes. It is still the wrong floor.
+//
+// Measured on gpt-oss-120b at top-4 (docs/bench-data/2026-07-15-pressure/): one token routes
+// 1815 MiB. Flooring the governor there pinned the budget at exactly 1815 MiB — a 9% cut from 2000
+// — where it bought an 8% hit rate and went on losing the memory war at 0.37 tok/s, with the fault
+// reflex firing into a floor that would not yield. Meanwhile a hand-set 1000 MiB budget, far BELOW
+// that floor, runs the same model well.
+//
+// The flaw is the comparison. "Below the floor the cache can only thrash" weighs the hits lost and
+// ignores that the memory itself is the cost: an unaffordable cache does not merely fail to earn
+// its hits, it starts a reclaim war that costs several times what any hit rate could return. Losing
+// inter-token hits is bounded and cheap; losing the war is neither. So usefulness must yield to
+// pressure, and the only floor that may not yield is the mechanical one.
 
 struct CacheGovernorParams {
     size_t user_cap = 0; // never exceed: the configured budget (--cache-mb, or the auto ceiling)

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -34,6 +34,20 @@ struct MoeStreamConfig {
                                // expert-set size); useful to keep the cache from taking all the
                                // headroom when the marginal hit-rate gain no longer justifies the RAM
 
+    // Let the engine find the largest cache the device will actually concede, instead of trusting a
+    // number. cache_mb (or the auto budget) becomes an upper bound; from there the engine watches
+    // its OWN pages — major faults per token, and how much of the cache the kernel still has in RAM
+    // — and shrinks the budget when reclaim starts taking it, growing back when the pressure lifts.
+    //
+    // The motivation is measured: a budget the device will not concede does not merely go unused,
+    // it starts a war that runs THROUGH the decode (pages taken, faulted back, taken again) and
+    // costs several times the throughput the cache was supposed to buy. The signals are deliberately
+    // syscalls about ourselves (getrusage, mincore), because that is all an unprivileged app can
+    // rely on across devices — MemAvailable counts our own mmap'd weights as free, PSI is
+    // SELinux-blocked, onTrimMemory is late and never signals relief. Requires the LRU cache.
+    // See docs/pressure.md and bmoe/cache_governor.h.
+    bool cache_dynamic = false;
+
     // Parallel expert-slice read lanes (incl. the calling thread). 1 = serial baseline.
     // Clamped to [1, io_threads_max]. 4 is the measured sweet spot on UFS4 phones.
     int io_threads = 4;

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -75,6 +75,11 @@ public:
         // throttled, sensing off, or a platform that cannot report). Below 1 means the kernel is
         // reclaiming the cache out from under us.
         double cache_resident_frac = -1.0;
+        // Sampled fraction of the DENSE weights (the mmap'd model) still in RAM, or -1 when not
+        // measured. The companion to cache_resident_frac: that one watches our anon cache, this one
+        // the file-backed weights it is blind to. Dense falling while cache holds means the faults
+        // are the model, not the cache — and shrinking the cache cannot help.
+        double dense_resident_frac = -1.0;
         // Bytes of distinct experts one token routes, measured (0 = not yet known). What a cache
         // must clear to hold anything BETWEEN tokens — where hits start, not a floor to defend:
         // on a >RAM model it can exceed what the device concedes. See bmoe/cache_governor.h.

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -75,9 +75,13 @@ public:
         // throttled, sensing off, or a platform that cannot report). Below 1 means the kernel is
         // reclaiming the cache out from under us.
         double cache_resident_frac = -1.0;
-        // Bytes of distinct experts one token routes, measured (0 = not yet known). The floor a
-        // cache must clear to hold anything between tokens.
+        // Bytes of distinct experts one token routes, measured (0 = not yet known). What a cache
+        // must clear to hold anything BETWEEN tokens — where hits start, not a floor to defend:
+        // on a >RAM model it can exceed what the device concedes. See bmoe/cache_governor.h.
         uint64_t token_demand_bytes = 0;
+        // Bytes the widest single layer routes, measured (0 = not yet known). The mechanical floor:
+        // the cache must hold the layer being staged.
+        uint64_t layer_demand_bytes = 0;
     };
     virtual Stats stats() const = 0;
 };

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -69,6 +69,15 @@ public:
         long long spec_useful = 0;         // prefetched experts that a later lookup actually hit
         uint64_t cache_budget_bytes = 0;   // current cache budget (moves under --cache-mb auto)
         long long cache_resizes = 0;       // times the budget changed at runtime (auto + explicit)
+
+        // ── pressure sensing (--cache-dynamic; see bmoe/cache_governor.h) ──
+        // Sampled fraction of the cache's own pages still in RAM, or -1 when not measured (sampler
+        // throttled, sensing off, or a platform that cannot report). Below 1 means the kernel is
+        // reclaiming the cache out from under us.
+        double cache_resident_frac = -1.0;
+        // Bytes of distinct experts one token routes, measured (0 = not yet known). The floor a
+        // cache must clear to hold anything between tokens.
+        uint64_t token_demand_bytes = 0;
     };
     virtual Stats stats() const = 0;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -75,6 +75,8 @@ struct RunSummary {
     // hits from inter-token routing correlation only. Reading it against cache_budget_mib is how a
     // budget stops being a guess. 0 when streaming is off or nothing was routed.
     double token_demand_mib = 0.0;
+    // The widest layer's routed bytes: the mechanical floor the governor may never cut below.
+    double layer_demand_mib = 0.0;
     // Times --cache-dynamic cut the budget because the device was reclaiming the cache (0 when off).
     long long cache_cuts = 0;
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -25,10 +25,15 @@ struct TokenMetrics {
     // them). They tell WHY a token's compute residual is large: major faults = dense weight re-read
     // from flash inside the decode; cpu_ms vs wall_ms×threads = how CPU-bound the decode really was
     // (low occupancy ⇒ throttled/preempted, not heavy math). See docs/telemetry.md.
-    uint64_t majflt = 0;        // major page faults during this decode (backing-store reads)
-    double cpu_ms = 0.0;        // CPU time summed across all threads during this decode
-    std::string piece;          // text of just this token (delta, for inline streaming)
-    std::string text;           // full generated text so far (for UI streaming)
+    uint64_t majflt = 0; // major page faults during this decode (backing-store reads)
+    double cpu_ms = 0.0; // CPU time summed across all threads during this decode
+    // Fraction of the expert cache's own pages the kernel still had in RAM at the last sample, or -1
+    // when unmeasured (sampler throttled, streaming off, platform can't report). Under 1 the device
+    // is reclaiming the cache mid-run — the pressure --cache-dynamic sizes against. See
+    // docs/pressure.md.
+    double resident_frac = -1.0;
+    std::string piece; // text of just this token (delta, for inline streaming)
+    std::string text;  // full generated text so far (for UI streaming)
 };
 
 struct RunSummary {
@@ -62,8 +67,16 @@ struct RunSummary {
     double majflt_per_token = 0.0;
     double cpu_s_per_token = 0.0;
     double cache_resident_mib = 0.0;
-    double cache_budget_mib = 0.0; // current cache budget (moves under --cache-mb auto)
-    long long cache_resizes = 0;   // runtime budget changes (0 unless auto/explicit resize)
+    double cache_budget_mib = 0.0; // current cache budget (moves under --cache-mb auto/--cache-dynamic)
+    long long cache_resizes = 0;   // runtime budget changes (0 unless auto/dynamic/explicit resize)
+
+    // What one token actually demands of the cache, measured: the distinct expert bytes routed per
+    // token. A cache below this can hold nothing between tokens; a cache far above it is buying
+    // hits from inter-token routing correlation only. Reading it against cache_budget_mib is how a
+    // budget stops being a guess. 0 when streaming is off or nothing was routed.
+    double token_demand_mib = 0.0;
+    // Times --cache-dynamic cut the budget because the device was reclaiming the cache (0 when off).
+    long long cache_cuts = 0;
 
     // Temporal prefetch (zero when --prefetch is off): speculative bytes read during generation,
     // experts successfully prefetched, and how many of those a later routing actually used.

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -32,6 +32,11 @@ struct TokenMetrics {
     // is reclaiming the cache mid-run — the pressure --cache-dynamic sizes against. See
     // docs/pressure.md.
     double resident_frac = -1.0;
+    // Fraction of the DENSE weights (the mmap'd model) still in RAM, or -1 when unmeasured. The other
+    // half of memory: resident_frac watches the anon cache, this the file-backed weights. Dense
+    // falling while resident_frac holds says the faults are the model, and a smaller cache cannot fix
+    // that. See docs/pressure.md.
+    double dense_resident_frac = -1.0;
     // What those faults actually moved, in MiB (majflt × page size). The same fact as `majflt`, in
     // the unit the rest of this struct is in: 47447 faults is unreadable, 194 MiB re-faulted in one
     // token is immediately comparable to `read_bytes` — the reads we chose against the reads the
@@ -51,15 +56,6 @@ struct TokenMetrics {
     double mem_available_mib = 0.0;
     double mem_free_mib = 0.0;
     double swap_free_mib = 0.0;
-
-    // System-wide reclaim activity this token, from /proc/vmstat (MiB scanned/refaulted = page-count
-    // delta × page size). The EARLIEST warning there is, and the noisiest: system-wide, so another
-    // app moves it too — but kswapd_scan rising means the machine started hunting for victims before
-    // any page of ours was taken, and direct_scan means a thread (maybe ours) had to stop and reclaim
-    // itself. ws_refault rising means thrash already began somewhere. 0 when /proc/vmstat is denied.
-    double kswapd_scan_mib = 0.0;
-    double direct_scan_mib = 0.0;
-    double ws_refault_mib = 0.0;
 
     // The cache budget as of this token. In the summary it is only the last value; per token it is
     // the governor's trajectory — when it cut, how far, whether it grew back. Without it a run that

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -113,11 +113,42 @@ struct RunSummary {
     long long moe_spec_useful = 0;
 };
 
-// Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_token for each
-// token and on_summary once at the end.
+// What this run IS: the model and the configuration every row below it was produced under.
+//
+// Rows without it are not evidence. Two CSVs put side by side answer "which is faster" only if
+// something says what differed between them — and by the time a file is read, the argv that made
+// it is long gone. The engine states it once, in the file, next to the numbers it explains.
+struct RunInfo {
+    std::string model; // file name, not the full path: the path is the reader's machine, not the run's
+    std::string arch;
+    int n_layer = 0;
+    int n_expert = 0;
+    int n_expert_used = 0; // effective top-k, after any override
+    int n_threads = 0;
+    int n_ctx = 0;
+
+    // The streaming configuration, as resolved (not as typed): cache_mb is what the engine settled
+    // on, which under auto-sizing is a number no flag mentioned.
+    bool moe_stream = false;
+    int cache_mb = 0;
+    bool cache_auto = false;
+    int cache_ceil_mb = 0;
+    bool cache_dynamic = false;
+    bool force_cache = false;
+    int io_threads = 0;
+    bool o_direct = false;
+    bool overlap = false;
+    int prefetch_layers = 0;
+    bool warm_dense = false;
+};
+
+// Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_run_info once before the
+// first token, then on_token for each token and on_summary at the end of every generation.
 class IMetricsSink {
 public:
     virtual ~IMetricsSink() = default;
+    // Default no-op: a sink that only wants numbers is not obliged to care what produced them.
+    virtual void on_run_info(const RunInfo &) {}
     virtual void on_token(const TokenMetrics &) = 0;
     virtual void on_summary(const RunSummary &) = 0;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -52,6 +52,15 @@ struct TokenMetrics {
     double mem_free_mib = 0.0;
     double swap_free_mib = 0.0;
 
+    // System-wide reclaim activity this token, from /proc/vmstat (MiB scanned/refaulted = page-count
+    // delta × page size). The EARLIEST warning there is, and the noisiest: system-wide, so another
+    // app moves it too — but kswapd_scan rising means the machine started hunting for victims before
+    // any page of ours was taken, and direct_scan means a thread (maybe ours) had to stop and reclaim
+    // itself. ws_refault rising means thrash already began somewhere. 0 when /proc/vmstat is denied.
+    double kswapd_scan_mib = 0.0;
+    double direct_scan_mib = 0.0;
+    double ws_refault_mib = 0.0;
+
     // The cache budget as of this token. In the summary it is only the last value; per token it is
     // the governor's trajectory — when it cut, how far, whether it grew back. Without it a run that
     // "did not work" cannot be told apart from one that never acted.

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -32,6 +32,32 @@ struct TokenMetrics {
     // is reclaiming the cache mid-run — the pressure --cache-dynamic sizes against. See
     // docs/pressure.md.
     double resident_frac = -1.0;
+    // What those faults actually moved, in MiB (majflt × page size). The same fact as `majflt`, in
+    // the unit the rest of this struct is in: 47447 faults is unreadable, 194 MiB re-faulted in one
+    // token is immediately comparable to `read_bytes` — the reads we chose against the reads the
+    // kernel forced on us. 0 when faults are unmeasured.
+    double majflt_mib = 0.0;
+
+    // ── where memory is, per token (0 when the platform cannot report) ──
+    // The split is the point: the expert cache is anonymous, the model's weights are file-backed,
+    // and they are reclaimed differently — anon is compressed into zram, file pages are just
+    // dropped. rss_anon_mib falling while the budget stays put IS the kernel taking the cache.
+    double rss_mib = 0.0;
+    double rss_anon_mib = 0.0;
+    double rss_file_mib = 0.0;
+    double swap_mib = 0.0;
+    // What the device claims about itself, recorded next to what we measured ourselves — the gap
+    // between mem_available_mib and our own residency is the reason this engine trusts neither.
+    double mem_available_mib = 0.0;
+    double mem_free_mib = 0.0;
+    double swap_free_mib = 0.0;
+
+    // The cache budget as of this token. In the summary it is only the last value; per token it is
+    // the governor's trajectory — when it cut, how far, whether it grew back. Without it a run that
+    // "did not work" cannot be told apart from one that never acted.
+    double cache_budget_mib = 0.0;
+    int turn = 0; // session turn this token belongs to (0 for a one-shot run)
+
     std::string piece; // text of just this token (delta, for inline streaming)
     std::string text;  // full generated text so far (for UI streaming)
 };

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -73,6 +73,11 @@ ValidationResult validate(const RunConfig & cfg) {
                         "speculative reads land in the per-layer cache buffers, which do not exist "
                         "with the cache off.");
         }
+        if (m.cache_dynamic && !cache_on) {
+            return fail("moe.cache_dynamic requires the LRU cache (cache_mb > 0 or cache_auto): it "
+                        "sizes a cache budget at runtime, and there is no budget to size with the "
+                        "cache off.");
+        }
     }
 
     return r;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -126,6 +126,12 @@ struct Session::Impl {
     // last turn learned about this device is exactly what the next turn needs.
     std::unique_ptr<CacheGovernor> gov;
 
+    // Stated once to a metrics sink, before the first token: the model and configuration every row
+    // it writes was produced under. info_sent guards a session's many generate() calls from
+    // interleaving preambles between turns.
+    RunInfo info;
+    bool info_sent = false;
+
     std::atomic<bool> cancel_requested{false};
 
     ~Impl() {
@@ -397,6 +403,45 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         if (im.io_trace) im.io_trace->on_static(st);
     }
 
+    // What this session IS, for any metrics sink that will describe what it DOES. Built here, where
+    // every fact is resolved: cache_mb in particular is what the streamer settled on, which under
+    // auto-sizing is a number no flag ever mentioned.
+    {
+        RunInfo & ri = im.info;
+        const std::string & p = cfg.model_path;
+        const size_t slash = p.find_last_of("/\\");
+        ri.model = slash == std::string::npos ? p : p.substr(slash + 1);
+        ri.arch = im.arch;
+        ri.n_layer = im.n_layer;
+        ri.n_threads = cfg.n_threads;
+        ri.n_ctx = cfg.n_ctx;
+        ri.moe_stream = cfg.moe.enabled;
+        ri.cache_auto = cfg.moe.cache_auto;
+        ri.cache_ceil_mb = cfg.moe.cache_ceil_mb;
+        ri.cache_dynamic = cfg.moe.cache_dynamic;
+        ri.force_cache = cfg.moe.force_cache;
+        ri.io_threads = cfg.moe.enabled ? cfg.moe.io_threads : 0;
+        ri.o_direct = cfg.moe.enabled && cfg.moe.o_direct;
+        ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
+        ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
+        ri.warm_dense = cfg.moe.enabled && cfg.moe.warm_dense;
+        if (cfg.moe.enabled) {
+            const IExpertSource::Stats st = im.source.stats();
+            ri.cache_mb = (int) (st.cache_budget_bytes / (1024ull * 1024ull));
+        }
+        // The EFFECTIVE top-k: an override IS the applied width, otherwise the model's own. Same
+        // resolution the route trace does, and worth a header read — a run whose top-k is unknown
+        // cannot be compared against one whose top-k differs, which is most of the point.
+        ri.n_expert_used = cfg.n_expert_used;
+        if (ri.n_expert_used <= 0 || ri.n_expert == 0) {
+            const GgufModelInfo mi = read_gguf_model_info(cfg.model_path.c_str());
+            if (mi.ok) {
+                ri.n_expert = mi.n_expert;
+                if (ri.n_expert_used <= 0) ri.n_expert_used = mi.n_expert_used;
+            }
+        }
+    }
+
     im.load_seconds = secs(t_load0, clock_t_::now());
     return self;
 }
@@ -407,6 +452,12 @@ RunResult Session::generate(const GenerateRequest & req,
     Impl & im = *impl_;
     const MoeStreamConfig & moe = im.cfg.moe;
     llama_context * ctx = im.ctx.get();
+
+    // Before anything is written about what this run did, say what it was.
+    if (sink && !im.info_sent) {
+        sink->on_run_info(im.info);
+        im.info_sent = true;
+    }
 
     // Fresh cancel latch for this generation; a stale request from a prior aborted call must
     // not carry over. (cancel() sets it; the abort callback reads it.)

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -678,6 +678,13 @@ RunResult Session::generate(const GenerateRequest & req,
     long long prev_spec_experts = moe.enabled ? im.source.stats().spec_experts : 0;
     long long prev_spec_useful = moe.enabled ? im.source.stats().spec_useful : 0;
 
+    // Baseline the system-wide reclaim counters before the first token, so each token reports the
+    // scanning that happened DURING it. Cumulative and machine-wide: the delta includes other apps,
+    // which is the price of the earliest signal there is (/proc/vmstat).
+    pio::SystemReclaim sr_prev;
+    const bool have_vmstat = pio::system_reclaim(&sr_prev);
+    const double page_mib = (double) pio::vm_page() / (1024.0 * 1024.0);
+
     uint64_t gen_read_bytes = 0;
     double gen_io_seconds = 0.0;
     double gen_mgmt_seconds = 0.0;
@@ -751,6 +758,20 @@ RunResult Session::generate(const GenerateRequest & req,
             m.mem_available_mib = dm.available_bytes / (1024.0 * 1024.0);
             m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
             m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
+        }
+        // System-wide reclaim since the previous token. A counter can only rise; guard the delta so
+        // a wrap or a first read never prints a negative MiB.
+        if (have_vmstat) {
+            pio::SystemReclaim sr;
+            if (pio::system_reclaim(&sr)) {
+                auto delta_mib = [&](uint64_t cur, uint64_t prev) {
+                    return cur > prev ? (double) (cur - prev) * page_mib : 0.0;
+                };
+                m.kswapd_scan_mib = delta_mib(sr.kswapd_scan_pages, sr_prev.kswapd_scan_pages);
+                m.direct_scan_mib = delta_mib(sr.direct_scan_pages, sr_prev.direct_scan_pages);
+                m.ws_refault_mib = delta_mib(sr.workingset_refault, sr_prev.workingset_refault);
+                sr_prev = sr;
+            }
         }
         if (moe.enabled) {
             IExpertSource::Stats st = im.source.stats();

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -759,11 +759,17 @@ RunResult Session::generate(const GenerateRequest & req,
             m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
             m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
         }
-        // System-wide reclaim since the previous token. A counter can only rise; guard the delta so
-        // a wrap or a first read never prints a negative MiB.
-        if (have_vmstat) {
+        // System-wide reclaim since the previous token. -1 marks "/proc/vmstat is denied us" so it
+        // never reads as 0 = "no scanning" — a vendor SELinux label (proc_vmstat, distinct from the
+        // proc_meminfo we read fine) may forbid it, and "we cannot see" must not look like "all calm".
+        if (!have_vmstat) {
+            m.kswapd_scan_mib = -1.0;
+            m.direct_scan_mib = -1.0;
+            m.ws_refault_mib = -1.0;
+        } else {
             pio::SystemReclaim sr;
             if (pio::system_reclaim(&sr)) {
+                // Counters only rise; guard the delta so a wrap or a first read never prints negative.
                 auto delta_mib = [&](uint64_t cur, uint64_t prev) {
                     return cur > prev ? (double) (cur - prev) * page_mib : 0.0;
                 };

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -1,4 +1,5 @@
 #include "bmoe/session.h"
+#include "bmoe/cache_governor.h"
 #include "bmoe/recipe.h"
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
@@ -113,6 +114,13 @@ struct Session::Impl {
     IComputeTraceSink * compute_trace = nullptr;
     IIoTraceSink * io_trace = nullptr;
     std::vector<IoTraceRow> io_rows_scratch;
+
+    // Pressure-aware cache sizing (--cache-dynamic): null unless requested AND the LRU cache is on.
+    // It lives here, not in the streamer, because it ticks once per token from the generation loop —
+    // the only point where no decode is in flight and an evicting shrink is safe. It outlives a
+    // single generate() on purpose: reclaim is a property of the session's residency, and what the
+    // last turn learned about this device is exactly what the next turn needs.
+    std::unique_ptr<CacheGovernor> gov;
 
     std::atomic<bool> cancel_requested{false};
 
@@ -309,6 +317,22 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         if (!im.source.init(cfg.model_path, n_expert, std::move(layers), cfg.moe))
             return fail("expert stream source init failed");
         im.hook->set_source(&im.source);
+
+        // The budget the streamer settled on — an explicit cache_mb, or what auto sized to — is the
+        // most the user sanctioned, so it becomes the governor's ceiling and its starting point. The
+        // loop only ever asks for less than this, and climbs back toward it when the device allows.
+        const uint64_t configured = im.source.stats().cache_budget_bytes;
+        if (cfg.moe.cache_dynamic && configured > 0) {
+            CacheGovernorParams gp;
+            gp.user_cap = (size_t) configured;
+            gp.initial = (size_t) configured;
+            // Until a token has been routed, the streamer cannot know the working set, so hold the
+            // configured floor. validate() rejects a sub-floor cache_mb without --force-cache, and
+            // an operator who forced one meant it: never let the governor undo that choice upward.
+            gp.min_cap =
+                std::min<size_t>((size_t) MoeStreamConfig::cache_min_mb * 1024ull * 1024ull, (size_t) configured);
+            im.gov = std::make_unique<CacheGovernor>(gp);
+        }
 
         if (route_trace) {
             im.route_trace = route_trace;
@@ -655,6 +679,7 @@ RunResult Session::generate(const GenerateRequest & req,
         gen_cpu_seconds += (c1 - c0);
         if (moe.enabled) {
             IExpertSource::Stats st = im.source.stats();
+            m.resident_frac = st.cache_resident_frac;
             m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
             m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
             m.mgmt_ms = (st.mgmt_seconds - prev_mgmt_s) * 1000.0;
@@ -674,6 +699,18 @@ RunResult Session::generate(const GenerateRequest & req,
             gen_io_seconds += m.io_ms / 1000.0;
             gen_mgmt_seconds += m.mgmt_ms / 1000.0;
             gen_stall_seconds += m.stall_ms / 1000.0;
+
+            // Size the cache to what the device concedes, here and nowhere else: between two decodes
+            // nothing is staged for a generation in flight, which is exactly the precondition
+            // set_cache_budget needs to evict the cold tail without a cstamp guard.
+            if (im.gov) {
+                CacheSignals sig;
+                sig.majflt = m.majflt;
+                sig.resident_frac = st.cache_resident_frac;
+                sig.floor = (size_t) st.token_demand_bytes;
+                const CacheGovernor::Decision d = im.gov->on_token(sig);
+                if (d.changed) im.source.set_cache_budget(d.cap);
+            }
         } else {
             m.compute_ms = m.wall_ms;
             m.cache_hit_pct = -1.0;
@@ -710,6 +747,8 @@ RunResult Session::generate(const GenerateRequest & req,
         s.cache_resident_mib = st.cache_resident_bytes / (1024.0 * 1024.0);
         s.cache_budget_mib = st.cache_budget_bytes / (1024.0 * 1024.0);
         s.cache_resizes = st.cache_resizes;
+        s.token_demand_mib = st.token_demand_bytes / (1024.0 * 1024.0);
+        s.cache_cuts = im.gov ? im.gov->cuts() : 0;
         s.moe_spec_read_mib = ((long long) st.spec_read_bytes - prev_spec_bytes) / (1024.0 * 1024.0);
         s.moe_spec_experts = st.spec_experts - prev_spec_experts;
         s.moe_spec_useful = st.spec_useful - prev_spec_useful;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -104,9 +104,13 @@ struct Session::Impl {
     std::vector<llama_token> kv_tokens;
 
     // Route trace (diagnostics): null unless requested AND streaming is on — there is no routing
-    // to trace otherwise. trace_turn labels each generate()'s rows in a multi-turn session.
+    // to trace otherwise.
     IRouteTraceSink * route_trace = nullptr;
-    int trace_turn = 0;
+
+    // Which generate() this is, 0-based. It labels a trace's rows, and it labels every token's
+    // metrics — a multi-turn CSV is unreadable without it, and the two-turn A/B (a fast turn, an
+    // idle, then the turn that pays for it) is exactly what this engine is measured by.
+    int turn = 0;
 
     // Decode traces (diagnostics): null unless requested. The compute trace needs no streaming —
     // it measures the graph, which a dense mmap run has too; the I/O trace needs the streamer,
@@ -547,10 +551,10 @@ RunResult Session::generate(const GenerateRequest & req,
     // The frame the I/O rows are stamped with at flush; the other traces carry their own.
     int trace_phase = 0, trace_step = 0;
     auto trace_begin = [&](int base_pos, int n_tokens, int phase) {
-        if (im.route_trace) im.hook->begin_trace_batch(base_pos, n_tokens, phase, im.trace_turn);
+        if (im.route_trace) im.hook->begin_trace_batch(base_pos, n_tokens, phase, im.turn);
         // A node is computed once for the whole batch, not per token, so a prefill chunk's graph is
         // attributed to its last position rather than pretending to split across the chunk.
-        if (im.compute_trace) im.hook->begin_compute_batch(base_pos + n_tokens - 1, phase, im.trace_turn);
+        if (im.compute_trace) im.hook->begin_compute_batch(base_pos + n_tokens - 1, phase, im.turn);
         trace_phase = phase;
         trace_step = base_pos + n_tokens - 1;
     };
@@ -571,7 +575,7 @@ RunResult Session::generate(const GenerateRequest & req,
             // so stamp them with the decode they were drained after.
             im.source.take_io_trace_rows(im.io_rows_scratch);
             for (IoTraceRow & r : im.io_rows_scratch) {
-                r.turn = im.trace_turn;
+                r.turn = im.turn;
                 r.phase = trace_phase;
                 r.step = trace_step;
             }
@@ -676,11 +680,31 @@ RunResult Session::generate(const GenerateRequest & req,
         // mmap baseline too — so record it for every token before the moe/no-moe split below.
         m.majflt = f1 - f0;
         m.cpu_ms = (c1 - c0) * 1000.0;
+        m.majflt_mib = (double) m.majflt * (double) pio::fault_bytes() / (1024.0 * 1024.0);
+        m.turn = im.turn;
         gen_majflt += m.majflt;
         gen_cpu_seconds += (c1 - c0);
+
+        // Read the memory picture AFTER the decode, outside the s0..s1 bracket: two /proc reads are
+        // cheap but they are not this token's work, and billing them to wall_ms would corrupt the
+        // very number the reader is here to trust.
+        pio::ProcessMemory pm;
+        if (pio::process_memory(&pm)) {
+            m.rss_mib = pm.rss_bytes / (1024.0 * 1024.0);
+            m.rss_anon_mib = pm.rss_anon_bytes / (1024.0 * 1024.0);
+            m.rss_file_mib = pm.rss_file_bytes / (1024.0 * 1024.0);
+            m.swap_mib = pm.swap_bytes / (1024.0 * 1024.0);
+        }
+        pio::DeviceMemory dm;
+        if (pio::device_memory(&dm)) {
+            m.mem_available_mib = dm.available_bytes / (1024.0 * 1024.0);
+            m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
+            m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
+        }
         if (moe.enabled) {
             IExpertSource::Stats st = im.source.stats();
             m.resident_frac = st.cache_resident_frac;
+            m.cache_budget_mib = st.cache_budget_bytes / (1024.0 * 1024.0);
             m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
             m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
             m.mgmt_ms = (st.mgmt_seconds - prev_mgmt_s) * 1000.0;
@@ -720,7 +744,7 @@ RunResult Session::generate(const GenerateRequest & req,
         if (sink) sink->on_token(m);
     }
 
-    if (im.route_trace) ++im.trace_turn; // this turn's rows are written; label the next one apart
+    ++im.turn; // this turn is written; label the next one apart
 
     // ── summary ──
     RunSummary & s = res.summary;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -678,13 +678,6 @@ RunResult Session::generate(const GenerateRequest & req,
     long long prev_spec_experts = moe.enabled ? im.source.stats().spec_experts : 0;
     long long prev_spec_useful = moe.enabled ? im.source.stats().spec_useful : 0;
 
-    // Baseline the system-wide reclaim counters before the first token, so each token reports the
-    // scanning that happened DURING it. Cumulative and machine-wide: the delta includes other apps,
-    // which is the price of the earliest signal there is (/proc/vmstat).
-    pio::SystemReclaim sr_prev;
-    const bool have_vmstat = pio::system_reclaim(&sr_prev);
-    const double page_mib = (double) pio::vm_page() / (1024.0 * 1024.0);
-
     uint64_t gen_read_bytes = 0;
     double gen_io_seconds = 0.0;
     double gen_mgmt_seconds = 0.0;
@@ -759,29 +752,10 @@ RunResult Session::generate(const GenerateRequest & req,
             m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
             m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
         }
-        // System-wide reclaim since the previous token. -1 marks "/proc/vmstat is denied us" so it
-        // never reads as 0 = "no scanning" — a vendor SELinux label (proc_vmstat, distinct from the
-        // proc_meminfo we read fine) may forbid it, and "we cannot see" must not look like "all calm".
-        if (!have_vmstat) {
-            m.kswapd_scan_mib = -1.0;
-            m.direct_scan_mib = -1.0;
-            m.ws_refault_mib = -1.0;
-        } else {
-            pio::SystemReclaim sr;
-            if (pio::system_reclaim(&sr)) {
-                // Counters only rise; guard the delta so a wrap or a first read never prints negative.
-                auto delta_mib = [&](uint64_t cur, uint64_t prev) {
-                    return cur > prev ? (double) (cur - prev) * page_mib : 0.0;
-                };
-                m.kswapd_scan_mib = delta_mib(sr.kswapd_scan_pages, sr_prev.kswapd_scan_pages);
-                m.direct_scan_mib = delta_mib(sr.direct_scan_pages, sr_prev.direct_scan_pages);
-                m.ws_refault_mib = delta_mib(sr.workingset_refault, sr_prev.workingset_refault);
-                sr_prev = sr;
-            }
-        }
         if (moe.enabled) {
             IExpertSource::Stats st = im.source.stats();
             m.resident_frac = st.cache_resident_frac;
+            m.dense_resident_frac = st.dense_resident_frac;
             m.cache_budget_mib = st.cache_budget_bytes / (1024.0 * 1024.0);
             m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
             m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -326,11 +326,12 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             CacheGovernorParams gp;
             gp.user_cap = (size_t) configured;
             gp.initial = (size_t) configured;
-            // Until a token has been routed, the streamer cannot know the working set, so hold the
-            // configured floor. validate() rejects a sub-floor cache_mb without --force-cache, and
-            // an operator who forced one meant it: never let the governor undo that choice upward.
-            gp.min_cap =
-                std::min<size_t>((size_t) MoeStreamConfig::cache_min_mb * 1024ull * 1024ull, (size_t) configured);
+            // Holds only until the streamer has staged a layer and can report the real mechanical
+            // floor. It must stay small: cache_min_mb would put a 1500 MiB floor here, which on a
+            // model the device concedes less to is just the pinned-inside-a-war failure wearing a
+            // rounder number. Being briefly too small costs hits for a few tokens; being too big
+            // costs the war this loop exists to end.
+            gp.min_cap = std::min<size_t>(64ull * 1024 * 1024, (size_t) configured);
             im.gov = std::make_unique<CacheGovernor>(gp);
         }
 
@@ -707,7 +708,7 @@ RunResult Session::generate(const GenerateRequest & req,
                 CacheSignals sig;
                 sig.majflt = m.majflt;
                 sig.resident_frac = st.cache_resident_frac;
-                sig.floor = (size_t) st.token_demand_bytes;
+                sig.floor = (size_t) st.layer_demand_bytes;
                 const CacheGovernor::Decision d = im.gov->on_token(sig);
                 if (d.changed) im.source.set_cache_budget(d.cap);
             }
@@ -748,6 +749,7 @@ RunResult Session::generate(const GenerateRequest & req,
         s.cache_budget_mib = st.cache_budget_bytes / (1024.0 * 1024.0);
         s.cache_resizes = st.cache_resizes;
         s.token_demand_mib = st.token_demand_bytes / (1024.0 * 1024.0);
+        s.layer_demand_mib = st.layer_demand_bytes / (1024.0 * 1024.0);
         s.cache_cuts = im.gov ? im.gov->cuts() : 0;
         s.moe_spec_read_mib = ((long long) st.spec_read_bytes - prev_spec_bytes) / (1024.0 * 1024.0);
         s.moe_spec_experts = st.spec_experts - prev_spec_experts;

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <ctime>
@@ -119,6 +120,24 @@ uint64_t major_faults() {
 }
 double process_cpu_seconds() {
     return 0.0;
+}
+
+size_t fault_bytes() {
+    return vm_page();
+}
+
+bool process_memory(ProcessMemory * /*out*/) {
+    return false;
+}
+
+bool device_memory(DeviceMemory * out) {
+    MEMORYSTATUSEX ms;
+    ms.dwLength = sizeof(ms);
+    if (!GlobalMemoryStatusEx(&ms)) return false;
+    out->available_bytes = (uint64_t) ms.ullAvailPhys;
+    out->free_bytes = (uint64_t) ms.ullAvailPhys; // no separate "free vs reclaimable" here
+    out->swap_free_bytes = (uint64_t) ms.ullAvailPageFile;
+    return true;
 }
 
 #else
@@ -231,6 +250,60 @@ double process_cpu_seconds() {
     if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == 0) return (double) ts.tv_sec + ts.tv_nsec * 1e-9;
 #endif
     return 0.0;
+}
+
+size_t fault_bytes() {
+    // One major fault brings back one page. The kernel can fault a cluster in around a single miss,
+    // so this is the floor of what a fault moved, not an upper bound — it under-reports rather than
+    // inventing, which is the right direction for a number a reader will compare against real reads.
+    return vm_page();
+}
+
+// Scan a "Key: <n> kB" file for the keys we want in one pass, rather than one open per field.
+namespace {
+bool scan_kb_file(const char * path, const char * const * keys, uint64_t * out, int n) {
+    FILE * f = std::fopen(path, "re");
+    if (!f) return false;
+    char line[256];
+    int found = 0;
+    while (found < n && std::fgets(line, sizeof(line), f)) {
+        for (int i = 0; i < n; ++i) {
+            if (out[i]) continue; // already have it
+            const size_t klen = std::strlen(keys[i]);
+            if (std::strncmp(line, keys[i], klen) != 0 || line[klen] != ':') continue;
+            unsigned long long kb = 0;
+            if (std::sscanf(line + klen + 1, " %llu kB", &kb) == 1) {
+                out[i] = (uint64_t) kb * 1024ull;
+                ++found;
+            }
+            break;
+        }
+    }
+    std::fclose(f);
+    return found > 0;
+}
+} // namespace
+
+bool process_memory(ProcessMemory * out) {
+    static const char * const keys[] = {"VmRSS", "RssAnon", "RssFile", "VmSwap", "VmHWM"};
+    uint64_t v[5] = {0, 0, 0, 0, 0};
+    if (!scan_kb_file("/proc/self/status", keys, v, 5)) return false;
+    out->rss_bytes = v[0];
+    out->rss_anon_bytes = v[1];
+    out->rss_file_bytes = v[2];
+    out->swap_bytes = v[3];
+    out->rss_peak_bytes = v[4];
+    return true;
+}
+
+bool device_memory(DeviceMemory * out) {
+    static const char * const keys[] = {"MemAvailable", "MemFree", "SwapFree"};
+    uint64_t v[3] = {0, 0, 0};
+    if (!scan_kb_file("/proc/meminfo", keys, v, 3)) return false;
+    out->available_bytes = v[0];
+    out->free_bytes = v[1];
+    out->swap_free_bytes = v[2];
+    return true;
 }
 
 #endif

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -140,6 +140,10 @@ bool device_memory(DeviceMemory * out) {
     return true;
 }
 
+bool system_reclaim(SystemReclaim * /*out*/) {
+    return false; // no /proc/vmstat equivalent worth wiring for the host gates
+}
+
 #else
 
 const fd_t fd_invalid = -1;
@@ -304,6 +308,37 @@ bool device_memory(DeviceMemory * out) {
     out->free_bytes = v[1];
     out->swap_free_bytes = v[2];
     return true;
+}
+
+bool system_reclaim(SystemReclaim * out) {
+    // /proc/vmstat is "name value\n", value a raw counter (pages for pgscan_*, events for
+    // workingset_*) — not the "Key: n kB" shape of meminfo, so it needs its own tiny parser.
+    FILE * f = std::fopen("/proc/vmstat", "re");
+    if (!f) return false; // a vendor policy may deny it; the caller reports that as unmeasured
+    char line[128];
+    // workingset_refault exists either whole (older kernels) or split into _anon + _file (~5.9+).
+    // Accumulate whatever is present, so one field covers both kernel generations.
+    uint64_t ws = 0;
+    bool any = false;
+    while (std::fgets(line, sizeof(line), f)) {
+        char name[64];
+        unsigned long long val = 0;
+        if (std::sscanf(line, "%63s %llu", name, &val) != 2) continue;
+        if (std::strcmp(name, "pgscan_kswapd") == 0) {
+            out->kswapd_scan_pages = val;
+            any = true;
+        } else if (std::strcmp(name, "pgscan_direct") == 0) {
+            out->direct_scan_pages = val;
+            any = true;
+        } else if (std::strcmp(name, "workingset_refault") == 0 || std::strcmp(name, "workingset_refault_anon") == 0 ||
+                   std::strcmp(name, "workingset_refault_file") == 0) {
+            ws += val;
+            any = true;
+        }
+    }
+    std::fclose(f);
+    out->workingset_refault = ws;
+    return any;
 }
 
 #endif

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -10,6 +10,7 @@
 #else
 #include <fcntl.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <sys/mman.h>
@@ -24,6 +25,16 @@
 #endif
 
 namespace bmoe::pio {
+
+#if !defined(_WIN32)
+// mincore's vector argument is `unsigned char *` on Linux/Android but `char *` on the BSDs and
+// macOS. Name the difference once instead of casting blind at the call site.
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+using mincore_vec_t = char;
+#else
+using mincore_vec_t = unsigned char;
+#endif
+#endif
 
 #if defined(_WIN32)
 
@@ -85,6 +96,13 @@ void vm_evict(void * p, size_t sz) {
 }
 void vm_release(void * p, size_t /*sz*/) {
     if (p) VirtualFree(p, 0, MEM_RELEASE);
+}
+
+// Unmeasured on the host build, like the fault counters below and for the same reason: the gates
+// prove byte-identity, they do not size a cache against a phone's reclaim. QueryWorkingSetEx could
+// answer this, but nothing here consumes it.
+bool vm_resident_sample(const void * /*p*/, size_t /*sz*/, size_t * /*sampled*/, size_t * /*resident*/) {
+    return false;
 }
 
 uint64_t mem_available_bytes() {
@@ -152,6 +170,26 @@ void vm_evict(void * p, size_t sz) {
 }
 void vm_release(void * p, size_t sz) {
     if (p) munmap(p, sz);
+}
+
+bool vm_resident_sample(const void * p, size_t sz, size_t * sampled, size_t * resident) {
+    if (!p || sz == 0) return true; // an empty range is measured, and holds nothing
+    const size_t page = vm_page();
+    // Clip to the pages FULLY inside the range, matching how the eviction path releases them: an
+    // edge page shared with a neighbouring slice belongs to that neighbour, not to this sample.
+    uintptr_t a0 = ((uintptr_t) p + page - 1) & ~(uintptr_t) (page - 1);
+    uintptr_t a1 = ((uintptr_t) p + sz) & ~(uintptr_t) (page - 1);
+    if (a1 <= a0) return true;
+    unsigned char vec[512]; // one byte per page: 512 pages (2 MiB at 4 KiB pages) per syscall
+    for (uintptr_t a = a0; a < a1;) {
+        const size_t want = std::min<size_t>((size_t) (a1 - a) / page, sizeof(vec));
+        if (mincore((void *) a, want * page, (mincore_vec_t *) vec) != 0) return false;
+        for (size_t i = 0; i < want; ++i)
+            *resident += (size_t) (vec[i] & 1u); // bit 0 = the page is resident
+        *sampled += want;
+        a += want * page;
+    }
+    return true;
 }
 
 uint64_t mem_available_bytes() {

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -106,6 +106,10 @@ bool vm_resident_sample(const void * /*p*/, size_t /*sz*/, size_t * /*sampled*/,
     return false;
 }
 
+bool file_mapped_regions(const char * /*basename*/, std::vector<MappedRegion> & /*out*/) {
+    return false; // no /proc/self/maps; the host gates do not exercise dense residency
+}
+
 uint64_t mem_available_bytes() {
     MEMORYSTATUSEX ms;
     ms.dwLength = sizeof(ms);
@@ -138,10 +142,6 @@ bool device_memory(DeviceMemory * out) {
     out->free_bytes = (uint64_t) ms.ullAvailPhys; // no separate "free vs reclaimable" here
     out->swap_free_bytes = (uint64_t) ms.ullAvailPageFile;
     return true;
-}
-
-bool system_reclaim(SystemReclaim * /*out*/) {
-    return false; // no /proc/vmstat equivalent worth wiring for the host gates
 }
 
 #else
@@ -310,34 +310,33 @@ bool device_memory(DeviceMemory * out) {
     return true;
 }
 
-bool system_reclaim(SystemReclaim * out) {
-    // /proc/vmstat is "name value\n", value a raw counter (pages for pgscan_*, events for
-    // workingset_*) — not the "Key: n kB" shape of meminfo, so it needs its own tiny parser.
-    FILE * f = std::fopen("/proc/vmstat", "re");
-    if (!f) return false; // a vendor policy may deny it; the caller reports that as unmeasured
-    char line[128];
-    // workingset_refault exists either whole (older kernels) or split into _anon + _file (~5.9+).
-    // Accumulate whatever is present, so one field covers both kernel generations.
-    uint64_t ws = 0;
+bool file_mapped_regions(const char * basename, std::vector<MappedRegion> & out) {
+    FILE * f = std::fopen("/proc/self/maps", "re");
+    if (!f) return false;
+    const size_t blen = std::strlen(basename);
+    char line[512];
     bool any = false;
+    // Each line: "start-end perms offset dev inode   pathname". We want the VMAs whose pathname ends
+    // with the model's file name — an mmap of a large file appears as one or more such VMAs.
     while (std::fgets(line, sizeof(line), f)) {
-        char name[64];
-        unsigned long long val = 0;
-        if (std::sscanf(line, "%63s %llu", name, &val) != 2) continue;
-        if (std::strcmp(name, "pgscan_kswapd") == 0) {
-            out->kswapd_scan_pages = val;
-            any = true;
-        } else if (std::strcmp(name, "pgscan_direct") == 0) {
-            out->direct_scan_pages = val;
-            any = true;
-        } else if (std::strcmp(name, "workingset_refault") == 0 || std::strcmp(name, "workingset_refault_anon") == 0 ||
-                   std::strcmp(name, "workingset_refault_file") == 0) {
-            ws += val;
-            any = true;
-        }
+        unsigned long long start = 0, end = 0, off = 0;
+        // The pathname is the last field; sscanf %n gives us where the fixed part ended so we can
+        // scan the remainder for it without copying.
+        int consumed = 0;
+        if (std::sscanf(line, "%llx-%llx %*s %llx %*s %*s %n", &start, &end, &off, &consumed) < 3) continue;
+        const char * path = line + consumed;
+        // Trim the trailing newline and any leading spaces %n may have left.
+        while (*path == ' ')
+            ++path;
+        size_t plen = std::strlen(path);
+        while (plen && (path[plen - 1] == '\n' || path[plen - 1] == ' '))
+            --plen;
+        if (plen < blen) continue;
+        if (std::strncmp(path + plen - blen, basename, blen) != 0) continue;
+        out.push_back({(uintptr_t) start, (uintptr_t) end, (uint64_t) off});
+        any = true;
     }
     std::fclose(f);
-    out->workingset_refault = ws;
     return any;
 }
 

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -48,6 +48,19 @@ bool vm_commit(void * p, size_t sz);
 void vm_evict(void * p, size_t sz);
 void vm_release(void * p, size_t sz);
 
+// How many of a committed range's pages the kernel still has in RAM. Counts only the pages fully
+// inside [p, p+sz) — the same clipping vm_evict's callers apply — and ADDS to *sampled/*resident,
+// so several ranges can be summed into one fraction (the caller zeroes them first).
+//
+// This is the reclaim sensor. Nothing unprivileged can ask Android how much memory it will concede
+// (MemAvailable counts our own file-backed weights as free; PSI is SELinux-blocked for apps), but a
+// process may always ask about its OWN pages — and pages we wrote, then lost, are reclaim by
+// definition. One mincore() serves a whole chunk of pages, so the cost is per range, not per page.
+//
+// Returns false when the platform cannot report residency (Windows host build), leaving the
+// counters untouched: "unmeasured", which callers must not read as "nothing is resident".
+bool vm_resident_sample(const void * p, size_t sz, size_t * sampled, size_t * resident);
+
 // Physical memory currently allocatable without paging, in bytes. 0 = unknown. Used to size the
 // expert cache to the device (--cache-mb auto) and to shrink it under memory pressure at runtime.
 uint64_t mem_available_bytes();

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -110,4 +110,27 @@ struct DeviceMemory {
 };
 bool device_memory(DeviceMemory * out);
 
+// The earliest warning there is, from /proc/vmstat. These are SYSTEM-wide, not this process's — so
+// they are noisier (another app can move them), but they fire before any per-process signal does:
+// before a page of OURS is chosen, the machine is already scanning to find victims.
+//
+//   * kswapd_scan_pages: pgscan_kswapd, cumulative. Its per-token delta rising means kswapd woke and
+//     is walking the LRU lists looking for pages to reclaim — the war's preconditions exist, but no
+//     victim has been picked yet.
+//   * direct_scan_pages: pgscan_direct, cumulative. Scanning done in DIRECT reclaim — a thread that
+//     wanted memory and had to stop and reclaim it itself. Strictly worse than kswapd: it is a stall,
+//     not a background sweep, and one of the stalling threads may be ours.
+//   * workingset_refault: cumulative refaults of pages that had been reclaimed and were needed again
+//     — the definition of thrash. Rising means it has already started, somewhere in the system.
+//     Kernels since ~5.9 split this into _anon + _file; this sums whichever form is present.
+//
+// Values are page counts; multiply by vm_page() for bytes. False (out untouched) when /proc/vmstat
+// cannot be read — a vendor SELinux policy may deny it, which is itself worth knowing.
+struct SystemReclaim {
+    uint64_t kswapd_scan_pages = 0;
+    uint64_t direct_scan_pages = 0;
+    uint64_t workingset_refault = 0;
+};
+bool system_reclaim(SystemReclaim * out);
+
 } // namespace bmoe::pio

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -80,4 +80,34 @@ uint64_t mem_available_bytes();
 uint64_t major_faults();
 double process_cpu_seconds();
 
+// Bytes one major fault moves: the page size. Faults are counted, but what a reader wants to know is
+// how much memory the kernel took back and made us re-read — and a count only becomes that once it
+// is multiplied by this. 194 MiB re-faulted in one token says what "47447 faults" does not.
+size_t fault_bytes();
+
+// Where this process's memory actually is, right now (/proc/self/status). The split is the whole
+// point: the expert cache is ANONYMOUS, the model's weights are FILE-backed, and they are reclaimed
+// by different mechanisms with different costs — anon goes to zram (swap), file pages are simply
+// dropped. Watching them separately is how you tell "the kernel is taking my cache" apart from
+// "the kernel is dropping the weights I mmap'd".
+struct ProcessMemory {
+    uint64_t rss_bytes = 0;      // VmRSS: everything resident
+    uint64_t rss_anon_bytes = 0; // RssAnon: our cache lives here
+    uint64_t rss_file_bytes = 0; // RssFile: the mmap'd model
+    uint64_t swap_bytes = 0;     // VmSwap: anon we have already lost to zram
+    uint64_t rss_peak_bytes = 0; // VmHWM
+};
+// False when the platform cannot report (Windows host), leaving `out` untouched.
+bool process_memory(ProcessMemory * out);
+
+// What the device says about itself (/proc/meminfo). MemAvailable is the number that lies (it counts
+// our own mmap'd weights as reclaimable), which is exactly why it is worth recording next to what we
+// measure ourselves: the gap between them IS the story.
+struct DeviceMemory {
+    uint64_t available_bytes = 0; // MemAvailable
+    uint64_t free_bytes = 0;      // MemFree
+    uint64_t swap_free_bytes = 0; // SwapFree
+};
+bool device_memory(DeviceMemory * out);
+
 } // namespace bmoe::pio

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 namespace bmoe::pio {
 
@@ -60,6 +61,22 @@ void vm_release(void * p, size_t sz);
 // Returns false when the platform cannot report residency (Windows host build), leaving the
 // counters untouched: "unmeasured", which callers must not read as "nothing is resident".
 bool vm_resident_sample(const void * p, size_t sz, size_t * sampled, size_t * resident);
+
+// One file-backed VMA of this process: a virtual span [start, end) that maps the file starting at
+// file_offset. The dense model weights are mmap'd, so this is how a file byte offset becomes an
+// address to probe with mincore — addr(off) = start + (off - file_offset) for off in this VMA.
+struct MappedRegion {
+    uintptr_t start = 0;
+    uintptr_t end = 0;
+    uint64_t file_offset = 0;
+};
+
+// Read /proc/self/maps and collect every file-backed VMA whose pathname ends with `basename` — the
+// model's file name, matched by suffix so it is found however the path is spelled. This is the
+// self-inspection that IS allowed where /proc/vmstat was not: /proc/self/maps is the process's own,
+// not a system file behind a vendor SELinux label. Returns false (out untouched) on the host build
+// or if the file cannot be read — the caller reports that as unmeasured, never as "nothing resident".
+bool file_mapped_regions(const char * basename, std::vector<MappedRegion> & out);
 
 // Physical memory currently allocatable without paging, in bytes. 0 = unknown. Used to size the
 // expert cache to the device (--cache-mb auto) and to shrink it under memory pressure at runtime.
@@ -109,28 +126,5 @@ struct DeviceMemory {
     uint64_t swap_free_bytes = 0; // SwapFree
 };
 bool device_memory(DeviceMemory * out);
-
-// The earliest warning there is, from /proc/vmstat. These are SYSTEM-wide, not this process's — so
-// they are noisier (another app can move them), but they fire before any per-process signal does:
-// before a page of OURS is chosen, the machine is already scanning to find victims.
-//
-//   * kswapd_scan_pages: pgscan_kswapd, cumulative. Its per-token delta rising means kswapd woke and
-//     is walking the LRU lists looking for pages to reclaim — the war's preconditions exist, but no
-//     victim has been picked yet.
-//   * direct_scan_pages: pgscan_direct, cumulative. Scanning done in DIRECT reclaim — a thread that
-//     wanted memory and had to stop and reclaim it itself. Strictly worse than kswapd: it is a stall,
-//     not a background sweep, and one of the stalling threads may be ours.
-//   * workingset_refault: cumulative refaults of pages that had been reclaimed and were needed again
-//     — the definition of thrash. Rising means it has already started, somewhere in the system.
-//     Kernels since ~5.9 split this into _anon + _file; this sums whichever form is present.
-//
-// Values are page counts; multiply by vm_page() for bytes. False (out untouched) when /proc/vmstat
-// cannot be read — a vendor SELinux policy may deny it, which is itself worth knowing.
-struct SystemReclaim {
-    uint64_t kswapd_scan_pages = 0;
-    uint64_t direct_scan_pages = 0;
-    uint64_t workingset_refault = 0;
-};
-bool system_reclaim(SystemReclaim * out);
 
 } // namespace bmoe::pio

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -11,18 +11,19 @@ public:
     explicit CsvMetricsSink(std::FILE * f) : f_(f) {
         // New columns are appended LAST so existing positional parsers stay valid: stall_ms (0 when
         // serial), mgmt_ms (cache-management split out of the compute residual), then majflt/cpu_ms
-        // (the fault + CPU-time decomposition of what remains of "compute").
-        std::fprintf(f_,
-                     "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms\n");
+        // (the fault + CPU-time decomposition of what remains of "compute"), then resident_frac
+        // (how much of the cache the kernel still has; -1 = unmeasured).
+        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
+                         "resident_frac\n");
     }
     ~CsvMetricsSink() override {
         if (f_) std::fclose(f_);
     }
 
     void on_token(const TokenMetrics & m) override {
-        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f\n", m.step, m.steps, m.wall_ms, m.io_ms,
-                     m.compute_ms, (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms, m.mgmt_ms,
-                     (unsigned long long) m.majflt, m.cpu_ms);
+        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f\n", m.step, m.steps, m.wall_ms,
+                     m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms, m.mgmt_ms,
+                     (unsigned long long) m.majflt, m.cpu_ms, m.resident_frac);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -34,13 +35,13 @@ public:
                      "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
-                     "majflt/tok=%.2f cpu_s/tok=%.4f\n",
+                     "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f cache_cuts=%lld\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
-                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful,
-                     s.majflt_per_token, s.cpu_s_per_token);
+                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
+                     s.cpu_s_per_token, s.token_demand_mib, s.cache_cuts);
         std::fflush(f_);
     }
 

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -33,11 +33,12 @@ public:
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f\n",
+                     "%.1f,%.1f,%.1f,%.2f,%.2f,%.2f\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms, m.resident_frac,
                      m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib, m.rss_file_mib, m.swap_mib,
-                     m.mem_available_mib, m.mem_free_mib, m.swap_free_mib);
+                     m.mem_available_mib, m.mem_free_mib, m.swap_free_mib, m.kswapd_scan_mib, m.direct_scan_mib,
+                     m.ws_refault_mib);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -72,7 +73,8 @@ private:
         // (how much of the cache the kernel still has; -1 = unmeasured), then the memory block.
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
                          "resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,"
-                         "mem_available_mib,mem_free_mib,swap_free_mib\n");
+                         "mem_available_mib,mem_free_mib,swap_free_mib,kswapd_scan_mib,direct_scan_mib,"
+                         "ws_refault_mib\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -8,20 +8,29 @@ namespace {
 
 class CsvMetricsSink final : public IMetricsSink {
 public:
-    explicit CsvMetricsSink(std::FILE * f) : f_(f) {
-        // New columns are appended LAST so existing positional parsers stay valid: stall_ms (0 when
-        // serial), mgmt_ms (cache-management split out of the compute residual), then majflt/cpu_ms
-        // (the fault + CPU-time decomposition of what remains of "compute"), then resident_frac
-        // (how much of the cache the kernel still has; -1 = unmeasured).
-        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
-                         "resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,"
-                         "mem_available_mib,mem_free_mib,swap_free_mib\n");
-    }
+    explicit CsvMetricsSink(std::FILE * f) : f_(f) {}
     ~CsvMetricsSink() override {
         if (f_) std::fclose(f_);
     }
 
+    // The `#` preamble, mirroring the route/compute traces: what this run was, before what it did.
+    // Key=value, whitespace-separated, order-independent — new keys are appended freely and older
+    // parsers ignore what they do not know.
+    void on_run_info(const RunInfo & r) override {
+        if (header_) return; // a session sends this once; a second call would interleave a preamble
+        std::fprintf(f_, "# bmoe_metrics v1\n");
+        std::fprintf(f_, "# model=%s arch=%s n_layer=%d n_expert=%d n_expert_used=%d threads=%d n_ctx=%d\n",
+                     r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx);
+        std::fprintf(f_,
+                     "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d cache_dynamic=%d force_cache=%d "
+                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d warm_dense=%d\n",
+                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.cache_dynamic, r.force_cache,
+                     r.io_threads, r.o_direct, r.overlap, r.prefetch_layers, r.warm_dense);
+        write_header();
+    }
+
     void on_token(const TokenMetrics & m) override {
+        write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,%.1f,%.1f,"
                      "%.1f,%.1f,%.1f\n",
@@ -52,7 +61,22 @@ public:
     }
 
 private:
+    // Deferred so the preamble can land above it: the column header is only correct once we know
+    // whether anything is going to describe the run first.
+    void write_header() {
+        if (header_) return;
+        header_ = true;
+        // New columns are appended LAST so existing positional parsers stay valid: stall_ms (0 when
+        // serial), mgmt_ms (cache-management split out of the compute residual), then majflt/cpu_ms
+        // (the fault + CPU-time decomposition of what remains of "compute"), then resident_frac
+        // (how much of the cache the kernel still has; -1 = unmeasured), then the memory block.
+        std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
+                         "resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,"
+                         "mem_available_mib,mem_free_mib,swap_free_mib\n");
+    }
+
     std::FILE * f_ = nullptr;
+    bool header_ = false;
 };
 
 } // namespace

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -35,13 +35,14 @@ public:
                      "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
-                     "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f cache_cuts=%lld\n",
+                     "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
+                     "cache_cuts=%lld\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
                      s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
-                     s.cpu_s_per_token, s.token_demand_mib, s.cache_cuts);
+                     s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.cache_cuts);
         std::fflush(f_);
     }
 

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -32,13 +32,12 @@ public:
     void on_token(const TokenMetrics & m) override {
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
-                     "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f,%.2f,%.2f,%.2f\n",
+                     "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,%.1f,%.1f,"
+                     "%.1f,%.1f,%.1f\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms, m.resident_frac,
-                     m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib, m.rss_file_mib, m.swap_mib,
-                     m.mem_available_mib, m.mem_free_mib, m.swap_free_mib, m.kswapd_scan_mib, m.direct_scan_mib,
-                     m.ws_refault_mib);
+                     m.dense_resident_frac, m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib,
+                     m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -72,9 +71,8 @@ private:
         // (the fault + CPU-time decomposition of what remains of "compute"), then resident_frac
         // (how much of the cache the kernel still has; -1 = unmeasured), then the memory block.
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
-                         "resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,"
-                         "mem_available_mib,mem_free_mib,swap_free_mib,kswapd_scan_mib,direct_scan_mib,"
-                         "ws_refault_mib\n");
+                         "resident_frac,dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,"
+                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -14,16 +14,21 @@ public:
         // (the fault + CPU-time decomposition of what remains of "compute"), then resident_frac
         // (how much of the cache the kernel still has; -1 = unmeasured).
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
-                         "resident_frac\n");
+                         "resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,"
+                         "mem_available_mib,mem_free_mib,swap_free_mib\n");
     }
     ~CsvMetricsSink() override {
         if (f_) std::fclose(f_);
     }
 
     void on_token(const TokenMetrics & m) override {
-        std::fprintf(f_, "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f\n", m.step, m.steps, m.wall_ms,
-                     m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes, m.cache_hit_pct, m.stall_ms, m.mgmt_ms,
-                     (unsigned long long) m.majflt, m.cpu_ms, m.resident_frac);
+        std::fprintf(f_,
+                     "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,%.1f,%.1f,"
+                     "%.1f,%.1f,%.1f\n",
+                     m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
+                     m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms, m.resident_frac,
+                     m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib, m.rss_file_mib, m.swap_mib,
+                     m.mem_available_mib, m.mem_free_mib, m.swap_free_mib);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {

--- a/core/src/moe/cache_governor.cpp
+++ b/core/src/moe/cache_governor.cpp
@@ -13,10 +13,9 @@ CacheGovernor::CacheGovernor(const CacheGovernorParams & p) : p_(p) {
     since_cut_ = p_.cut_cooldown;
 }
 
-// The floor is one token's routed working set once the streamer has measured it, and the
-// configured minimum until then. Never above the cap the user allowed: if a single token already
-// demands more than the whole budget, the cache is pathological whatever we do here, and the
-// governor's job is only to stop making it worse.
+// The mechanical floor: the largest layer we must be able to stage, once the streamer has measured
+// it, and the configured minimum until then. Deliberately NOT one token's working set — see the
+// note in the header. Never above the cap the user allowed.
 size_t CacheGovernor::floor_of(const CacheSignals & s) const {
     return std::min(s.floor ? s.floor : p_.min_cap, p_.user_cap);
 }
@@ -47,8 +46,9 @@ CacheGovernor::Decision CacheGovernor::on_token(const CacheSignals & s) {
 
     if (pressure) {
         calm_ = 0;
-        // Below the floor a smaller cache cannot help: the misses are the model's own demand, not
-        // the kernel's doing, and cutting further only trades hits for the same war.
+        // Keep cutting for as long as the device keeps taking memory, all the way down to the
+        // mechanical floor. There is no budget worth defending against a kernel that will not
+        // concede it: the hits a smaller cache gives up are bounded, the war is not.
         if (since_cut_ >= p_.cut_cooldown && cap_ > floor) {
             ceiling_ = cap_;
             cap_ = std::max((size_t) ((double) cap_ * p_.cut_factor), floor);

--- a/core/src/moe/cache_governor.cpp
+++ b/core/src/moe/cache_governor.cpp
@@ -1,0 +1,89 @@
+#include "bmoe/cache_governor.h"
+
+#include <algorithm>
+
+namespace bmoe {
+
+CacheGovernor::CacheGovernor(const CacheGovernorParams & p) : p_(p) {
+    cap_ = std::min(p_.initial, p_.user_cap);
+    cap_ = std::max(cap_, std::min(p_.min_cap, p_.user_cap));
+    // The cooldown paces cuts APART; it must not delay the first one. Starting it spent lets the
+    // very first token act — which is the token that matters most, because a session opened onto an
+    // already-pressured device is in the war before it generates anything.
+    since_cut_ = p_.cut_cooldown;
+}
+
+// The floor is one token's routed working set once the streamer has measured it, and the
+// configured minimum until then. Never above the cap the user allowed: if a single token already
+// demands more than the whole budget, the cache is pathological whatever we do here, and the
+// governor's job is only to stop making it worse.
+size_t CacheGovernor::floor_of(const CacheSignals & s) const {
+    return std::min(s.floor ? s.floor : p_.min_cap, p_.user_cap);
+}
+
+// Grow freely up to the user's cap, but stay a margin below any budget already known to provoke
+// reclaim — re-touching the ceiling just to be cut again is a war with extra steps.
+size_t CacheGovernor::grow_limit() const {
+    if (ceiling_ == no_ceiling) return p_.user_cap;
+    return std::min(p_.user_cap, (size_t) ((double) ceiling_ * p_.ceiling_retreat));
+}
+
+CacheGovernor::Decision CacheGovernor::on_token(const CacheSignals & s) {
+    if (since_cut_ < p_.cut_cooldown) ++since_cut_;
+
+    // Residency first: it is absolute (our pages are either in RAM or they are not), so it needs
+    // no baseline and cannot be fooled by faults that belong to someone else's memory. The fault
+    // reflex only covers the tokens between samples, and only once a calm baseline exists to
+    // compare against — without one, every value looks extreme.
+    const bool sampled = s.resident_frac >= 0.0;
+    bool pressure = false;
+    if (sampled && s.resident_frac < p_.resident_min) {
+        pressure = true;
+    } else if (baseline_ >= 0.0 && (double) s.majflt > baseline_ * p_.fault_ratio + (double) p_.fault_margin) {
+        pressure = true;
+    }
+
+    const size_t floor = floor_of(s);
+
+    if (pressure) {
+        calm_ = 0;
+        // Below the floor a smaller cache cannot help: the misses are the model's own demand, not
+        // the kernel's doing, and cutting further only trades hits for the same war.
+        if (since_cut_ >= p_.cut_cooldown && cap_ > floor) {
+            ceiling_ = cap_;
+            cap_ = std::max((size_t) ((double) cap_ * p_.cut_factor), floor);
+            since_cut_ = 0;
+            ++cuts_;
+            return {cap_, true};
+        }
+        return {cap_, false};
+    }
+
+    // Calm. Learn what this device's quiet fault rate looks like, so the reflex is calibrated to
+    // it rather than to a number we guessed. Only calm tokens feed the baseline — sampling a storm
+    // would teach the loop that the storm is normal.
+    baseline_ = baseline_ < 0.0 ? (double) s.majflt
+                                : p_.baseline_decay * baseline_ + (1.0 - p_.baseline_decay) * (double) s.majflt;
+
+    if (++calm_ < p_.calm_tokens) return {cap_, false};
+
+    const size_t limit = grow_limit();
+    if (cap_ < limit) {
+        cap_ = std::min(cap_ + p_.grow_step, limit);
+        calm_ = 0;
+        since_probe_ = 0;
+        return {cap_, true};
+    }
+
+    // Pinned at a remembered ceiling and calm for a long time: the concession may have moved (a
+    // background app exited, the user left the camera). Forget the ceiling and let ordinary growth
+    // re-discover it. Being wrong costs exactly one cut, which is the price of not staying small
+    // forever because of one bad minute.
+    if (ceiling_ != no_ceiling && ++since_probe_ >= p_.probe_after) {
+        since_probe_ = 0;
+        ceiling_ = no_ceiling;
+    }
+    return {cap_, false};
+}
+
+} // namespace bmoe

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -614,10 +614,14 @@ void ExpertStreamSource::sample_residency() {
 void ExpertStreamSource::account_demand(int il, int n_unique) {
     if (il <= last_il_) {
         token_demand_ = demand_accum_;
+        layer_demand_ = layer_demand_accum_;
         demand_accum_ = 0;
+        layer_demand_accum_ = 0;
     }
     last_il_ = il;
-    demand_accum_ += (size_t) n_unique * entry_bytes(il);
+    const size_t bytes = (size_t) n_unique * entry_bytes(il);
+    demand_accum_ += bytes;
+    layer_demand_accum_ = std::max(layer_demand_accum_, bytes); // the widest layer of this pass
 }
 
 // Explicit budget change from outside a decode (memory-pressure callback, the governor, or the
@@ -1112,6 +1116,7 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     s.cache_resizes = cache_resizes_;
     s.cache_resident_frac = resident_frac_;
     s.token_demand_bytes = (uint64_t) token_demand_;
+    s.layer_demand_bytes = (uint64_t) layer_demand_;
     return s;
 }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -38,6 +38,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     load_all_ = cfg.load_all;
     overlap_ = cfg.overlap;
     prefetch_sync_ = cfg.prefetch_sync && !cfg.overlap; // serial only: overlap lane 0 is a worker
+    cache_dynamic_ = cfg.cache_dynamic;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
 
@@ -585,15 +586,58 @@ void ExpertStreamSource::adapt_cache_budget() {
     }
 }
 
-// Explicit budget change from outside a decode (memory-pressure callback, or the shrink gate).
+// Ask the kernel which of our own cache pages it still has. Walking from the LRU tail samples the
+// coldest entries: they are neither the ones a decode is about to touch nor the ones we would keep
+// under our own eviction, so what is missing there was taken by reclaim, not by us. Bounded by
+// residency_sample_entries and throttled — this runs inside the mgmt window of a layer load.
+void ExpertStreamSource::sample_residency() {
+    if (++probe_tick_ % residency_probe_every != 0) return;
+    size_t sampled = 0, resident = 0;
+    int32_t id = ctail_;
+    for (int n = 0; n < residency_sample_entries && id != -1; ++n, id = cprev_[id]) {
+        const int il = id / n_expert_, e = id % n_expert_;
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            const uint64_t slice = layers_[il].proj[p].nb2;
+            if (slice == 0) continue; // absent slot in a fused layout
+            if (!pio::vm_resident_sample((char *) lbuf_[p][il] + (uint64_t) e * slice, slice, &sampled, &resident))
+                return; // platform cannot report: keep the last reading rather than invent one
+        }
+    }
+    // No resident entries yet (early prefill) is not a residency of zero — it is no sample at all.
+    resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
+}
+
+// A token's pass over the layer stack is monotonic in il, so a non-increasing layer index means the
+// previous token's pass just ended and the bytes it demanded are known. Prefill measures the
+// batch's union (larger); the first decode token overwrites it with the decode value, which is the
+// one the governor reads.
+void ExpertStreamSource::account_demand(int il, int n_unique) {
+    if (il <= last_il_) {
+        token_demand_ = demand_accum_;
+        demand_accum_ = 0;
+    }
+    last_il_ = il;
+    demand_accum_ += (size_t) n_unique * entry_bytes(il);
+}
+
+// Explicit budget change from outside a decode (memory-pressure callback, the governor, or the
+// shrink gate).
 void ExpertStreamSource::set_cache_budget(size_t bytes) {
     if (cache_max_ == 0) return; // initialised off (shared-slot mode); the LRU buffers do not exist
-    quiesce_spec();              // cancel/drain spec reads so no worker is mid-write to an evicted page
+    if (bytes > cache_max_) {
+        // Growing evicts nothing, so it needs no quiesce — and must not do one: cancelling the
+        // speculative reads in flight on every grow would quietly defeat --prefetch.
+        cache_max_ = std::min(bytes, total_expert_bytes_);
+        cache_target_ = std::max(cache_target_, cache_max_); // an explicit raise lifts the grow ceiling
+        ++cache_resizes_;
+        return;
+    }
+    if (bytes == cache_max_) return;
+    quiesce_spec(); // cancel/drain spec reads so no worker is mid-write to an evicted page
     // Keep the budget strictly positive. The shared-slot buffers were never allocated (LRU mode was
     // chosen at init), and load_layer branches on cache_max_ == 0 to pick shared-slot vs LRU — so a
     // runtime zero would route into buffers that do not exist. This shrinks toward, never to, zero.
-    cache_max_ = std::max<size_t>(1, std::min(bytes, total_expert_bytes_));
-    cache_target_ = std::max(cache_target_, cache_max_); // an explicit raise lifts the grow ceiling
+    cache_max_ = std::max<size_t>(1, bytes);
     ++cache_resizes_;
     // No cstamp guard: with no decode in flight, nothing is staged for the current generation, so
     // every resident entry (coldest first) is a valid eviction target.
@@ -707,7 +751,13 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     // cache. After this returns no spec read is in flight and completed ones are resident hits.
     if (cache_max_) {
         quiesce_spec();
-        adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
+        // Exactly one hand on the budget: with the governor on it owns cache_max_ (from the token
+        // loop, where an evicting shrink is safe) and we only sense here; otherwise the legacy
+        // free-RAM tracking sizes it in place.
+        if (cache_dynamic_)
+            sample_residency();
+        else
+            adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
     }
 
     auto stage = [&](int e) -> bool {
@@ -754,6 +804,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     };
 
     std::fill(seen_.begin(), seen_.end(), (uint8_t) 0);
+    int n_unique = 0;
     for (int i = 0; i < n_ids; ++i) {
         const int e = load_all_ ? (i < n_expert_ ? i : -1) : ids[i];
         if (e < 0 || e >= n_expert_) continue;
@@ -771,15 +822,18 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
             continue;
         }
         seen_[e] = 1;
+        ++n_unique;
         if (!stage(e)) return false;
     }
     if (load_all_) {
         for (int e = 0; e < n_expert_; ++e) {
             if (seen_[e]) continue;
             seen_[e] = 1;
+            ++n_unique;
             if (!stage(e)) return false;
         }
     }
+    account_demand(il, n_unique);
 
     const size_t njobs = jobs_.size();
     mgmt_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - tm0).count());
@@ -848,7 +902,11 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
     // batch is already drained above, so this only waits on in-flight spec reads).
     if (cache_max_) {
         quiesce_spec();
-        adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
+        // See the serial path: the governor owns the budget when it is on, and only senses here.
+        if (cache_dynamic_)
+            sample_residency();
+        else
+            adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
     }
 
     // 2. New generation for this layer. A flag counts as ready only once its gen matches.
@@ -878,6 +936,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
         }
     }
     std::sort(staged_.begin(), staged_.end());
+    account_demand(il, (int) staged_.size());
 
     if (cache_max_ == 0) {
         // Cache off: every (projection, expert) is a fresh read into the shared full-size slot
@@ -1051,6 +1110,8 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     s.stall_seconds = stall_ns_.load() / 1e9;
     s.cache_budget_bytes = (uint64_t) cache_max_;
     s.cache_resizes = cache_resizes_;
+    s.cache_resident_frac = resident_frac_;
+    s.token_demand_bytes = (uint64_t) token_demand_;
     return s;
 }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -677,7 +677,12 @@ void ExpertStreamSource::sample_dense_residency() {
             }
             target -= len;
         }
-        if (const char * a = addr_of(off)) pio::vm_resident_sample(a, page_, &sampled, &resident);
+        // Align the probe DOWN to its page: vm_resident_sample counts only pages fully inside the
+        // range, so a single page's worth handed in at an arbitrary offset would clip to nothing.
+        if (const char * a = addr_of(off)) {
+            const char * pg = (const char *) ((uintptr_t) a & ~(uintptr_t) (page_ - 1));
+            pio::vm_resident_sample(pg, page_, &sampled, &resident);
+        }
     }
     dense_resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
 }

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -244,6 +244,28 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         }
     }
 
+    // The dense byte ranges are the complement of the expert ranges in the file — the same set
+    // warm_dense_regions sweeps. Kept here so the dense-residency sensor can find them at runtime
+    // without recomputing; the path is kept alongside to locate the mmap in /proc/self/maps.
+    gguf_path_ = gguf_path;
+    if (cache_dynamic_) {
+        std::vector<std::pair<uint64_t, uint64_t>> exp;
+        for (const LayerExperts & L : layers_) {
+            if (!L.bound) continue;
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                const uint64_t sz = (uint64_t) L.proj[p].nb2 * (uint64_t) n_expert_;
+                if (sz) exp.push_back({L.proj[p].file_off, L.proj[p].file_off + sz});
+            }
+        }
+        std::sort(exp.begin(), exp.end());
+        uint64_t pos = 0;
+        for (const auto & r : exp) {
+            if (r.first > pos) dense_ranges_.push_back({pos, r.first});
+            pos = std::max(pos, r.second);
+        }
+        if (pos < fsize_) dense_ranges_.push_back({pos, fsize_});
+    }
+
     // Warm the dense (non-expert) regions into the page cache before the first token, so the early
     // decodes do not fault them in one scattered 4 KiB page at a time. Independent of the cache
     // budget: it only pre-faults the mmap-resident pages, it neither pins nor reserves them. Runs on
@@ -607,6 +629,59 @@ void ExpertStreamSource::sample_residency() {
     resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
 }
 
+// The dense weights' residency, the half resident_frac cannot see. The weights are one mmap of the
+// gguf; a dense file offset becomes an address through the VMA that backs it (/proc/self/maps),
+// which — unlike /proc/vmstat — an app may read, being its own. Probe dense_sample_pages points
+// spread evenly across the dense byte ranges; one page each, so the cost is a few hundred mincore
+// calls, and only every residency_probe_every load. Shares probe_tick_ with sample_residency, so it
+// fires on the same throttle without a second counter.
+void ExpertStreamSource::sample_dense_residency() {
+    if (dense_ranges_.empty()) return;
+    // Share sample_residency's throttle without a second counter: it has just done the ++, so this
+    // fires exactly on the loads where it did, and skips the rest.
+    if (probe_tick_ % residency_probe_every != 0) return;
+    if (!dense_vmas_tried_) { // resolve the mmap once; llama.cpp has mapped the file by first decode
+        dense_vmas_tried_ = true;
+        const size_t slash = gguf_path_.find_last_of("/\\");
+        const std::string base = slash == std::string::npos ? gguf_path_ : gguf_path_.substr(slash + 1);
+        pio::file_mapped_regions(base.c_str(), dense_vmas_);
+    }
+    if (dense_vmas_.empty()) return; // maps unreadable → leave dense_resident_frac_ at -1
+
+    uint64_t total = 0;
+    for (const auto & r : dense_ranges_)
+        total += r.second - r.first;
+    if (total == 0) return;
+
+    // Map a file offset to a virtual address via the VMA that contains it. A large mmap can be split
+    // into several VMAs, so search rather than assume one.
+    auto addr_of = [&](uint64_t off) -> const char * {
+        for (const auto & v : dense_vmas_) {
+            const uint64_t span = (uint64_t) (v.end - v.start);
+            if (off >= v.file_offset && off < v.file_offset + span)
+                return (const char *) v.start + (off - v.file_offset);
+        }
+        return nullptr;
+    };
+
+    size_t sampled = 0, resident = 0;
+    for (int k = 0; k < dense_sample_pages; ++k) {
+        // Stratified: the k-th of dense_sample_pages evenly spaced points across the dense bytes.
+        uint64_t target = (total * (uint64_t) k) / (uint64_t) dense_sample_pages;
+        uint64_t off = 0;
+        for (const auto & r : dense_ranges_) {
+            const uint64_t len = r.second - r.first;
+            if (target < len) {
+                off = r.first + target;
+                break;
+            }
+            target -= len;
+        }
+        if (const char * a = addr_of(off)) pio::vm_resident_sample(a, page_, &sampled, &resident);
+    }
+    dense_resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
+}
+
 // A token's pass over the layer stack is monotonic in il, so a non-increasing layer index means the
 // previous token's pass just ended and the bytes it demanded are known. Prefill measures the
 // batch's union (larger); the first decode token overwrites it with the decode value, which is the
@@ -758,10 +833,12 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
         // Exactly one hand on the budget: with the governor on it owns cache_max_ (from the token
         // loop, where an evicting shrink is safe) and we only sense here; otherwise the legacy
         // free-RAM tracking sizes it in place.
-        if (cache_dynamic_)
+        if (cache_dynamic_) {
             sample_residency();
-        else
+            sample_dense_residency();
+        } else {
             adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
+        }
     }
 
     auto stage = [&](int e) -> bool {
@@ -907,10 +984,12 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
     if (cache_max_) {
         quiesce_spec();
         // See the serial path: the governor owns the budget when it is on, and only senses here.
-        if (cache_dynamic_)
+        if (cache_dynamic_) {
             sample_residency();
-        else
+            sample_dense_residency();
+        } else {
             adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
+        }
     }
 
     // 2. New generation for this layer. A flag counts as ready only once its gen matches.
@@ -1115,6 +1194,7 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     s.cache_budget_bytes = (uint64_t) cache_max_;
     s.cache_resizes = cache_resizes_;
     s.cache_resident_frac = resident_frac_;
+    s.dense_resident_frac = dense_resident_frac_;
     s.token_demand_bytes = (uint64_t) token_demand_;
     s.layer_demand_bytes = (uint64_t) layer_demand_;
     return s;

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -139,6 +139,15 @@ private:
     // loop that follows drains any shrink.
     void adapt_cache_budget();
 
+    // Pressure sensing (cache_dynamic): sample (throttled) how much of the cache the kernel still
+    // has in RAM, walking the LRU cold end — the pages reclaim takes first, so a dip here is the
+    // earliest evidence the budget outgrew what the device concedes. Sets resident_frac_ for the
+    // governor; changes no budget itself. Eval-thread only (it walks the LRU list).
+    void sample_residency();
+
+    // Accumulate one token's routed working set. Eval-thread only, called per layer load.
+    void account_demand(int il, int n_unique);
+
     bool load_layer_async(int il, const int32_t * ids, int n_ids); // overlap path
 
     static void c_expert_ready(const ggml_tensor * src0, int expert, void * user_data);
@@ -185,8 +194,25 @@ private:
     size_t cache_target_ = 0;
     size_t total_expert_bytes_ = 0;
     size_t cache_hard_cap_ = 0; // upper bound on the auto budget (ceiling ∧ full expert-set size)
-    unsigned probe_tick_ = 0;   // throttles the mem_available re-probe (once per N load_layer calls)
+    unsigned probe_tick_ = 0;   // throttles the periodic sensing (once per N load_layer calls)
     long long cache_resizes_ = 0;
+
+    // ── pressure sensing (cache_dynamic): the engine senses, bmoe::CacheGovernor decides ──
+    // Sampling the whole cache every layer would cost more than the reclaim it detects, so a probe
+    // reads a bounded window of the cold end. Cost lands in mgmt_ns_, where a regression is visible
+    // rather than hidden in the compute residual.
+    static constexpr unsigned residency_probe_every = 128; // load_layer calls between probes (~2-3 tokens)
+    static constexpr int residency_sample_entries = 16;    // coldest entries read per probe
+    bool cache_dynamic_ = false;
+    double resident_frac_ = -1.0; // last sampled cache residency; -1 = never measured
+
+    // One token's routed working set, measured: the bytes demanded between two visits to the same
+    // layer. Below it, every token evicts what the next one needs and the cache can only thrash —
+    // which is what cache_min_mb encodes as a static guess. This is the same bound, discovered per
+    // model and top-k at runtime instead, and it is what floors the governor.
+    size_t demand_accum_ = 0;
+    size_t token_demand_ = 0;
+    int last_il_ = -1;
     std::vector<void *> lbuf_[MoeRecipe::max_exps];
     std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];
     std::vector<uint8_t> cvalid_;

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -145,6 +145,13 @@ private:
     // governor; changes no budget itself. Eval-thread only (it walks the LRU list).
     void sample_residency();
 
+    // Companion sensor for the OTHER half of memory: the dense weights, which are mmap'd file-backed
+    // and reclaimed by being dropped (never swapped), so resident_frac — which watches only our anon
+    // cache — is blind to them. A stratified mincore over the dense file ranges says how much of the
+    // model itself the kernel still has. When this falls while resident_frac holds, the faults are
+    // the weights, not the cache, and shrinking the cache cannot help. Sets dense_resident_frac_.
+    void sample_dense_residency();
+
     // Accumulate one token's routed working set. Eval-thread only, called per layer load.
     void account_demand(int il, int n_unique);
 
@@ -203,8 +210,18 @@ private:
     // rather than hidden in the compute residual.
     static constexpr unsigned residency_probe_every = 128; // load_layer calls between probes (~2-3 tokens)
     static constexpr int residency_sample_entries = 16;    // coldest entries read per probe
+    static constexpr int dense_sample_pages = 256;         // stratified probe points over the dense weights
     bool cache_dynamic_ = false;
-    double resident_frac_ = -1.0; // last sampled cache residency; -1 = never measured
+    double resident_frac_ = -1.0;       // last sampled cache residency; -1 = never measured
+    double dense_resident_frac_ = -1.0; // last sampled dense-weight residency; -1 = never measured
+
+    // The dense weights' byte ranges in the file (complement of the expert ranges), and the mmap VMAs
+    // that back them — resolved once, lazily, from /proc/self/maps. Empty vma set = maps unreadable,
+    // which keeps dense_resident_frac_ at -1 rather than inventing a number.
+    std::string gguf_path_;
+    std::vector<std::pair<uint64_t, uint64_t>> dense_ranges_;
+    std::vector<pio::MappedRegion> dense_vmas_;
+    bool dense_vmas_tried_ = false;
 
     // Two measured demands, and the difference between them decides the whole policy.
     //

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -206,12 +206,20 @@ private:
     bool cache_dynamic_ = false;
     double resident_frac_ = -1.0; // last sampled cache residency; -1 = never measured
 
-    // One token's routed working set, measured: the bytes demanded between two visits to the same
-    // layer. Below it, every token evicts what the next one needs and the cache can only thrash —
-    // which is what cache_min_mb encodes as a static guess. This is the same bound, discovered per
-    // model and top-k at runtime instead, and it is what floors the governor.
+    // Two measured demands, and the difference between them decides the whole policy.
+    //
+    // token_demand_: the bytes routed between two visits to the same layer — one token's working
+    // set. Below it the cache stops holding anything BETWEEN tokens, so its hit rate collapses to
+    // inter-token correlation only. Informative (it says where hits start), never a floor: measured
+    // on gpt-oss it is 1815 MiB, more than the device concedes, so flooring there just pins the
+    // budget inside a war it cannot win. See bmoe/cache_governor.h.
+    //
+    // layer_demand_: the largest single layer's routed bytes. THIS is the floor, because it is
+    // mechanical — the cache has to hold the layer it is staging right now.
     size_t demand_accum_ = 0;
     size_t token_demand_ = 0;
+    size_t layer_demand_accum_ = 0;
+    size_t layer_demand_ = 0;
     int last_il_ = -1;
     std::vector<void *> lbuf_[MoeRecipe::max_exps];
     std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ for the idea the project is built on.
 | [adaptive-cache.md](adaptive-cache.md) | `--cache-mb auto`, the cache ceiling, and dense warm-up. |
 | [prefetch.md](prefetch.md) | `--prefetch K`: the design and why it cannot change output. |
 | [android-memory.md](android-memory.md) | What reclaims the engine's memory on a phone, which levers exist (almost none), and why the cache hit rate is what the kernel judges you by. |
+| [pressure.md](pressure.md) | `--cache-dynamic`: why a cache budget cannot be a constant, and how the engine finds the one the device concedes by watching its own pages. |
 
 ## Measurements
 

--- a/docs/adaptive-cache.md
+++ b/docs/adaptive-cache.md
@@ -50,6 +50,12 @@ the rest of the system.
 > cache holding this model's own dense weights as free. Before trusting `auto` on a model whose
 > expert set dwarfs the budget, read [android-memory.md](android-memory.md).
 
+> **`auto` sizes from a signal that lies.** Everything on this page tracks `MemAvailable`, which
+> reports memory the device will not actually concede — so `auto` over-asks, and an over-ask is not
+> a wasted budget but a running fight. [`--cache-dynamic`](pressure.md) answers the same question
+> from the other end: instead of asking the OS how much memory exists, it watches what happens to
+> the pages the cache already holds, and sizes to what the device does rather than what it says.
+
 ## Flags
 
 | Flag | Meaning |

--- a/docs/pressure.md
+++ b/docs/pressure.md
@@ -1,0 +1,125 @@
+# Pressure-aware cache sizing
+
+`--cache-dynamic` treats the cache budget as a ceiling rather than an instruction, and lets the
+engine find the largest cache the device will actually concede. It is off by default.
+
+## Why a budget cannot be a constant
+
+The expert cache is the one lever that trades RAM for flash reads, so the temptation is to set it as
+large as the device seems to allow. On a phone that is the wrong shape of decision, for three
+reasons that are measured rather than argued:
+
+**A budget the device refuses does not go unused — it starts a war.** Ask for more than the device
+concedes and reclaim stops being an event and becomes a standing condition: pages are taken *during*
+the decode, faulted back in, and taken again. On gpt-oss-120b the engine asking ~3.8 GiB on a device
+that conceded ~3.0 ran a turn at 0.3 tok/s against 1.45 tok/s for the same turn without the fight.
+The cache was not slightly too big; it was net negative.
+
+**Restoring the stolen pages does not win it.** Bulk-restoring the whole cache after an idle reclaim
+works mechanically — 2.0 GiB back in 6.4 s — and the kernel takes it back within 8 s. Throughput
+does not move. The ask has to shrink; re-fetching what was taken is treating the scoreboard.
+
+**The number is not knowable in advance.** It depends on the model (one token of gpt-oss at top-2
+routes ~536 MiB, Qwen3-30B at top-8 routes ~1051 MiB), on the top-k, on the device, and on whatever
+else the user has open right now. Any constant is wrong for some model on some phone on some day.
+
+## Why the OS cannot be asked
+
+The obvious design — subscribe to the platform's memory-pressure signal — does not survive contact
+with Android:
+
+| Signal | Why it fails |
+| --- | --- |
+| `/proc/meminfo` `MemAvailable` | Counts the page cache holding our *own* mmap'd dense weights as free, so it over-reports by roughly the model's resident size. This is what `--cache-mb auto` sizes from, and why it over-asks. |
+| PSI (`/proc/pressure/memory`) | SELinux label `proc_pressure_mem`; no `untrusted_app` allow rule. Unreadable by an app. |
+| `onTrimMemory` | Late, coarse, one-sided — it never signals that pressure *eased*, and the `RUNNING_*` levels are deprecated since API 34. |
+| `mlock` / memcg `min`/`low` | `RLIMIT_MEMLOCK` is 64 KiB on this device; cgroup v1 has no protection knobs an app can set. Nothing unprivileged protects anonymous memory. |
+
+So the engine does not ask the OS anything. It watches what happens to memory it already holds.
+A process may always ask about its **own** pages, on any device, with no permission and no vendor
+cooperation — and pages we wrote, then lost, *are* reclaim, by definition.
+
+## The loop
+
+Three roles, one per concern, so the policy is portable and the syscalls are not:
+
+- **Sense** (`core/src/io/platform_io.cpp`, `core/src/moe/expert_stream_source.cpp`)
+  - `mincore()` over the cache's own anonymous buffers, walking the LRU cold end — the pages reclaim
+    takes first. This is the primary signal: it is absolute (our pages are in RAM or they are not),
+    needs no baseline, and sees the theft *before* those pages fault back and cost a read. Bounded
+    and throttled; its cost lands in `mgmt_ms`, where a regression is visible rather than hidden.
+  - `getrusage(RUSAGE_SELF).ru_majflt` deltas per token — the fast reflex between residency samples.
+    Already measured for the telemetry, so it costs nothing new.
+- **Decide** (`core/include/bmoe/cache_governor.h`) — AIMD with hysteresis. Pure policy: no
+  syscalls, no clocks, no llama.cpp, no config reads. Unit-tested against a synthetic device
+  (`tests/cache_governor_test.cpp`).
+- **Act** (`ExpertStreamSource::set_cache_budget`) — resize and evict the cold tail. Driven once per
+  token from the generation loop, which is the only point where no decode is in flight and an
+  evicting shrink is safe.
+
+The shape is TCP's, for the same reason TCP has it: an unobservable bottleneck, probed by watching
+your own losses. Growth is additive because being wrong upward is cheap to give back; a cut is
+multiplicative because the asymmetry is real — asking too much costs a continuous war mid-decode,
+asking too little costs only a few points of hit rate.
+
+```
+every token, after the decode:
+    if sampled residency < 0.90            → the kernel is taking the cache
+    else if majflt > baseline*3 + 32       → reflex, once a calm baseline exists
+        → ceiling := cap;  cap := max(cap * 0.7, floor);  wait out a cooldown
+
+    else (calm):
+        learn the baseline from this token
+        after N calm tokens: cap += 64 MiB, up to min(user cap, ceiling * 0.9)
+        after a long calm at the ceiling: forget it and re-test (the device may have changed)
+```
+
+## The floor is measured, not guessed
+
+A cache below **one token's routed working set** can hold nothing between tokens: every token evicts
+what the next one needs, so it cannot buy a single hit and still pays the management cost. That
+bound — not any particular number of MiB — is what `MoeStreamConfig::cache_min_mb` (1500 MiB)
+encodes as a static guess, and the guess is model-specific: it is roughly right for Qwen3-30B at
+top-8 (1051 MiB/token) and much too high for gpt-oss-120b at top-2 (536 MiB/token).
+
+So the streamer measures it. The bytes of distinct experts routed between two visits to the same
+layer *is* the working set; it is reported as `token_demand_MiB` in the run summary and it is what
+floors the governor. That keeps the loop honest on a model nobody has benchmarked yet: below the
+floor a smaller cache cannot help, because the misses there are the model's own demand and not the
+kernel's doing.
+
+## Reading it
+
+Per token (`--csv`, `BMOE_PROGRESS`): `resident_frac` — the sampled fraction of the cache still in
+RAM, `-1` when unmeasured (throttled sample, streaming off, or a host that cannot report).
+
+Per run (`# summary`, `BMOE_DONE`): `token_demand_MiB` (what one token demands), `cache_budget_MiB`
+(where the loop settled), `cache_cuts` (how often the device pushed back), `cache_resizes`.
+
+Reading `cache_budget_MiB` against `token_demand_MiB` is how a budget stops being a guess: a budget
+near the demand holds about one token of routing history and its hits come from inter-token
+correlation only; a budget far above it is either buying real reuse or buying a war, and
+`cache_cuts` says which.
+
+## Portability
+
+The sensors are the platform's half, and they are deliberately the least exotic syscalls available:
+`getrusage` and `mincore` exist on every POSIX target, need no permission, and cannot be disabled by
+a vendor kernel the way PSI and `mlock` are here. On a platform that cannot report residency (the
+Windows host build) the sample reads as unmeasured, the loop stays calm, and the budget behaves
+exactly as a static one — which is the right degradation.
+
+An iOS port would replace only the sensor: `os_proc_available_memory()` plus
+`DISPATCH_SOURCE_TYPE_MEMORYPRESSURE`, which unlike `onTrimMemory` fires on both edges. The
+governor and the actuator do not change.
+
+## Status
+
+Off by default, and the app exposes it as a switch ("Pressure-aware cache sizing"). It stays off
+until the on-device A/B says otherwise — the same discipline that turned the rewarm pass off after
+it was measured. The tunables (0.90 residency, ×3 faults, ×0.7 cut, 64 MiB growth) are compiled in
+rather than exposed: they are control-loop policy, not per-device facts, and the loop discovers the
+device's concession at runtime regardless.
+
+See also: [android-memory.md](android-memory.md) for what reclaims the engine's memory and which
+levers exist, [adaptive-cache.md](adaptive-cache.md) for `--cache-mb auto` and the ceiling.

--- a/docs/pressure.md
+++ b/docs/pressure.md
@@ -74,27 +74,49 @@ every token, after the decode:
         after a long calm at the ceiling: forget it and re-test (the device may have changed)
 ```
 
-## The floor is measured, not guessed
+## The floor is measured — and it is not the obvious one
 
-A cache below **one token's routed working set** can hold nothing between tokens: every token evicts
-what the next one needs, so it cannot buy a single hit and still pays the management cost. That
-bound — not any particular number of MiB — is what `MoeStreamConfig::cache_min_mb` (1500 MiB)
-encodes as a static guess, and the guess is model-specific: it is roughly right for Qwen3-30B at
-top-8 (1051 MiB/token) and much too high for gpt-oss-120b at top-2 (536 MiB/token).
+The tempting floor is **one token's routed working set**. Below it, every token evicts what the next
+one needs, so the cache holds nothing between tokens and its hit rate collapses. That is true, and
+it is the bound `MoeStreamConfig::cache_min_mb` (1500 MiB) encodes as a static guess. It is still
+the wrong floor, and the device said so.
 
-So the streamer measures it. The bytes of distinct experts routed between two visits to the same
-layer *is* the working set; it is reported as `token_demand_MiB` in the run summary and it is what
-floors the governor. That keeps the loop honest on a model nobody has benchmarked yet: below the
-floor a smaller cache cannot help, because the misses there are the model's own demand and not the
-kernel's doing.
+Measured on gpt-oss-120b at top-4, `--cache-mb 2000 --cache-dynamic`:
+
+| | |
+|---|---|
+| `token_demand_MiB` | 1815.4 |
+| `cache_budget_MiB` | 1815.4 — the budget *is* the floor, to the decimal |
+| `cache_cuts` | 1 — cut once, then pinned |
+| `cache_hit_pct` | 8.2 — 1.8 GiB of RAM, for 8% of hits |
+| `majflt/tok` | 5174, at 0.37 tok/s |
+
+The loop cut 2000 → max(1400, 1815.4) = 1815.4 and stopped, because `cap > floor` was now false.
+The sensor kept firing (`resident_frac` 1.000 → 0.937, 47k faults on one token) into a floor that
+could not yield. A 9% cut, and the war went on.
+
+The flaw is the comparison. "Below the floor the cache can only thrash" weighs the hits given up and
+ignores that **the memory itself is the cost**: an unaffordable cache does not merely fail to earn
+its hits, it starts a reclaim war worth several times any hit rate — and here it was buying 8%. The
+falsifying evidence was already on the table: a hand-set 1000 MiB budget, far below that "floor",
+runs this model well.
+
+So usefulness yields to pressure. The only floor that may not yield is the **mechanical** one — the
+widest layer of a pass, which the cache must be able to stage — and it is measured the same way
+(`layer_demand_MiB`). `token_demand_MiB` stays in the telemetry, because where hits start is worth
+knowing; it is simply not the same claim as where the cache must stop.
 
 ## Reading it
 
 Per token (`--csv`, `BMOE_PROGRESS`): `resident_frac` — the sampled fraction of the cache still in
 RAM, `-1` when unmeasured (throttled sample, streaming off, or a host that cannot report).
 
-Per run (`# summary`, `BMOE_DONE`): `token_demand_MiB` (what one token demands), `cache_budget_MiB`
-(where the loop settled), `cache_cuts` (how often the device pushed back), `cache_resizes`.
+Per run (`# summary`, `BMOE_DONE`): `token_demand_MiB` (what one token demands), `layer_demand_MiB`
+(the mechanical floor), `cache_budget_MiB` (where the loop settled), `cache_cuts` (how often the
+device pushed back), `cache_resizes`.
+
+A budget sitting exactly on `token_demand_MiB` with `cache_cuts` stuck at 1 is the failure above:
+the loop wanted to cut and something floored it.
 
 Reading `cache_budget_MiB` against `token_demand_MiB` is how a budget stops being a guess: a budget
 near the demand holds about one token of routing history and its hits come from inter-token

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -117,8 +117,9 @@ that token (`0` in serial mode); `mgmt_ms` is the cache-management time describe
 `-1` when unmeasured. All are additive: older CSVs have fewer columns, so consumers must read by
 column NAME (from the header row) and treat any as optional. The `# summary` line likewise gains
 `stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>`, `cpu_s/tok=<s>`, `token_demand_MiB=<f>` (the
-expert bytes one token routes, measured — the floor a cache must clear to hold anything between
-tokens) and `cache_cuts=<int>` (times `--cache-dynamic` shrank the budget under reclaim); see the
+expert bytes one token routes, measured — where cache hits start, NOT a floor to defend; see
+[pressure.md](pressure.md)), `layer_demand_MiB=<f>` (the widest layer's routed bytes: the mechanical
+floor the governor may not cut below) and `cache_cuts=<int>` (times `--cache-dynamic` shrank the budget under reclaim); see the
 `io_ms` note above for how the read-time columns are reinterpreted under overlap.
 
 ## Route trace

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -11,7 +11,8 @@ Emitted once per generated token, in order:
 BMOE_LOAD {"mb":<float>,"ms":<float>}
 BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
                "compute_ms":<float>,"mgmt_ms":<float>,"stall_ms":<float>,"read_mb":<float>,
-               "cache_hit_pct":<float>,"majflt":<int>,"cpu_ms":<float>,"text":"<string>"}
+               "cache_hit_pct":<float>,"majflt":<int>,"cpu_ms":<float>,"resident_frac":<float>,
+               "text":"<string>"}
 ```
 
 - `BMOE_LOAD` appears only when experts were read this token; `mb` is the flash bytes read,
@@ -53,6 +54,11 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
   near 100% is genuinely compute-bound, well below means the cores were throttled, preempted, or
   blocked (a low-clock frequency cap or a co-resident process), not doing more math. Both are `0`
   when the platform can't report them (the Windows host build); treat `0` as "unmeasured".
+- `resident_frac` is the sampled fraction of the expert cache's own pages the kernel still had in
+  RAM at the last probe. Below `1` the device is reclaiming the cache mid-run — the pressure
+  `--cache-dynamic` sizes against (see [pressure.md](pressure.md)). It is `-1` when unmeasured: the
+  sampler is throttled (it probes every ~2-3 tokens), streaming is off, or the platform cannot
+  report residency. Treat `-1` as "no sample", never as "nothing resident".
 - `text` is the full generated text so far, JSON-escaped (for streaming into a UI).
 
 ## End-of-run lines
@@ -98,19 +104,22 @@ prints just the summary lines.
 `--csv PATH` additionally writes one row per token:
 
 ```
-step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms
+step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,resident_frac
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
 
-`stall_ms`, `mgmt_ms`, `majflt` and `cpu_ms` are trailing columns appended (in that order) after
-the original seven. `stall_ms` is the wall time compute threads waited for expert reads that token
-(`0` in serial mode); `mgmt_ms` is the cache-management time described above; `majflt`/`cpu_ms` are
-the fault + CPU-time decomposition of the compute residual (see the `BMOE_PROGRESS` notes above),
-`0` when unmeasured. All are additive: older CSVs have fewer columns, so consumers must read by
+`stall_ms`, `mgmt_ms`, `majflt`, `cpu_ms` and `resident_frac` are trailing columns appended (in that
+order) after the original seven. `stall_ms` is the wall time compute threads waited for expert reads
+that token (`0` in serial mode); `mgmt_ms` is the cache-management time described above;
+`majflt`/`cpu_ms` are the fault + CPU-time decomposition of the compute residual (see the
+`BMOE_PROGRESS` notes above), `0` when unmeasured; `resident_frac` is the sampled cache residency,
+`-1` when unmeasured. All are additive: older CSVs have fewer columns, so consumers must read by
 column NAME (from the header row) and treat any as optional. The `# summary` line likewise gains
-`stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>` and `cpu_s/tok=<s>` (see the `io_ms` note
-above for how the read-time columns are reinterpreted under overlap).
+`stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>`, `cpu_s/tok=<s>`, `token_demand_MiB=<f>` (the
+expert bytes one token routes, measured — the floor a cache must clear to hold anything between
+tokens) and `cache_cuts=<int>` (times `--cache-dynamic` shrank the budget under reclaim); see the
+`io_ms` note above for how the read-time columns are reinterpreted under overlap.
 
 ## Route trace
 
@@ -221,7 +230,7 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "n_prompt":<int>,"n_past":<int>,"compute_s_tok":<float>,"io_s_tok":<float>,
             "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
             "stall_s_tok":<float>,"mgmt_s_tok":<float>,"majflt_tok":<float>,"cpu_s_tok":<float>,
-            "text":"<string>"}
+            "token_demand_mib":<float>,"cache_cuts":<int>,"text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -105,8 +105,8 @@ prints just the summary lines.
 
 ```
 step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,resident_frac,
-turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,
-swap_free_mib
+dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,
+mem_available_mib,mem_free_mib,swap_free_mib
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
@@ -133,6 +133,7 @@ The trailing block is the memory picture, added so a run can be diagnosed from i
 | `cache_budget_mib` | the expert-cache budget this token ran under. Per token, not just in the summary: it is the governor's trajectory, and without it a loop that cut once and pinned reads exactly like one that never acted. |
 | `rss_anon_mib` | resident anonymous memory — **the expert cache lives here**. Falling while `cache_budget_mib` stays put means the kernel is taking the cache. |
 | `rss_file_mib` | resident file-backed memory — the mmap'd model. Reclaimed by being dropped, not swapped, so it never shows in `swap_mib`. |
+| `dense_resident_frac` | fraction of the DENSE mmap'd weights still in RAM, by `mincore` over the model's own VMAs (`/proc/self/maps`, which an app may read where `/proc/vmstat` it may not). Companion to `resident_frac`: that watches the anon cache, this the file-backed weights. Dense falling while `resident_frac` holds means the faults are the model, not the cache — so shrinking the cache cannot help. `-1` when unmeasured. |
 | `swap_mib` | anonymous memory already lost to zram (`VmSwap`). |
 | `rss_mib` | total resident (`VmRSS`). |
 | `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -104,7 +104,9 @@ prints just the summary lines.
 `--csv PATH` additionally writes one row per token:
 
 ```
-step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,resident_frac
+step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,resident_frac,
+turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,
+swap_free_mib
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
@@ -121,6 +123,21 @@ expert bytes one token routes, measured — where cache hits start, NOT a floor 
 [pressure.md](pressure.md)), `layer_demand_MiB=<f>` (the widest layer's routed bytes: the mechanical
 floor the governor may not cut below) and `cache_cuts=<int>` (times `--cache-dynamic` shrank the budget under reclaim); see the
 `io_ms` note above for how the read-time columns are reinterpreted under overlap.
+
+The trailing block is the memory picture, added so a run can be diagnosed from its own file:
+
+| column | meaning |
+| --- | --- |
+| `turn` | which `generate()` this token belongs to (0 for a one-shot run). A session CSV spans every turn; without this the two-turn shape — a fast turn, an idle, then the turn that pays for it — is unreadable. |
+| `majflt_mib` | what those faults moved: `majflt` x page size. The same fact as the count, in the unit the rest of the row uses — directly comparable to `read_bytes`, i.e. the reads we chose against the reads the kernel forced on us. |
+| `cache_budget_mib` | the expert-cache budget this token ran under. Per token, not just in the summary: it is the governor's trajectory, and without it a loop that cut once and pinned reads exactly like one that never acted. |
+| `rss_anon_mib` | resident anonymous memory — **the expert cache lives here**. Falling while `cache_budget_mib` stays put means the kernel is taking the cache. |
+| `rss_file_mib` | resident file-backed memory — the mmap'd model. Reclaimed by being dropped, not swapped, so it never shows in `swap_mib`. |
+| `swap_mib` | anonymous memory already lost to zram (`VmSwap`). |
+| `rss_mib` | total resident (`VmRSS`). |
+| `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |
+
+All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split).
 
 ## Route trace
 

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -31,5 +31,19 @@
             android:name=".RunService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+        <!-- Hands a metrics CSV to another app (Drive, Gmail, Files) as a content:// URI with a
+             one-shot read grant. A file:// URI would be refused outright since Android 7, and the
+             alternative — telling the user to go find the file — is not a feature. Scoped to the
+             app's own external files dir; it exposes nothing else. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 </manifest>

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -25,6 +25,7 @@ data class AppSettings(
     val warmDense: Boolean = true,      // page-cache the non-expert weights at load (kills >RAM slow-start)
     val prefetchLayers: Int = 0,        // temporal prefetch depth K (0 = off); needs the cache
     val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
+    val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
 ) {
     /**
      * Build the argv that OPENS a persistent bmoe-cli session (`--session`): everything fixed for
@@ -35,8 +36,13 @@ data class AppSettings(
      * When [mmap] is set, expert streaming is turned off entirely: the CLI omits --moe-stream and
      * every streaming knob (cache / lanes / O_DIRECT / overlap), so llama.cpp loads the whole model
      * via mmap through the page cache — the baseline the streaming modes compare to.
+     *
+     * @param csvPath where the engine should write its per-token metrics CSV, or null to not ask
+     *   for one. One file per SESSION, not per turn: the engine appends every turn's rows to it and
+     *   marks each with a `turn` column, which is the only way to read the two-turn shape this
+     *   engine is judged by (a fast turn, an idle, then the turn that pays for it).
      */
-    fun sessionArgv(cliPath: String, modelPath: String): List<String> {
+    fun sessionArgv(cliPath: String, modelPath: String, csvPath: String? = null): List<String> {
         val a = mutableListOf(
             cliPath,
             "-m", modelPath,
@@ -48,6 +54,9 @@ data class AppSettings(
         // Active-expert (top-k) override is a load-time kv_override, valid with or without
         // streaming — so it lives outside the mmap gate below.
         if (nExpertUsed > 0) a += listOf("--n-expert-used", nExpertUsed.toString())
+        // Outside the mmap gate too: the fault and memory columns are measured whether or not the
+        // streamer is on, and the mmap baseline is exactly what they are compared against.
+        if (metricsCsv && csvPath != null) a += listOf("--csv", csvPath)
         if (!mmap) {
             a += "--moe-stream"
             if (cacheMb == CACHE_AUTO) {
@@ -95,6 +104,7 @@ data class AppSettings(
             .putBoolean("overlap", overlap).putBoolean("warmDense", warmDense)
             .putInt("prefetchLayers", prefetchLayers)
             .putBoolean("thinking", thinking)
+            .putBoolean("metricsCsv", metricsCsv)
             .apply()
     }
 
@@ -103,6 +113,30 @@ data class AppSettings(
         // long prompt plus the largest practical generation. A request that would overflow it is
         // rejected recoverably by the CLI, leaving the session usable.
         const val SESSION_CTX = 4096
+
+        /**
+         * A fresh CSV path for a session about to open, under the app's own external files dir —
+         * no permission needed to write, and `adb pull`-able without root:
+         *
+         *     /sdcard/Android/data/<pkg>/files/metrics/bmoe-<yyyyMMdd-HHmmss>.csv
+         *
+         * Timestamped rather than fixed, because a run you cannot tell apart from the previous one
+         * is not evidence. Returns null if the volume is unavailable, which just means no CSV.
+         */
+        fun newMetricsCsvPath(ctx: Context): String? {
+            val dir = java.io.File(ctx.getExternalFilesDir(null) ?: return null, "metrics")
+            if (!dir.isDirectory && !dir.mkdirs()) return null
+            val ts = java.text.SimpleDateFormat("yyyyMMdd-HHmmss", java.util.Locale.US).format(java.util.Date())
+            return java.io.File(dir, "bmoe-$ts.csv").absolutePath
+        }
+
+        /** The most recent metrics CSV, or null if none was written yet. */
+        fun latestMetricsCsv(ctx: Context): java.io.File? {
+            val root = ctx.getExternalFilesDir(null) ?: return null
+            return java.io.File(root, "metrics")
+                .listFiles { f -> f.name.endsWith(".csv") }
+                ?.maxByOrNull { it.lastModified() }
+        }
 
         // -1 (Auto) sizes the cache to the device's free RAM at runtime (--cache-mb auto).
         //
@@ -147,6 +181,7 @@ data class AppSettings(
                 warmDense = p.getBoolean("warmDense", d.warmDense),
                 prefetchLayers = p.getInt("prefetchLayers", d.prefetchLayers),
                 thinking = p.getBoolean("thinking", d.thinking),
+                metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),
             )
         }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -13,6 +13,9 @@ data class AppSettings(
     val mmap: Boolean = false,          // baseline: no streaming — llama.cpp mmap loads the whole model
     val cacheMb: Int = CACHE_AUTO,      // LRU expert cache budget; Auto / 0 / 500..6000 (see CACHE_CHOICES)
     val cacheCeilMb: Int = 3000,        // with cacheMb=Auto: upper bound on the auto budget (0 = no cap)
+    val cacheDynamic: Boolean = false,  // treat the budget as a ceiling and let the engine find the
+                                        // largest cache the device concedes (--cache-dynamic). Off
+                                        // until it is measured on device, like every other claim here.
     val ioThreads: Int = 4,             // parallel expert-read lanes
     val threads: Int = 4,               // compute threads (-t)
     val nExpertUsed: Int = 0,           // top-k override (0 = model default); lower = faster, changes output
@@ -64,6 +67,8 @@ data class AppSettings(
             // Auto sizing is a live LRU cache, so it satisfies the prefetch cache requirement.
             val cacheOn = cacheMb == CACHE_AUTO || cacheMb > 0
             if (prefetchLayers > 0 && cacheOn) a += listOf("--prefetch", prefetchLayers.toString())
+            // Same requirement: there is no budget to size at runtime with the cache off.
+            if (cacheDynamic && cacheOn) a += "--cache-dynamic"
         }
         return a
     }
@@ -75,14 +80,15 @@ data class AppSettings(
      * excluded — they vary per request without touching the loaded model.
      */
     fun sessionSignature(modelPath: String): String =
-        listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, oDirect, overlap,
-               warmDense, prefetchLayers)
+        listOf(modelPath, mmap, cacheMb, cacheCeilMb, cacheDynamic, ioThreads, threads, nExpertUsed, oDirect,
+               overlap, warmDense, prefetchLayers)
             .joinToString("|")
 
     fun save(ctx: Context) {
         ctx.prefs().edit()
             .putBoolean("mmap", mmap)
             .putInt("cacheMb", cacheMb).putInt("cacheCeilMb", cacheCeilMb)
+            .putBoolean("cacheDynamic", cacheDynamic)
             .putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nExpertUsed", nExpertUsed)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
@@ -131,6 +137,7 @@ data class AppSettings(
                 mmap = p.getBoolean("mmap", d.mmap),
                 cacheMb = p.getInt("cacheMb", d.cacheMb),
                 cacheCeilMb = p.getInt("cacheCeilMb", d.cacheCeilMb),
+                cacheDynamic = p.getBoolean("cacheDynamic", d.cacheDynamic),
                 ioThreads = p.getInt("ioThreads", d.ioThreads),
                 threads = p.getInt("threads", d.threads),
                 nExpertUsed = p.getInt("nExpertUsed", d.nExpertUsed),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -94,6 +94,7 @@ fun requestSharedStorageAccess(context: android.content.Context) {
 private fun Root() {
     val context = LocalContext.current
     var showSettings by remember { mutableStateOf(false) }
+    var showMetrics by remember { mutableStateOf(false) }
     var settings by remember { mutableStateOf(AppSettings.load(context)) }
 
     // Model-scan state lives here, above the settings/main switch, so opening Settings and
@@ -118,6 +119,8 @@ private fun Root() {
             onChange = { settings = it; it.save(context) },
             onBack = { showSettings = false },
         )
+    } else if (showMetrics) {
+        MetricsScreen(onBack = { showMetrics = false })
     } else {
         MainScreen(
             settings = settings,
@@ -127,6 +130,7 @@ private fun Root() {
             onSelectModel = { modelIdx = it },
             onRefresh = { refreshKey++ },
             onOpenSettings = { showSettings = true },
+            onOpenMetrics = { showMetrics = true },
         )
     }
 }
@@ -140,6 +144,7 @@ private fun MainScreen(
     onSelectModel: (Int) -> Unit,
     onRefresh: () -> Unit,
     onOpenSettings: () -> Unit,
+    onOpenMetrics: () -> Unit,
 ) {
     val context = LocalContext.current
     val ui by RunBus.state.collectAsStateWithLifecycle()
@@ -187,6 +192,7 @@ private fun MainScreen(
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                         Text("BigMoeOnEdge", fontSize = 22.sp, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                        TextButton(onClick = onOpenMetrics) { Text("Metrics") }
                         TextButton(onClick = onOpenSettings) { Text("Settings") }
                     }
 
@@ -638,7 +644,10 @@ private fun launchPrompt(
     } else {
         // A new session starts with an empty KV and a cleared transcript, so its first turn
         // always clears regardless of [clearKv].
-        val argv = ArrayList(settings.sessionArgv(ModelManager.cliPath(context), model.absolutePath))
+        // One CSV per session: the engine holds it open across every turn, so it is opened here,
+        // where a session is opened, and nowhere else.
+        val csv = if (settings.metricsCsv) AppSettings.newMetricsCsvPath(context) else null
+        val argv = ArrayList(settings.sessionArgv(ModelManager.cliPath(context), model.absolutePath, csv))
         ContextCompat.startForegroundService(
             context,
             Intent(context, RunService::class.java)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -1,0 +1,52 @@
+package io.bigmoeonedge.example
+
+/**
+ * What each metrics-CSV column means, in one place. The engine writes the columns
+ * (core/src/metrics/csv_metrics_sink.cpp); this is the reader's side of that contract, so a column
+ * added there and not described here still plots — it just shows up unexplained, which is the right
+ * failure. Keep the names in exact sync with the header the engine writes.
+ */
+enum class Better { LOWER, HIGHER, NEUTRAL }
+
+data class MetricField(
+    val name: String,
+    val short: String,   // what it is, in a phrase
+    val measures: String, // what the number actually counts
+    val better: Better,   // and which direction is good — NEUTRAL when "it depends" is the honest answer
+)
+
+object MetricFields {
+    val all: List<MetricField> = listOf(
+        MetricField("turn", "which generation", "0-based turn in the session; one file spans them all", Better.NEUTRAL),
+        MetricField("step", "token index", "this token's number within the turn, from 1", Better.NEUTRAL),
+        MetricField("steps", "tokens requested", "the n_predict target for the turn", Better.NEUTRAL),
+
+        MetricField("wall_ms", "token time", "the whole time this token took — the one number measured directly; tok/s = 1000/wall_ms", Better.LOWER),
+        MetricField("compute_ms", "compute (a residual!)", "what is left after io/stall and mgmt are subtracted — NOT measured, so it also absorbs faults and scheduler stalls", Better.LOWER),
+        MetricField("io_ms", "flash read time", "time reading experts from flash. In serial it is part of wall_ms; under overlap it is per-lane busy time summed, so it can exceed wall_ms", Better.LOWER),
+        MetricField("stall_ms", "wait on flash", "overlap only: the wall time compute actually sat idle waiting for a read (already divided per thread)", Better.LOWER),
+        MetricField("mgmt_ms", "cache bookkeeping", "time spent committing, evicting and reordering the LRU cache this token", Better.LOWER),
+
+        MetricField("read_bytes", "flash read", "bytes of experts pulled from flash THIS token (not cumulative)", Better.LOWER),
+        MetricField("cache_hit_pct", "hit rate (cumulative!)", "share of expert lookups served from cache — averaged from the start of the session, so it moves slowly and is not a per-token value", Better.HIGHER),
+
+        MetricField("majflt", "hard faults", "pages the kernel reclaimed and the decode had to re-read from flash mid-compute this token", Better.LOWER),
+        MetricField("majflt_mib", "faulted MiB", "the same faults as memory: majflt x 4 KiB. Compare directly to read_bytes — reads we chose vs reads the kernel forced", Better.LOWER),
+        MetricField("cpu_ms", "CPU used", "CPU time across all threads. Compare to wall_ms x threads: near 100% is compute-bound, far below means throttled or stalled cores", Better.NEUTRAL),
+
+        MetricField("cache_budget_mib", "cache budget", "the expert-cache size this token ran under — the governor's trajectory. Bigger buys hits but risks the reclaim war, so neither direction is simply good", Better.NEUTRAL),
+        MetricField("resident_frac", "cache still in RAM", "fraction of our own cache pages the kernel still had (mincore). 1.0 = all ours, below 0.9 = it is taking it, -1 = not sampled this token", Better.HIGHER),
+
+        MetricField("rss_anon_mib", "anon resident = the cache", "resident anonymous memory — where the expert cache lives. Falling while cache_budget holds = the kernel taking it", Better.NEUTRAL),
+        MetricField("rss_file_mib", "file resident = the model", "resident file-backed memory: the mmap'd weights. Dropped (not swapped) under pressure, so it never shows in swap", Better.NEUTRAL),
+        MetricField("swap_mib", "our memory in zram", "anonymous memory already compressed into swap — cache we have effectively lost", Better.LOWER),
+        MetricField("rss_mib", "total resident", "everything resident (VmRSS)", Better.NEUTRAL),
+
+        MetricField("mem_available_mib", "device 'available' (it lies)", "what the kernel claims is free — it counts our own mmap'd weights as reclaimable, so it over-states headroom", Better.NEUTRAL),
+        MetricField("mem_free_mib", "device free", "truly free RAM, before any reclaim", Better.NEUTRAL),
+        MetricField("swap_free_mib", "swap free", "zram space left before the device is truly out of room", Better.NEUTRAL),
+    )
+
+    private val byName = all.associateBy { it.name }
+    fun of(name: String): MetricField? = byName[name]
+}

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -36,6 +36,7 @@ object MetricFields {
 
         MetricField("cache_budget_mib", "cache budget", "the expert-cache size this token ran under — the governor's trajectory. Bigger buys hits but risks the reclaim war, so neither direction is simply good", Better.NEUTRAL),
         MetricField("resident_frac", "cache still in RAM", "fraction of our own cache pages the kernel still had (mincore). 1.0 = all ours, below 0.9 = it is taking it, -1 = not sampled this token", Better.HIGHER),
+        MetricField("dense_resident_frac", "model weights still in RAM", "fraction of the DENSE mmap'd weights still resident (mincore). The half resident_frac misses: if this falls while resident_frac holds, the faults are the model, not the cache — so a smaller cache cannot help. -1 = not sampled", Better.HIGHER),
 
         MetricField("rss_anon_mib", "anon resident = the cache", "resident anonymous memory — where the expert cache lives. Falling while cache_budget holds = the kernel taking it", Better.NEUTRAL),
         MetricField("rss_file_mib", "file resident = the model", "resident file-backed memory: the mmap'd weights. Dropped (not swapped) under pressure, so it never shows in swap", Better.NEUTRAL),
@@ -45,10 +46,6 @@ object MetricFields {
         MetricField("mem_available_mib", "device 'available' (it lies)", "what the kernel claims is free — it counts our own mmap'd weights as reclaimable, so it over-states headroom", Better.NEUTRAL),
         MetricField("mem_free_mib", "device free", "truly free RAM, before any reclaim", Better.NEUTRAL),
         MetricField("swap_free_mib", "swap free", "zram space left before the device is truly out of room", Better.NEUTRAL),
-
-        MetricField("kswapd_scan_mib", "kswapd scanning (earliest warning)", "MiB the background reclaimer scanned this token (system-wide, so noisy). Rising = the machine started hunting for pages to reclaim, before any of ours was taken. -1 = /proc/vmstat denied by SELinux", Better.LOWER),
-        MetricField("direct_scan_mib", "direct reclaim (worse)", "MiB scanned in DIRECT reclaim — a thread that wanted memory had to stop and reclaim it itself. A stall, not a background sweep, and one of them may be ours. -1 = denied", Better.LOWER),
-        MetricField("ws_refault_mib", "thrash (system-wide)", "MiB of pages that were reclaimed and then needed again — the definition of thrash. Rising means it has already started somewhere in the system. -1 = denied", Better.LOWER),
     )
 
     private val byName = all.associateBy { it.name }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -45,6 +45,10 @@ object MetricFields {
         MetricField("mem_available_mib", "device 'available' (it lies)", "what the kernel claims is free — it counts our own mmap'd weights as reclaimable, so it over-states headroom", Better.NEUTRAL),
         MetricField("mem_free_mib", "device free", "truly free RAM, before any reclaim", Better.NEUTRAL),
         MetricField("swap_free_mib", "swap free", "zram space left before the device is truly out of room", Better.NEUTRAL),
+
+        MetricField("kswapd_scan_mib", "kswapd scanning (earliest warning)", "MiB the background reclaimer scanned this token (system-wide, so noisy). Rising = the machine started hunting for pages to reclaim, before any of ours was taken", Better.LOWER),
+        MetricField("direct_scan_mib", "direct reclaim (worse)", "MiB scanned in DIRECT reclaim — a thread that wanted memory had to stop and reclaim it itself. A stall, not a background sweep, and one of them may be ours", Better.LOWER),
+        MetricField("ws_refault_mib", "thrash (system-wide)", "MiB of pages that were reclaimed and then needed again — the definition of thrash. Rising means it has already started somewhere in the system", Better.LOWER),
     )
 
     private val byName = all.associateBy { it.name }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -46,9 +46,9 @@ object MetricFields {
         MetricField("mem_free_mib", "device free", "truly free RAM, before any reclaim", Better.NEUTRAL),
         MetricField("swap_free_mib", "swap free", "zram space left before the device is truly out of room", Better.NEUTRAL),
 
-        MetricField("kswapd_scan_mib", "kswapd scanning (earliest warning)", "MiB the background reclaimer scanned this token (system-wide, so noisy). Rising = the machine started hunting for pages to reclaim, before any of ours was taken", Better.LOWER),
-        MetricField("direct_scan_mib", "direct reclaim (worse)", "MiB scanned in DIRECT reclaim — a thread that wanted memory had to stop and reclaim it itself. A stall, not a background sweep, and one of them may be ours", Better.LOWER),
-        MetricField("ws_refault_mib", "thrash (system-wide)", "MiB of pages that were reclaimed and then needed again — the definition of thrash. Rising means it has already started somewhere in the system", Better.LOWER),
+        MetricField("kswapd_scan_mib", "kswapd scanning (earliest warning)", "MiB the background reclaimer scanned this token (system-wide, so noisy). Rising = the machine started hunting for pages to reclaim, before any of ours was taken. -1 = /proc/vmstat denied by SELinux", Better.LOWER),
+        MetricField("direct_scan_mib", "direct reclaim (worse)", "MiB scanned in DIRECT reclaim — a thread that wanted memory had to stop and reclaim it itself. A stall, not a background sweep, and one of them may be ours. -1 = denied", Better.LOWER),
+        MetricField("ws_refault_mib", "thrash (system-wide)", "MiB of pages that were reclaimed and then needed again — the definition of thrash. Rising means it has already started somewhere in the system. -1 = denied", Better.LOWER),
     )
 
     private val byName = all.associateBy { it.name }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -37,13 +37,17 @@ import kotlin.math.abs
  * feature off and a run with it on, on one axis. Everything here reads columns by NAME, so a CSV
  * from an older build (fewer columns) still plots whatever it does have.
  */
+// What the screen is showing. picked = view one file; correlating = overlay one file's own columns;
+// comparing = two files' same column; glossary = the field reference.
+private enum class View { LIST, FILE, CORRELATE, COMPARE, GLOSSARY }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MetricsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     var picked by remember { mutableStateOf<File?>(null) }
     var selection by remember { mutableStateOf<List<File>>(emptyList()) }
-    var comparing by remember { mutableStateOf(false) }
+    var view by remember { mutableStateOf(View.LIST) }
     var refresh by remember { mutableStateOf(0) }
     val files = remember(refresh) {
         File(context.getExternalFilesDir(null), "metrics")
@@ -52,42 +56,54 @@ fun MetricsScreen(onBack: () -> Unit) {
             ?: emptyList()
     }
 
+    // Back always steps one level toward the list, then out of the screen.
+    fun back() {
+        when (view) {
+            View.CORRELATE -> view = View.FILE
+            View.FILE, View.COMPARE, View.GLOSSARY -> view = View.LIST
+            View.LIST -> onBack()
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
                     Text(
-                        when {
-                            comparing -> "Compare"
-                            picked != null -> picked!!.name
-                            else -> "Metrics"
+                        when (view) {
+                            View.COMPARE -> "Compare files"
+                            View.CORRELATE -> "Correlate fields"
+                            View.GLOSSARY -> "What the columns mean"
+                            View.FILE -> picked?.name ?: "Metrics"
+                            View.LIST -> "Metrics"
                         },
                         maxLines = 1,
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = {
-                        when {
-                            comparing -> comparing = false
-                            picked != null -> picked = null
-                            else -> onBack()
-                        }
-                    }) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back") }
+                    IconButton(onClick = { back() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
                 },
                 actions = {
-                    picked?.let { f -> TextButton(onClick = { shareCsv(context, listOf(f)) }) { Text("Share") } }
+                    if (view == View.FILE) {
+                        TextButton(onClick = { view = View.CORRELATE }) { Text("Correlate") }
+                        picked?.let { f -> TextButton(onClick = { shareCsv(context, listOf(f)) }) { Text("Share") } }
+                    }
+                    if (view == View.LIST || view == View.FILE) {
+                        TextButton(onClick = { view = View.GLOSSARY }) { Text("?") }
+                    }
                 },
             )
         },
         bottomBar = {
-            // Only while picking: two files is what a comparison is.
-            if (!comparing && picked == null && selection.isNotEmpty()) {
+            if (view == View.LIST && selection.isNotEmpty()) {
                 BottomAppBar {
                     Spacer(Modifier.width(12.dp))
                     Text("${selection.size} selected", modifier = Modifier.weight(1f), fontSize = 13.sp)
                     TextButton(onClick = { shareCsv(context, selection) }) { Text("Share") }
                     TextButton(
-                        onClick = { comparing = true },
+                        onClick = { view = View.COMPARE },
                         enabled = selection.size == 2,
                     ) { Text("Compare") }
                     Spacer(Modifier.width(8.dp))
@@ -95,15 +111,17 @@ fun MetricsScreen(onBack: () -> Unit) {
             }
         },
     ) { padding ->
-        val file = picked
-        when {
-            comparing -> CompareView(selection[0], selection[1], Modifier.padding(padding))
-            file != null -> CsvView(file, Modifier.padding(padding))
-            else -> FileList(
+        val m = Modifier.padding(padding)
+        when (view) {
+            View.COMPARE -> CompareView(selection[0], selection[1], m)
+            View.CORRELATE -> picked?.let { CorrelateView(it, m) }
+            View.GLOSSARY -> GlossaryView(m)
+            View.FILE -> picked?.let { CsvView(it, m) }
+            View.LIST -> FileList(
                 files = files,
                 selection = selection,
-                modifier = Modifier.padding(padding),
-                onPick = { picked = it },
+                modifier = m,
+                onPick = { picked = it; view = View.FILE },
                 onToggle = { f ->
                     selection = when {
                         selection.contains(f) -> selection - f
@@ -326,6 +344,7 @@ private fun CompareView(fa: File, fb: File, modifier: Modifier) {
                 }
             }
         }
+        FieldNote(metric)
 
         val sa = a.column(metric).orEmpty()
         val sb = b.column(metric).orEmpty()
@@ -440,5 +459,207 @@ private fun LineChart(a: List<Float?>, b: List<Float?>, colorA: Color, colorB: C
     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         Text(fmt(lo), fontSize = 10.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(fmt(hi), fontSize = 10.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+// ── the field reference ─────────────────────────────────────────────────────────────────────────
+
+/** "lower is better" / "higher is better" / "depends", coloured, in three characters plus a word. */
+@Composable
+private fun BetterBadge(better: Better) {
+    val (text, color) = when (better) {
+        Better.LOWER -> "↓ lower better" to MaterialTheme.colorScheme.primary
+        Better.HIGHER -> "↑ higher better" to MaterialTheme.colorScheme.primary
+        Better.NEUTRAL -> "– depends" to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Text(text, fontSize = 11.sp, fontWeight = FontWeight.Medium, color = color)
+}
+
+/** The one-line meaning of the currently plotted column, under a chart or a picker. */
+@Composable
+private fun FieldNote(name: String) {
+    val f = MetricFields.of(name) ?: return
+    Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(f.short, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+            BetterBadge(f.better)
+        }
+        Text(f.measures, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun GlossaryView(modifier: Modifier) {
+    LazyColumn(modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        item {
+            Text(
+                "Every column the metrics CSV can hold. \"depends\" means neither direction is simply " +
+                    "good — a bigger cache buys hits but risks the reclaim war, and mem_available lies.",
+                fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 10.dp),
+            )
+        }
+        items(MetricFields.all) { f ->
+            Column(Modifier.padding(vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(f.name, fontFamily = FontFamily.Monospace, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                    BetterBadge(f.better)
+                }
+                Text(f.short, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+                Text(f.measures, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+// ── correlate: one file's own columns, normalized, on one axis ──────────────────────────────────
+
+/**
+ * Overlays several of a file's columns after squashing each to 0..1, so their SHAPES can be
+ * compared even though their units cannot. The question it answers is "when this rises, does that
+ * rise too" — e.g. does rss_anon fall exactly as majflt spikes, which says the faults are the cache
+ * being taken and not the model. A Pearson r against the first-picked column puts a number on it.
+ *
+ * Normalization is per-column min..max: it discards magnitude on purpose. A flat line means the
+ * column did not vary, not that it was zero — the legend keeps the real min/max so nothing is lost.
+ */
+@Composable
+private fun CorrelateView(file: File, modifier: Modifier) {
+    val csv = remember(file) { Csv.read(file) }
+    val cols = remember(csv) { csv.plottable() }
+    // Start with the pair this was built to look at, if the file has them.
+    var chosen by remember(cols) {
+        mutableStateOf(cols.filter { it in setOf("majflt_mib", "rss_anon_mib", "cache_budget_mib") }.ifEmpty { cols.take(2) })
+    }
+    var expanded by remember { mutableStateOf(false) }
+
+    val palette = listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.error,
+        MaterialTheme.colorScheme.tertiary,
+        MaterialTheme.colorScheme.secondary,
+        MaterialTheme.colorScheme.inversePrimary,
+    )
+
+    Column(modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        if (cols.isEmpty()) {
+            Text("This file has no numeric columns to correlate.", fontSize = 13.sp)
+            return@Column
+        }
+        if (csv.info.isNotEmpty()) Text(csv.label(), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+
+        Box {
+            OutlinedButton(onClick = { expanded = true }) { Text("Fields (${chosen.size})") }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                cols.forEach { c ->
+                    DropdownMenuItem(
+                        text = {
+                            Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                                Checkbox(checked = c in chosen, onCheckedChange = null)
+                                Spacer(Modifier.width(6.dp))
+                                Text(c, fontFamily = FontFamily.Monospace, fontSize = 13.sp)
+                            }
+                        },
+                        // Cap at the palette size: more lines than colours is not a chart, it is a knot.
+                        onClick = {
+                            chosen = if (c in chosen) chosen - c
+                            else if (chosen.size < palette.size) chosen + c else chosen
+                        },
+                    )
+                }
+            }
+        }
+
+        val series = chosen.map { it to (csv.column(it) ?: emptyList()) }
+        MultiLineChart(series.map { it.second }, palette, Modifier.fillMaxWidth().height(240.dp))
+
+        // Pearson r of every series against the first-picked one — the pivot. |r|→1 is tight
+        // correlation, sign says direction, ~0 says the two move independently.
+        val pivot = series.firstOrNull()
+        chosen.forEachIndexed { i, name ->
+            val col = MetricFields.of(name)
+            val vals = series[i].second.filterNotNull()
+            val r = if (pivot != null && i > 0) pearson(pivot.second, series[i].second) else null
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Canvas(Modifier.size(12.dp).padding(top = 3.dp)) { drawRect(palette[i % palette.size]) }
+                Column {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(name, fontFamily = FontFamily.Monospace, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                        if (i == 0) Text("pivot", fontSize = 11.sp, color = MaterialTheme.colorScheme.primary)
+                        else if (r != null) Text("r=${fmt(r)} ${corrWord(r)}", fontSize = 11.sp, fontWeight = FontWeight.Medium)
+                    }
+                    if (col != null) Text(col.short, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (vals.isNotEmpty()) Text(
+                        "min=${fmt(vals.min())}  max=${fmt(vals.max())}",
+                        fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+        Text(
+            "Each line is squashed to its own 0..1, so only the SHAPES compare — the legend keeps the " +
+                "real range. r is vs the first field (the pivot): near ±1 they move together, near 0 they do not.",
+            fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** How to say a correlation out loud, so the number is not the only cue. */
+private fun corrWord(r: Float): String = when {
+    abs(r) >= 0.8f -> if (r > 0) "moves together" else "moves opposite"
+    abs(r) >= 0.4f -> if (r > 0) "loosely together" else "loosely opposite"
+    else -> "unrelated"
+}
+
+/** Pearson correlation over the positions where BOTH series have a value; null if too few. */
+private fun pearson(a: List<Float?>, b: List<Float?>): Float? {
+    val pairs = a.zip(b).mapNotNull { (x, y) -> if (x != null && y != null) x to y else null }
+    if (pairs.size < 3) return null
+    val n = pairs.size
+    val mx = pairs.sumOf { it.first.toDouble() } / n
+    val my = pairs.sumOf { it.second.toDouble() } / n
+    var sxy = 0.0; var sxx = 0.0; var syy = 0.0
+    for ((x, y) in pairs) {
+        val dx = x - mx; val dy = y - my
+        sxy += dx * dy; sxx += dx * dx; syy += dy * dy
+    }
+    if (sxx <= 0.0 || syy <= 0.0) return null // a flat series correlates with nothing
+    return (sxy / kotlin.math.sqrt(sxx * syy)).toFloat()
+}
+
+/**
+ * N series on one axis, each independently normalized to 0..1. Unlike the two-file compare (one
+ * shared scale, because there the magnitudes ARE the comparison), here the magnitudes are unlike by
+ * construction — cache_budget in GiB against resident_frac in [0,1] — so each gets its own scale and
+ * only the shapes are claimed to line up.
+ */
+@Composable
+private fun MultiLineChart(series: List<List<Float?>>, palette: List<Color>, modifier: Modifier) {
+    val grid = MaterialTheme.colorScheme.outlineVariant
+    if (series.all { it.filterNotNull().isEmpty() }) {
+        Box(modifier) { Text("pick at least one field", fontSize = 12.sp) }
+        return
+    }
+    val n = maxOf(series.maxOfOrNull { it.size } ?: 2, 2)
+    // Per-series min/max, computed once: normalization is min..max within each column.
+    val ranges = series.map { s -> s.filterNotNull().let { v -> (v.minOrNull() ?: 0f) to (v.maxOrNull() ?: 1f) } }
+
+    Canvas(modifier) {
+        val w = size.width; val h = size.height
+        listOf(0f, 0.5f, 1f).forEach { t -> drawLine(grid, Offset(0f, h * t), Offset(w, h * t), strokeWidth = 1f) }
+        series.forEachIndexed { si, s ->
+            val (lo, hi) = ranges[si]
+            val span = (hi - lo).takeIf { it > 1e-6f } ?: 1f
+            val path = Path()
+            var started = false
+            s.forEachIndexed { i, v ->
+                if (v == null) return@forEachIndexed
+                val px = w * i / (n - 1).toFloat()
+                val py = h - (v - lo) / span * h
+                if (started) path.lineTo(px, py) else { path.moveTo(px, py); started = true }
+            }
+            if (started) drawPath(path, palette[si % palette.size], style = androidx.compose.ui.graphics.drawscope.Stroke(width = 3f))
+        }
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -327,12 +328,17 @@ private fun CompareView(fa: File, fb: File, modifier: Modifier) {
     val colorA = MaterialTheme.colorScheme.primary
     val colorB = MaterialTheme.colorScheme.error
 
-    Column(modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        if (metrics.isEmpty()) {
-            Text("These two files share no numeric column.", fontSize = 13.sp)
-            return@Column
-        }
+    if (metrics.isEmpty()) {
+        Box(modifier.fillMaxSize().padding(12.dp)) { Text("These two files share no numeric column.", fontSize = 13.sp) }
+        return
+    }
 
+    // The content is taller than the screen (chart + legends + two full configs), so it scrolls.
+    val changed = remember(a, b) { (a.info.keys + b.info.keys).filter { a.info[it] != b.info[it] }.toSet() }
+    Column(
+        modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
         Box {
             OutlinedButton(onClick = { expanded = true }) { Text(metric.ifEmpty { "pick a column" }) }
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
@@ -352,12 +358,16 @@ private fun CompareView(fa: File, fb: File, modifier: Modifier) {
 
         Legend(fa.name, a.label(), colorA, sa)
         Legend(fb.name, b.label(), colorB, sb)
-        Diff(a, b)
         Text(
             "x = token index within the file (turns run end to end). Both series share one y scale, " +
                 "which is the only way the comparison means anything.",
             fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        // The full configuration of each run, changed settings highlighted — not just the diff, so a
+        // setting that stayed the same (was warm-dense on in both?) is still there to read.
+        Text("Configuration", fontSize = 13.sp, fontWeight = FontWeight.Bold)
+        FullConfig(a, colorA, changed)
+        FullConfig(b, colorB, changed)
     }
 }
 
@@ -381,28 +391,72 @@ private fun Legend(name: String, label: String, color: Color, series: List<Float
     }
 }
 
+// The run preamble, every field, in the settings screen's order. Kept in full — not just what
+// differs — because a setting that did NOT change between two runs is still worth seeing: "was warm
+// dense on in both?" is a real question, and a diff that hides it cannot answer it.
+private val CONFIG_ORDER = listOf(
+    "model" to "Model",
+    "arch" to "Architecture",
+    "n_layer" to "Layers",
+    "n_expert" to "Experts",
+    "n_expert_used" to "Active experts (top-k)",
+    "n_ctx" to "Context",
+    "threads" to "Compute threads",
+    "moe_stream" to "MoE streaming",
+    "cache_mb" to "Cache budget (MiB)",
+    "cache_auto" to "Cache auto-size",
+    "cache_ceil_mb" to "Cache ceiling (MiB)",
+    "cache_dynamic" to "Pressure-aware sizing",
+    "force_cache" to "Force cache",
+    "io_threads" to "I/O lanes",
+    "o_direct" to "Direct I/O",
+    "overlap" to "I/O–compute overlap",
+    "prefetch" to "Temporal prefetch",
+    "warm_dense" to "Dense weight warm-up",
+)
+private val CONFIG_BOOLS = setOf("moe_stream", "cache_auto", "cache_dynamic", "force_cache", "o_direct", "overlap", "warm_dense")
+
+private fun prettyConfigValue(key: String, v: String): String = when {
+    key in CONFIG_BOOLS -> if (v == "1") "on" else "off"
+    key == "prefetch" && v == "0" -> "off"
+    else -> v
+}
+
 /**
- * What actually differs between the two runs' configurations. With two long labels on screen the
- * eye will not find it, and the one setting that changed is the only reason to read the chart.
+ * The complete run configuration of one file — every field from the preamble, present or absent.
+ * `changed` marks the settings that differ from the other file, so "what changed" is still obvious
+ * without hiding "what did not".
  */
 @Composable
-private fun Diff(a: Csv, b: Csv) {
-    if (a.info.isEmpty() || b.info.isEmpty()) {
-        Text(
-            "One of these files has no run header — it predates it, so what it was configured with " +
-                "is unknown and the comparison is a guess.",
-            fontSize = 11.sp, color = MaterialTheme.colorScheme.error,
-        )
+private fun FullConfig(csv: Csv, accent: Color, changed: Set<String>) {
+    if (csv.info.isEmpty()) {
+        Text("No run header in this file — its configuration is unknown.",
+             fontSize = 11.sp, color = MaterialTheme.colorScheme.error)
         return
     }
-    val keys = (a.info.keys + b.info.keys).filter { a.info[it] != b.info[it] }.sorted()
     Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
-        Text(
-            if (keys.isEmpty()) "Same configuration in both — whatever differs, the settings do not."
-            else "differs: " + keys.joinToString("   ") { "$it ${a.info[it] ?: "-"}→${b.info[it] ?: "-"}" },
-            fontFamily = FontFamily.Monospace, fontSize = 11.sp,
-            modifier = Modifier.padding(8.dp),
-        )
+        Column(Modifier.padding(10.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                Canvas(Modifier.size(12.dp)) { drawRect(accent) }
+                Text(csv.info["model"] ?: "run", fontSize = 12.sp, fontWeight = FontWeight.Bold, maxLines = 1)
+            }
+            CONFIG_ORDER.forEach { (key, label) ->
+                val v = csv.info[key] ?: return@forEach // a field an older engine did not write
+                val isChanged = key in changed
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("$label:", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                         modifier = Modifier.weight(1f))
+                    Text(
+                        prettyConfigValue(key, v),
+                        fontSize = 11.sp,
+                        fontFamily = FontFamily.Monospace,
+                        // A changed setting is the reason to be here; make it the thing the eye lands on.
+                        fontWeight = if (isChanged) FontWeight.Bold else FontWeight.Normal,
+                        color = if (isChanged) accent else MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -542,11 +596,14 @@ private fun CorrelateView(file: File, modifier: Modifier) {
         MaterialTheme.colorScheme.inversePrimary,
     )
 
-    Column(modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        if (cols.isEmpty()) {
-            Text("This file has no numeric columns to correlate.", fontSize = 13.sp)
-            return@Column
-        }
+    if (cols.isEmpty()) {
+        Box(modifier.fillMaxSize().padding(12.dp)) { Text("This file has no numeric columns to correlate.", fontSize = 13.sp) }
+        return
+    }
+    Column(
+        modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
         if (csv.info.isNotEmpty()) Text(csv.label(), fontSize = 12.sp, fontWeight = FontWeight.Medium)
 
         Box {
@@ -602,6 +659,10 @@ private fun CorrelateView(file: File, modifier: Modifier) {
                 "real range. r is vs the first field (the pivot): near ±1 they move together, near 0 they do not.",
             fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        // The run this file came from, in full — the correlations mean nothing without knowing the
+        // configuration that produced them.
+        Text("Configuration", fontSize = 13.sp, fontWeight = FontWeight.Bold)
+        FullConfig(csv, MaterialTheme.colorScheme.primary, emptySet())
     }
 }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -170,15 +170,28 @@ private fun FileList(
         return
     }
     val stamp = SimpleDateFormat("d MMM HH:mm:ss", Locale.getDefault())
+    // A run's identity, not its filename: the model's initial and each turn's tok/s, read from the
+    // preamble and summaries. Computed once per file list — the files are small and few.
+    val titles = remember(files) { files.associateWith { runTitle(it) } }
     LazyColumn(modifier.fillMaxSize()) {
         items(files) { f ->
+            val title = titles[f].orEmpty()
             ListItem(
                 leadingContent = {
                     Checkbox(checked = selection.contains(f), onCheckedChange = { onToggle(f) })
                 },
-                headlineContent = { Text(f.name, fontFamily = FontFamily.Monospace, fontSize = 13.sp) },
+                headlineContent = {
+                    Text(title.ifEmpty { f.name }, fontWeight = FontWeight.Medium, fontSize = 15.sp)
+                },
                 supportingContent = {
-                    Text("${stamp.format(Date(f.lastModified()))} · ${f.length() / 1024} KiB", fontSize = 12.sp)
+                    // Timestamp + size, then the bare filename (the ID is now the headline). The
+                    // filename drops its fixed "bmoe-" prefix and ".csv" tail — it is only there to
+                    // match a shared file, and the stamp already carries the date.
+                    val short = f.name.removePrefix("bmoe-").removeSuffix(".csv")
+                    Text(
+                        "${stamp.format(Date(f.lastModified()))} · ${f.length() / 1024} KiB · $short",
+                        fontSize = 11.sp, maxLines = 1,
+                    )
                 },
                 trailingContent = { TextButton(onClick = { onDelete(f) }) { Text("Delete") } },
                 modifier = Modifier.clickable(onClick = { onPick(f) }),
@@ -186,6 +199,23 @@ private fun FileList(
             HorizontalDivider()
         }
     }
+}
+
+/**
+ * A short human name for a run: the model's initial and each turn's tok/s, e.g. "Q · 1.45→0.75 t/s"
+ * for a two-turn Qwen session. Reads only the file's `#` lines. Empty when the file has no header
+ * (a pre-preamble CSV), so the caller falls back to the filename.
+ */
+private fun runTitle(file: File): String {
+    val lines = runCatching { file.readLines() }.getOrElse { return "" }
+    val model = lines.firstOrNull { it.startsWith("# model=") }
+        ?.substringAfter("model=", "")?.substringBefore(" ").orEmpty()
+    if (model.isEmpty()) return ""
+    val initial = model.first().uppercaseChar()
+    val tps = lines.filter { it.startsWith("# summary") }
+        .mapNotNull { Regex("""tok/s=([0-9.]+)""").find(it)?.groupValues?.get(1)?.toFloatOrNull() }
+    val tpsStr = if (tps.isEmpty()) "" else tps.joinToString("→") { fmt(it) } + " t/s"
+    return listOf(initial.toString(), tpsStr).filter { it.isNotEmpty() }.joinToString(" · ")
 }
 
 // ── the CSV, parsed once ────────────────────────────────────────────────────────────────────────

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -1,41 +1,51 @@
 package io.bigmoeonedge.example
 
+import android.content.Intent
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlin.math.abs
 
 /**
- * Reads back the per-token CSV the engine wrote for a session (`--csv`, see [AppSettings]).
+ * Reads back the per-token CSVs the engine wrote (`--csv`, see [AppSettings]): view one, share one,
+ * or plot one column of two against each other.
  *
- * Deliberately a viewer, not a dashboard: it shows the file as it is, because the point of the file
- * is to be the evidence. A summary that averaged these rows would hide exactly the thing worth
- * seeing — a run's shape is in the individual token where the budget moved and the faults spiked,
- * not in its mean.
+ * The compare view is the point. A claim like "the cache budget now falls under pressure" is not
+ * settled by a number in a summary — it is settled by seeing the same column from a run with the
+ * feature off and a run with it on, on one axis. Everything here reads columns by NAME, so a CSV
+ * from an older build (fewer columns) still plots whatever it does have.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MetricsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     var picked by remember { mutableStateOf<File?>(null) }
-    val files = remember {
+    var selection by remember { mutableStateOf<List<File>>(emptyList()) }
+    var comparing by remember { mutableStateOf(false) }
+    var refresh by remember { mutableStateOf(0) }
+    val files = remember(refresh) {
         File(context.getExternalFilesDir(null), "metrics")
             .listFiles { f -> f.name.endsWith(".csv") }
             ?.sortedByDescending { it.lastModified() }
@@ -45,32 +55,96 @@ fun MetricsScreen(onBack: () -> Unit) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(picked?.name ?: "Metrics") },
+                title = {
+                    Text(
+                        when {
+                            comparing -> "Compare"
+                            picked != null -> picked!!.name
+                            else -> "Metrics"
+                        },
+                        maxLines = 1,
+                    )
+                },
                 navigationIcon = {
-                    IconButton(onClick = { if (picked != null) picked = null else onBack() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
+                    IconButton(onClick = {
+                        when {
+                            comparing -> comparing = false
+                            picked != null -> picked = null
+                            else -> onBack()
+                        }
+                    }) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back") }
+                },
+                actions = {
+                    picked?.let { f -> TextButton(onClick = { shareCsv(context, listOf(f)) }) { Text("Share") } }
                 },
             )
         },
+        bottomBar = {
+            // Only while picking: two files is what a comparison is.
+            if (!comparing && picked == null && selection.isNotEmpty()) {
+                BottomAppBar {
+                    Spacer(Modifier.width(12.dp))
+                    Text("${selection.size} selected", modifier = Modifier.weight(1f), fontSize = 13.sp)
+                    TextButton(onClick = { shareCsv(context, selection) }) { Text("Share") }
+                    TextButton(
+                        onClick = { comparing = true },
+                        enabled = selection.size == 2,
+                    ) { Text("Compare") }
+                    Spacer(Modifier.width(8.dp))
+                }
+            }
+        },
     ) { padding ->
         val file = picked
-        if (file == null) {
-            FileList(files, Modifier.padding(padding)) { picked = it }
-        } else {
-            CsvView(file, Modifier.padding(padding))
+        when {
+            comparing -> CompareView(selection[0], selection[1], Modifier.padding(padding))
+            file != null -> CsvView(file, Modifier.padding(padding))
+            else -> FileList(
+                files = files,
+                selection = selection,
+                modifier = Modifier.padding(padding),
+                onPick = { picked = it },
+                onToggle = { f ->
+                    selection = when {
+                        selection.contains(f) -> selection - f
+                        selection.size < 2 -> selection + f
+                        else -> listOf(selection[1], f) // a third pick replaces the oldest
+                    }
+                },
+                onDelete = { f -> f.delete(); selection = selection - f; refresh++ },
+            )
         }
     }
 }
 
+/** Hand the files to another app as content:// URIs (see the FileProvider in the manifest). */
+private fun shareCsv(context: android.content.Context, files: List<File>) {
+    val uris = ArrayList(files.map {
+        FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", it)
+    })
+    val intent = Intent(if (uris.size == 1) Intent.ACTION_SEND else Intent.ACTION_SEND_MULTIPLE).apply {
+        type = "text/csv"
+        if (uris.size == 1) putExtra(Intent.EXTRA_STREAM, uris[0]) else putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    runCatching { context.startActivity(Intent.createChooser(intent, "Share metrics").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }
+}
+
 @Composable
-private fun FileList(files: List<File>, modifier: Modifier, onPick: (File) -> Unit) {
+private fun FileList(
+    files: List<File>,
+    selection: List<File>,
+    modifier: Modifier,
+    onPick: (File) -> Unit,
+    onToggle: (File) -> Unit,
+    onDelete: (File) -> Unit,
+) {
     if (files.isEmpty()) {
         Column(modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("No metrics yet.", fontWeight = FontWeight.Medium)
             Text(
                 "Turn on Settings → Diagnostics → Metrics CSV, then run a prompt. One file is written " +
-                    "per session, covering every turn in it.",
+                    "per session, covering every turn in it. Tick two to compare them.",
                 fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
@@ -80,13 +154,14 @@ private fun FileList(files: List<File>, modifier: Modifier, onPick: (File) -> Un
     LazyColumn(modifier.fillMaxSize()) {
         items(files) { f ->
             ListItem(
+                leadingContent = {
+                    Checkbox(checked = selection.contains(f), onCheckedChange = { onToggle(f) })
+                },
                 headlineContent = { Text(f.name, fontFamily = FontFamily.Monospace, fontSize = 13.sp) },
                 supportingContent = {
-                    Text(
-                        "${stamp.format(Date(f.lastModified()))} · ${f.length() / 1024} KiB",
-                        fontSize = 12.sp,
-                    )
+                    Text("${stamp.format(Date(f.lastModified()))} · ${f.length() / 1024} KiB", fontSize = 12.sp)
                 },
+                trailingContent = { TextButton(onClick = { onDelete(f) }) { Text("Delete") } },
                 modifier = Modifier.clickable(onClick = { onPick(f) }),
             )
             HorizontalDivider()
@@ -94,20 +169,38 @@ private fun FileList(files: List<File>, modifier: Modifier, onPick: (File) -> Un
     }
 }
 
+// ── the CSV, parsed once ────────────────────────────────────────────────────────────────────────
+
+/** A parsed CSV: columns by name, plus the engine's per-turn `# summary` trailers. */
+private class Csv(val header: List<String>, val rows: List<List<String>>, val summaries: List<String>) {
+    /** This column's values, or null where the column is absent or the cell is not a number. */
+    fun column(name: String): List<Float?>? {
+        val i = header.indexOf(name).takeIf { it >= 0 } ?: return null
+        return rows.map { it.getOrNull(i)?.toFloatOrNull() }
+    }
+
+    /** Columns worth plotting: numeric, and not an axis or a label. */
+    fun plottable(): List<String> =
+        header.filter { it !in setOf("step", "steps", "turn") && column(it)?.any { v -> v != null } == true }
+
+    companion object {
+        fun read(f: File): Csv {
+            val lines = runCatching { f.readLines() }.getOrElse { emptyList() }
+            val header = lines.firstOrNull { !it.startsWith("#") }?.split(",") ?: emptyList()
+            val rows = lines.drop(1).filter { it.isNotBlank() && !it.startsWith("#") }.map { it.split(",") }
+            return Csv(header, rows, lines.filter { it.startsWith("# summary") })
+        }
+    }
+}
+
 @Composable
 private fun CsvView(file: File, modifier: Modifier) {
-    // Read once per open. These files are one row per token — thousands at worst, tens of KiB — so
-    // the whole thing fits in memory and there is nothing to gain from streaming it.
-    val lines = remember(file) { runCatching { file.readLines() }.getOrElse { listOf("cannot read: ${it.message}") } }
-    val header = lines.firstOrNull()?.split(",") ?: emptyList()
-    val rows = lines.drop(1).filter { it.isNotBlank() && !it.startsWith("#") }.map { it.split(",") }
-    // The engine writes one `# summary key=value ...` trailer per turn: the run-level facts
-    // (tok/s, token_demand_MiB, cache_cuts) that no single row carries.
-    val summaries = lines.filter { it.startsWith("# summary") }
-
+    // One row per token — thousands at worst, ~112 bytes each — so the whole file fits in memory
+    // and there is nothing to gain from streaming it.
+    val csv = remember(file) { Csv.read(file) }
     val hscroll = rememberScrollState()
     Column(modifier.fillMaxSize()) {
-        summaries.forEach { s ->
+        csv.summaries.forEach { s ->
             Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
                 Text(
                     s.removePrefix("# summary ").replace(" ", "   "),
@@ -118,28 +211,21 @@ private fun CsvView(file: File, modifier: Modifier) {
             Spacer(Modifier.height(4.dp))
         }
         Text(
-            "${rows.size} tokens · ${header.size} columns · scroll sideways for all of them",
+            "${csv.rows.size} tokens · ${csv.header.size} columns · scroll sideways for all of them",
             fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
         )
         // One horizontal scroll shared by the header and every row, so the columns stay aligned.
         Column(Modifier.horizontalScroll(hscroll)) {
-            Row(Modifier.padding(horizontal = 8.dp)) {
-                header.forEach { h -> Cell(h, bold = true) }
-            }
+            Row(Modifier.padding(horizontal = 8.dp)) { csv.header.forEach { h -> Cell(h, bold = true) } }
             HorizontalDivider()
             LazyColumn(Modifier.fillMaxWidth()) {
-                items(rows) { r ->
-                    Row(Modifier.padding(horizontal = 8.dp)) {
-                        r.forEach { v -> Cell(v) }
-                    }
-                }
+                items(csv.rows) { r -> Row(Modifier.padding(horizontal = 8.dp)) { r.forEach { v -> Cell(v) } } }
             }
         }
     }
 }
 
-// Fixed-width cells: a table of numbers that does not line up is a table you have to read twice.
 @Composable
 private fun Cell(text: String, bold: Boolean = false) {
     Text(
@@ -150,4 +236,125 @@ private fun Cell(text: String, bold: Boolean = false) {
         maxLines = 1,
         modifier = Modifier.width(88.dp).padding(vertical = 3.dp, horizontal = 2.dp),
     )
+}
+
+// ── compare ─────────────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun CompareView(fa: File, fb: File, modifier: Modifier) {
+    val a = remember(fa) { Csv.read(fa) }
+    val b = remember(fb) { Csv.read(fb) }
+    // Only columns both files actually have: plotting a series against a blank is not a comparison.
+    val metrics = remember(a, b) { a.plottable().filter { it in b.plottable() } }
+    // Default to the column this whole feature was built to look at, if it is there.
+    var metric by remember(metrics) {
+        mutableStateOf(metrics.firstOrNull { it == "cache_budget_mib" } ?: metrics.firstOrNull() ?: "")
+    }
+    var expanded by remember { mutableStateOf(false) }
+
+    val colorA = MaterialTheme.colorScheme.primary
+    val colorB = MaterialTheme.colorScheme.error
+
+    Column(modifier.fillMaxSize().padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        if (metrics.isEmpty()) {
+            Text("These two files share no numeric column.", fontSize = 13.sp)
+            return@Column
+        }
+
+        Box {
+            OutlinedButton(onClick = { expanded = true }) { Text(metric.ifEmpty { "pick a column" }) }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                metrics.forEach { m ->
+                    DropdownMenuItem(
+                        text = { Text(m, fontFamily = FontFamily.Monospace, fontSize = 13.sp) },
+                        onClick = { metric = m; expanded = false },
+                    )
+                }
+            }
+        }
+
+        val sa = a.column(metric).orEmpty()
+        val sb = b.column(metric).orEmpty()
+        LineChart(sa, sb, colorA, colorB, Modifier.fillMaxWidth().height(260.dp))
+
+        Legend(fa.name, colorA, sa)
+        Legend(fb.name, colorB, sb)
+        Text(
+            "x = token index within the file (turns run end to end). Both series share one y scale, " +
+                "which is the only way the comparison means anything.",
+            fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun Legend(name: String, color: Color, series: List<Float?>) {
+    val vals = series.filterNotNull()
+    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Canvas(Modifier.size(14.dp)) { drawRect(color) }
+        Column {
+            Text(name, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 1)
+            Text(
+                if (vals.isEmpty()) "no data" else
+                    "n=${vals.size}  min=${fmt(vals.min())}  mean=${fmt(vals.average().toFloat())}  max=${fmt(vals.max())}",
+                fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun fmt(v: Float): String = when {
+    abs(v) >= 1000f -> String.format(Locale.US, "%.0f", v)
+    abs(v) >= 10f -> String.format(Locale.US, "%.1f", v)
+    else -> String.format(Locale.US, "%.2f", v)
+}
+
+/**
+ * Two series on one pair of axes, drawn by hand rather than by pulling in a charting library for a
+ * single plot. Both share one y range: two auto-scaled axes would make any two runs look alike,
+ * which is the opposite of the job.
+ */
+@Composable
+private fun LineChart(a: List<Float?>, b: List<Float?>, colorA: Color, colorB: Color, modifier: Modifier) {
+    val grid = MaterialTheme.colorScheme.outlineVariant
+    val all = (a + b).filterNotNull()
+    if (all.isEmpty()) {
+        Box(modifier) { Text("nothing to plot", fontSize = 12.sp) }
+        return
+    }
+    var lo = all.min()
+    var hi = all.max()
+    if (hi - lo < 1e-6f) { hi += 1f; lo -= 1f } // a flat series is a fact, not a divide-by-zero
+    val n = maxOf(a.size, b.size, 2)
+
+    Canvas(modifier) {
+        val w = size.width
+        val h = size.height
+        fun x(i: Int) = w * i / (n - 1).toFloat()
+        fun y(v: Float) = h - (v - lo) / (hi - lo) * h
+
+        // Three gridlines: enough to read a level off, few enough not to be a cage.
+        listOf(0f, 0.5f, 1f).forEach { t ->
+            val yy = h * t
+            drawLine(grid, Offset(0f, yy), Offset(w, yy), strokeWidth = 1f)
+        }
+
+        fun draw(series: List<Float?>, color: Color) {
+            val path = Path()
+            var started = false
+            series.forEachIndexed { i, v ->
+                if (v == null) return@forEachIndexed // a gap is a gap: do not bridge it with a lie
+                val px = x(i)
+                val py = y(v)
+                if (started) path.lineTo(px, py) else { path.moveTo(px, py); started = true }
+            }
+            if (started) drawPath(path, color, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 3f))
+        }
+        draw(a, colorA)
+        draw(b, colorB)
+    }
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(fmt(lo), fontSize = 10.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(fmt(hi), fontSize = 10.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -171,8 +171,33 @@ private fun FileList(
 
 // ── the CSV, parsed once ────────────────────────────────────────────────────────────────────────
 
-/** A parsed CSV: columns by name, plus the engine's per-turn `# summary` trailers. */
-private class Csv(val header: List<String>, val rows: List<List<String>>, val summaries: List<String>) {
+/**
+ * A parsed CSV: columns by name, the engine's `# bmoe_metrics` preamble (what the run WAS), and its
+ * per-turn `# summary` trailers (what each turn DID).
+ */
+private class Csv(
+    val header: List<String>,
+    val rows: List<List<String>>,
+    val summaries: List<String>,
+    val info: Map<String, String>,
+) {
+    /** The run's identity, short enough to sit under a chart line. Empty for a pre-preamble CSV. */
+    fun label(): String {
+        if (info.isEmpty()) return ""
+        val cache = when {
+            info["cache_dynamic"] == "1" -> "cache ${info["cache_mb"]}→dynamic"
+            info["cache_auto"] == "1" -> "cache auto(${info["cache_mb"]})"
+            else -> "cache ${info["cache_mb"]}"
+        }
+        return listOfNotNull(
+            info["model"],
+            info["n_expert_used"]?.let { "top-$it" },
+            if (info["moe_stream"] == "1") cache else "mmap baseline",
+            info["io_threads"]?.let { "$it lanes" },
+            if (info["overlap"] == "1") "overlap" else null,
+            info["prefetch"]?.takeIf { it != "0" }?.let { "prefetch $it" },
+        ).joinToString(" · ")
+    }
     /** This column's values, or null where the column is absent or the cell is not a number. */
     fun column(name: String): List<Float?>? {
         val i = header.indexOf(name).takeIf { it >= 0 } ?: return null
@@ -187,8 +212,14 @@ private class Csv(val header: List<String>, val rows: List<List<String>>, val su
         fun read(f: File): Csv {
             val lines = runCatching { f.readLines() }.getOrElse { emptyList() }
             val header = lines.firstOrNull { !it.startsWith("#") }?.split(",") ?: emptyList()
-            val rows = lines.drop(1).filter { it.isNotBlank() && !it.startsWith("#") }.map { it.split(",") }
-            return Csv(header, rows, lines.filter { it.startsWith("# summary") })
+            val rows = lines.filter { it.isNotBlank() && !it.startsWith("#") }.drop(1).map { it.split(",") }
+            // The preamble's key=value pairs, order-independent, unknown keys kept: same contract
+            // as the `# summary` trailer, so an older or newer engine still parses.
+            val info = lines.filter { it.startsWith("# ") && !it.startsWith("# summary") }
+                .flatMap { it.removePrefix("# ").trim().split(" ") }
+                .mapNotNull { tok -> tok.split("=", limit = 2).takeIf { it.size == 2 } }
+                .associate { it[0] to it[1] }
+            return Csv(header, rows, lines.filter { it.startsWith("# summary") }, info)
         }
     }
 }
@@ -200,6 +231,29 @@ private fun CsvView(file: File, modifier: Modifier) {
     val csv = remember(file) { Csv.read(file) }
     val hscroll = rememberScrollState()
     Column(modifier.fillMaxSize()) {
+        // What the run was, before what it did. A file whose configuration is unknown is a file
+        // whose numbers cannot be compared to anything.
+        if (csv.info.isNotEmpty()) {
+            Surface(color = MaterialTheme.colorScheme.primaryContainer, modifier = Modifier.fillMaxWidth()) {
+                Column(Modifier.padding(10.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(csv.label(), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+                    Text(
+                        listOfNotNull(
+                            csv.info["arch"]?.let { "arch $it" },
+                            csv.info["n_layer"]?.let { "$it layers" },
+                            csv.info["n_expert"]?.let { "$it experts" },
+                            csv.info["threads"]?.let { "$it threads" },
+                            csv.info["n_ctx"]?.let { "ctx $it" },
+                            if (csv.info["o_direct"] == "1") "O_DIRECT" else null,
+                            if (csv.info["warm_dense"] == "1") "warm dense" else null,
+                            if (csv.info["force_cache"] == "1") "forced" else null,
+                        ).joinToString(" · "),
+                        fontSize = 11.sp,
+                    )
+                }
+            }
+            Spacer(Modifier.height(4.dp))
+        }
         csv.summaries.forEach { s ->
             Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
                 Text(
@@ -275,10 +329,11 @@ private fun CompareView(fa: File, fb: File, modifier: Modifier) {
 
         val sa = a.column(metric).orEmpty()
         val sb = b.column(metric).orEmpty()
-        LineChart(sa, sb, colorA, colorB, Modifier.fillMaxWidth().height(260.dp))
+        LineChart(sa, sb, colorA, colorB, Modifier.fillMaxWidth().height(240.dp))
 
-        Legend(fa.name, colorA, sa)
-        Legend(fb.name, colorB, sb)
+        Legend(fa.name, a.label(), colorA, sa)
+        Legend(fb.name, b.label(), colorB, sb)
+        Diff(a, b)
         Text(
             "x = token index within the file (turns run end to end). Both series share one y scale, " +
                 "which is the only way the comparison means anything.",
@@ -288,18 +343,47 @@ private fun CompareView(fa: File, fb: File, modifier: Modifier) {
 }
 
 @Composable
-private fun Legend(name: String, color: Color, series: List<Float?>) {
+private fun Legend(name: String, label: String, color: Color, series: List<Float?>) {
     val vals = series.filterNotNull()
-    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Canvas(Modifier.size(14.dp)) { drawRect(color) }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Canvas(Modifier.size(12.dp).padding(top = 3.dp)) { drawRect(color) }
         Column {
-            Text(name, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 1)
+            // The configuration first, the file name second: which run this is matters more than
+            // what it happens to be called.
+            if (label.isNotEmpty()) Text(label, fontSize = 11.sp, fontWeight = FontWeight.Medium)
+            Text(name, fontFamily = FontFamily.Monospace, fontSize = 10.sp, maxLines = 1,
+                 color = MaterialTheme.colorScheme.onSurfaceVariant)
             Text(
                 if (vals.isEmpty()) "no data" else
                     "n=${vals.size}  min=${fmt(vals.min())}  mean=${fmt(vals.average().toFloat())}  max=${fmt(vals.max())}",
                 fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+/**
+ * What actually differs between the two runs' configurations. With two long labels on screen the
+ * eye will not find it, and the one setting that changed is the only reason to read the chart.
+ */
+@Composable
+private fun Diff(a: Csv, b: Csv) {
+    if (a.info.isEmpty() || b.info.isEmpty()) {
+        Text(
+            "One of these files has no run header — it predates it, so what it was configured with " +
+                "is unknown and the comparison is a guess.",
+            fontSize = 11.sp, color = MaterialTheme.colorScheme.error,
+        )
+        return
+    }
+    val keys = (a.info.keys + b.info.keys).filter { a.info[it] != b.info[it] }.sorted()
+    Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
+        Text(
+            if (keys.isEmpty()) "Same configuration in both — whatever differs, the settings do not."
+            else "differs: " + keys.joinToString("   ") { "$it ${a.info[it] ?: "-"}→${b.info[it] ?: "-"}" },
+            fontFamily = FontFamily.Monospace, fontSize = 11.sp,
+            modifier = Modifier.padding(8.dp),
+        )
     }
 }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -1,0 +1,153 @@
+package io.bigmoeonedge.example
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Reads back the per-token CSV the engine wrote for a session (`--csv`, see [AppSettings]).
+ *
+ * Deliberately a viewer, not a dashboard: it shows the file as it is, because the point of the file
+ * is to be the evidence. A summary that averaged these rows would hide exactly the thing worth
+ * seeing — a run's shape is in the individual token where the budget moved and the faults spiked,
+ * not in its mean.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MetricsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    var picked by remember { mutableStateOf<File?>(null) }
+    val files = remember {
+        File(context.getExternalFilesDir(null), "metrics")
+            .listFiles { f -> f.name.endsWith(".csv") }
+            ?.sortedByDescending { it.lastModified() }
+            ?: emptyList()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(picked?.name ?: "Metrics") },
+                navigationIcon = {
+                    IconButton(onClick = { if (picked != null) picked = null else onBack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        val file = picked
+        if (file == null) {
+            FileList(files, Modifier.padding(padding)) { picked = it }
+        } else {
+            CsvView(file, Modifier.padding(padding))
+        }
+    }
+}
+
+@Composable
+private fun FileList(files: List<File>, modifier: Modifier, onPick: (File) -> Unit) {
+    if (files.isEmpty()) {
+        Column(modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("No metrics yet.", fontWeight = FontWeight.Medium)
+            Text(
+                "Turn on Settings → Diagnostics → Metrics CSV, then run a prompt. One file is written " +
+                    "per session, covering every turn in it.",
+                fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+    val stamp = SimpleDateFormat("d MMM HH:mm:ss", Locale.getDefault())
+    LazyColumn(modifier.fillMaxSize()) {
+        items(files) { f ->
+            ListItem(
+                headlineContent = { Text(f.name, fontFamily = FontFamily.Monospace, fontSize = 13.sp) },
+                supportingContent = {
+                    Text(
+                        "${stamp.format(Date(f.lastModified()))} · ${f.length() / 1024} KiB",
+                        fontSize = 12.sp,
+                    )
+                },
+                modifier = Modifier.clickable(onClick = { onPick(f) }),
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun CsvView(file: File, modifier: Modifier) {
+    // Read once per open. These files are one row per token — thousands at worst, tens of KiB — so
+    // the whole thing fits in memory and there is nothing to gain from streaming it.
+    val lines = remember(file) { runCatching { file.readLines() }.getOrElse { listOf("cannot read: ${it.message}") } }
+    val header = lines.firstOrNull()?.split(",") ?: emptyList()
+    val rows = lines.drop(1).filter { it.isNotBlank() && !it.startsWith("#") }.map { it.split(",") }
+    // The engine writes one `# summary key=value ...` trailer per turn: the run-level facts
+    // (tok/s, token_demand_MiB, cache_cuts) that no single row carries.
+    val summaries = lines.filter { it.startsWith("# summary") }
+
+    val hscroll = rememberScrollState()
+    Column(modifier.fillMaxSize()) {
+        summaries.forEach { s ->
+            Surface(color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    s.removePrefix("# summary ").replace(" ", "   "),
+                    fontFamily = FontFamily.Monospace, fontSize = 11.sp,
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+        }
+        Text(
+            "${rows.size} tokens · ${header.size} columns · scroll sideways for all of them",
+            fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+        )
+        // One horizontal scroll shared by the header and every row, so the columns stay aligned.
+        Column(Modifier.horizontalScroll(hscroll)) {
+            Row(Modifier.padding(horizontal = 8.dp)) {
+                header.forEach { h -> Cell(h, bold = true) }
+            }
+            HorizontalDivider()
+            LazyColumn(Modifier.fillMaxWidth()) {
+                items(rows) { r ->
+                    Row(Modifier.padding(horizontal = 8.dp)) {
+                        r.forEach { v -> Cell(v) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Fixed-width cells: a table of numbers that does not line up is a table you have to read twice.
+@Composable
+private fun Cell(text: String, bold: Boolean = false) {
+    Text(
+        text,
+        fontFamily = FontFamily.Monospace,
+        fontSize = 11.sp,
+        fontWeight = if (bold) FontWeight.Bold else FontWeight.Normal,
+        maxLines = 1,
+        modifier = Modifier.width(88.dp).padding(vertical = 3.dp, horizontal = 2.dp),
+    )
+}

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -81,6 +81,13 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                         "devices with tight free RAM.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                SwitchRow(
+                    "Pressure-aware cache sizing",
+                    "Experimental. Treat the cache budget as a ceiling: the engine watches its own pages, " +
+                        "shrinks the cache when the device starts reclaiming it, and grows back when the " +
+                        "pressure lifts. Needs the cache on",
+                    current.cacheDynamic, enabled = stream && cacheOn,
+                ) { onChange(current.copy(cacheDynamic = it)) }
                 IntSetting("Parallel I/O lanes", AppSettings.IO_CHOICES, current.ioThreads, enabled = stream) {
                     onChange(current.copy(ioThreads = it))
                 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -155,6 +155,16 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     current.thinking,
                 ) { onChange(current.copy(thinking = it)) }
             }
+
+            Section("Diagnostics") {
+                SwitchRow(
+                    "Metrics CSV",
+                    "Write one CSV per session with every token's timings, page faults (count and MiB), " +
+                        "cache budget, and the memory split — anon (the expert cache), file (the model), " +
+                        "swap. Takes effect on the next session; share it from the menu",
+                    current.metricsCsv,
+                ) { onChange(current.copy(metricsCsv = it)) }
+            }
         }
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -20,6 +20,9 @@ data class Telemetry(
     // means a throttled/preempted core. 0 when the platform can't measure them.
     var majflt: Double = 0.0,
     var cpuMs: Double = 0.0,
+    // Fraction of the expert cache still in RAM at the last sample (-1 = unmeasured). Under 1 the
+    // device is reclaiming the cache mid-run: the pressure "Pressure-aware cache sizing" reacts to.
+    var residentFrac: Double = -1.0,
     var text: String = "",
     // Aggregate decode rate over the whole run, parsed from the final summary line; -1 until
     // generation finishes. The per-token [tokensPerSecond] is instantaneous (last token only),
@@ -76,6 +79,7 @@ class TelemetryParser {
             current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
             current.majflt = o.optDouble("majflt", 0.0)
             current.cpuMs = o.optDouble("cpu_ms", 0.0)
+            current.residentFrac = o.optDouble("resident_frac", -1.0)
             current.text = o.optString("text")
         }.isSuccess
     }

--- a/examples/android/app/src/main/res/xml/file_paths.xml
+++ b/examples/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- What the FileProvider may hand out: only the metrics CSVs, under the app's own external files
+     dir. Deliberately not the parent (which also holds downloaded multi-GB models) — a share sheet
+     has no business being able to reach those. -->
+<paths>
+    <external-files-path
+        name="metrics"
+        path="metrics/" />
+</paths>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@
 add_executable(bmoe_moe_gates moe_gates.cpp)
 target_link_libraries(bmoe_moe_gates PRIVATE bmoe_core)
 
+# The cache governor is pure policy (no llama.cpp, no syscalls, no model), so unlike the gates it
+# needs neither a fixture nor the native backend: it runs against a synthetic device.
+add_executable(bmoe_cache_governor_test cache_governor_test.cpp)
+target_link_libraries(bmoe_cache_governor_test PRIVATE bmoe_core)
+add_test(NAME cache_governor COMMAND bmoe_cache_governor_test)
+
 find_program(PYTHON3 NAMES python3 python)
 
 if(PYTHON3)

--- a/tests/cache_governor_test.cpp
+++ b/tests/cache_governor_test.cpp
@@ -1,8 +1,9 @@
 // The cache governor is pure policy, so its device is a function: "faults iff the budget exceeds
 // what I concede". That makes the properties that actually matter testable without a phone —
-// convergence, that it never cuts below what a token demands, that it stops oscillating — none of
-// which a byte-identity gate can see, because the governor changes what is resident and never what
-// is computed.
+// that it converges just under an unobservable concession and stops, that it keeps cutting for as
+// long as the device keeps taking, that it never cuts below the layer it must stage — none of which
+// a byte-identity gate can see, because the governor changes what is resident and never what is
+// computed.
 
 #include "bmoe/cache_governor.h"
 
@@ -124,15 +125,26 @@ void test_cooldown_collapses_a_burst() {
     check(g.cuts() == 1, "one cut for one burst");
 }
 
-void test_never_cuts_below_a_token_demand() {
-    const size_t demand = 500 * MiB;
+// Regression, measured on gpt-oss-120b (docs/bench-data/2026-07-15-pressure/): flooring the loop at
+// one TOKEN's working set (1815 MiB there) pinned the budget one cut below the ceiling, inside a war
+// the reflex could see and not act on. The floor is mechanical — one LAYER — and pressure outranks
+// it: a budget the device refuses is not worth defending at any hit rate.
+void test_cuts_below_a_token_working_set_when_the_device_refuses_it() {
+    const size_t layer = 50 * MiB;   // the mechanical floor: the layer being staged
+    const size_t token = 1815 * MiB; // one token's working set — informative, not a floor
     CacheGovernor g(params(2000 * MiB, 2000 * MiB, /*min_cap*/ 16 * MiB));
-    // Sustained, unrelenting reclaim: the device wants everything back.
     for (int i = 0; i < 500; ++i)
-        g.on_token(reclaiming(0.2, demand));
-    check(g.cap() == demand, "the floor is one token's routed working set, not zero");
-    // Below the floor a smaller cache cannot buy anything: the misses would be the model's own
-    // demand. Stopping there is the difference between a small cache and a broken one.
+        g.on_token(reclaiming(0.2, layer));
+    check(g.cap() < token, "sustained reclaim cuts below one token's working set");
+    check(g.cap() == layer, "and stops at the mechanical floor, not at zero");
+}
+
+void test_floor_is_respected_when_it_is_reachable() {
+    const size_t layer = 50 * MiB;
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB, /*min_cap*/ 16 * MiB));
+    for (int i = 0; i < 500; ++i)
+        g.on_token(reclaiming(0.2, layer));
+    check(g.cap() >= layer, "never cuts below the layer it must stage");
 }
 
 void test_growth_is_additive_and_capped() {
@@ -232,7 +244,8 @@ int main() {
     test_fault_reflex_needs_a_baseline();
     test_small_fault_counts_are_noise();
     test_cooldown_collapses_a_burst();
-    test_never_cuts_below_a_token_demand();
+    test_cuts_below_a_token_working_set_when_the_device_refuses_it();
+    test_floor_is_respected_when_it_is_reachable();
     test_growth_is_additive_and_capped();
     test_growth_retreats_from_a_known_ceiling();
     test_probe_forgets_a_stale_ceiling();

--- a/tests/cache_governor_test.cpp
+++ b/tests/cache_governor_test.cpp
@@ -1,0 +1,248 @@
+// The cache governor is pure policy, so its device is a function: "faults iff the budget exceeds
+// what I concede". That makes the properties that actually matter testable without a phone —
+// convergence, that it never cuts below what a token demands, that it stops oscillating — none of
+// which a byte-identity gate can see, because the governor changes what is resident and never what
+// is computed.
+
+#include "bmoe/cache_governor.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace bmoe;
+
+namespace {
+
+int failures = 0;
+
+void check(bool ok, const std::string & what) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s\n", what.c_str());
+        ++failures;
+    }
+}
+
+constexpr size_t MiB = 1024ull * 1024ull;
+
+CacheGovernorParams params(size_t user_cap, size_t initial, size_t min_cap = 64 * MiB) {
+    CacheGovernorParams p;
+    p.user_cap = user_cap;
+    p.initial = initial;
+    p.min_cap = min_cap;
+    return p;
+}
+
+// A calm token: cache fully resident, no faults.
+CacheSignals calm(size_t floor = 0) {
+    CacheSignals s;
+    s.resident_frac = 1.0;
+    s.majflt = 0;
+    s.floor = floor;
+    return s;
+}
+
+// A token during reclaim: the kernel has taken part of the cache.
+CacheSignals reclaiming(double frac = 0.5, size_t floor = 0) {
+    CacheSignals s;
+    s.resident_frac = frac;
+    s.majflt = 500;
+    s.floor = floor;
+    return s;
+}
+
+void test_starts_at_initial() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    check(g.cap() == 2000 * MiB, "starts at the configured budget");
+    check(g.ceiling() == CacheGovernor::no_ceiling, "no ceiling is known before any reclaim");
+    check(g.cuts() == 0, "no cuts before any pressure");
+
+    CacheGovernor clamped(params(500 * MiB, 2000 * MiB));
+    check(clamped.cap() == 500 * MiB, "the initial budget is clamped to the user cap");
+}
+
+void test_residency_triggers_a_cut() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    const CacheGovernor::Decision d = g.on_token(reclaiming());
+    check(d.changed, "a residency dip resizes");
+    check(d.cap == (size_t) (2000.0 * MiB * 0.7), "the cut is multiplicative");
+    check(g.ceiling() == 2000 * MiB, "the budget that provoked reclaim becomes the ceiling");
+    check(g.cuts() == 1, "the cut is counted");
+}
+
+void test_unmeasured_residency_is_not_pressure() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    CacheSignals s;
+    s.resident_frac = -1.0; // sampler throttled, or a platform that cannot report
+    s.majflt = 0;
+    check(!g.on_token(s).changed, "a missing sample is not evidence of pressure");
+    check(g.cap() == 2000 * MiB, "an unmeasured token leaves the budget alone");
+}
+
+void test_fault_reflex_needs_a_baseline() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    // A storm on the very first token has nothing to be extreme relative to: with no baseline the
+    // reflex must stay quiet and let the residency sample decide.
+    CacheSignals storm;
+    storm.resident_frac = -1.0;
+    storm.majflt = 10000;
+    check(!g.on_token(storm).changed, "the fault reflex does not fire before a baseline exists");
+
+    // Learn a calm baseline, then storm.
+    CacheGovernor g2(params(2000 * MiB, 2000 * MiB));
+    for (int i = 0; i < 8; ++i) {
+        CacheSignals s = calm();
+        s.majflt = 10;
+        s.resident_frac = 1.0;
+        g2.on_token(s);
+    }
+    CacheSignals s = storm;
+    check(g2.on_token(s).changed, "a fault storm well above the learned baseline cuts");
+}
+
+void test_small_fault_counts_are_noise() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    for (int i = 0; i < 8; ++i) {
+        CacheSignals s = calm();
+        s.majflt = 0;
+        g.on_token(s);
+    }
+    // Baseline is ~0: without an absolute margin, ratio*0 would make a single fault a war.
+    CacheSignals s;
+    s.resident_frac = -1.0;
+    s.majflt = 5;
+    check(!g.on_token(s).changed, "a handful of faults against a zero baseline is not a war");
+}
+
+void test_cooldown_collapses_a_burst() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    g.on_token(reclaiming());
+    const size_t after_first = g.cap();
+    for (int i = 0; i < 3; ++i)
+        g.on_token(reclaiming()); // still reclaiming, but the previous cut has not landed yet
+    check(g.cap() == after_first, "a burst of pressure inside the cooldown cuts once");
+    check(g.cuts() == 1, "one cut for one burst");
+}
+
+void test_never_cuts_below_a_token_demand() {
+    const size_t demand = 500 * MiB;
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB, /*min_cap*/ 16 * MiB));
+    // Sustained, unrelenting reclaim: the device wants everything back.
+    for (int i = 0; i < 500; ++i)
+        g.on_token(reclaiming(0.2, demand));
+    check(g.cap() == demand, "the floor is one token's routed working set, not zero");
+    // Below the floor a smaller cache cannot buy anything: the misses would be the model's own
+    // demand. Stopping there is the difference between a small cache and a broken one.
+}
+
+void test_growth_is_additive_and_capped() {
+    CacheGovernorParams p = params(2000 * MiB, 500 * MiB);
+    p.calm_tokens = 4;
+    p.grow_step = 64 * MiB;
+    CacheGovernor g(p);
+
+    for (int i = 0; i < 4; ++i)
+        g.on_token(calm());
+    check(g.cap() == 564 * MiB, "calm grows by exactly one step");
+
+    for (int i = 0; i < 10000; ++i)
+        g.on_token(calm());
+    check(g.cap() == 2000 * MiB, "sustained calm climbs back to the user cap");
+    check(g.cap() <= 2000 * MiB, "growth never exceeds the user cap");
+}
+
+void test_growth_retreats_from_a_known_ceiling() {
+    CacheGovernorParams p = params(2000 * MiB, 2000 * MiB);
+    p.calm_tokens = 4;
+    p.probe_after = 1000000; // never probe in this test
+    CacheGovernor g(p);
+    g.on_token(reclaiming()); // ceiling := 2000, cap := 1400
+    for (int i = 0; i < 10000; ++i)
+        g.on_token(calm());
+    const size_t limit = (size_t) (2000.0 * MiB * 0.9);
+    check(g.cap() <= limit, "growth stays below the ceiling it already lost at");
+    check(g.cap() > 1400 * MiB, "but it does grow back toward it");
+}
+
+void test_probe_forgets_a_stale_ceiling() {
+    CacheGovernorParams p = params(2000 * MiB, 2000 * MiB);
+    p.calm_tokens = 4;
+    p.probe_after = 8;
+    CacheGovernor g(p);
+    g.on_token(reclaiming());
+    check(g.ceiling() == 2000 * MiB, "the ceiling is remembered");
+    // A long calm at the retreat line: the device that refused 2000 MiB may not be the device we
+    // are on now (an app exited). Re-test rather than stay small forever.
+    for (int i = 0; i < 10000; ++i)
+        g.on_token(calm());
+    check(g.cap() == 2000 * MiB, "after a long calm the governor re-earns the full budget");
+}
+
+// The real property: against a device with a hidden concession, the loop must settle just under it
+// and STOP — no perpetual sawtooth between war and retreat.
+void test_converges_on_a_synthetic_device() {
+    const size_t concession = 1200 * MiB; // hidden from the governor
+    CacheGovernorParams p = params(3000 * MiB, 3000 * MiB);
+    p.calm_tokens = 8;
+    p.probe_after = 1000000; // no probing: measure the settled state, not the re-test
+    CacheGovernor g(p);
+
+    std::vector<size_t> caps;
+    for (int i = 0; i < 4000; ++i) {
+        const bool over = g.cap() > concession;
+        g.on_token(over ? reclaiming(0.5, 300 * MiB) : calm(300 * MiB));
+        if (i >= 3000) caps.push_back(g.cap());
+    }
+    for (size_t c : caps)
+        check(c <= concession, "the settled budget never exceeds what the device concedes");
+    size_t lo = caps.front(), hi = caps.front();
+    for (size_t c : caps) {
+        lo = c < lo ? c : lo;
+        hi = c > hi ? c : hi;
+    }
+    check(hi - lo <= p.grow_step, "the settled budget stops oscillating");
+    check(lo > concession / 2, "and it settles near the concession, not far below it");
+    // No cuts in the tail means the loop found the edge and stopped fighting for it.
+    const long long cuts_at_3000 = g.cuts();
+    for (int i = 0; i < 1000; ++i)
+        g.on_token(g.cap() > concession ? reclaiming(0.5, 300 * MiB) : calm(300 * MiB));
+    check(g.cuts() == cuts_at_3000, "a settled governor stops cutting");
+}
+
+void test_degenerate_caps() {
+    CacheGovernor g(params(100 * MiB, 100 * MiB, /*min_cap*/ 100 * MiB));
+    for (int i = 0; i < 100; ++i)
+        g.on_token(reclaiming(0.1, 0));
+    check(g.cap() == 100 * MiB, "cap == min_cap leaves nothing to give back");
+
+    // A floor above the user cap: the cache is pathological by configuration, and the governor's
+    // job is only to not make it worse by cutting further.
+    CacheGovernor g2(params(200 * MiB, 200 * MiB, 16 * MiB));
+    for (int i = 0; i < 100; ++i)
+        g2.on_token(reclaiming(0.1, /*floor*/ 900 * MiB));
+    check(g2.cap() == 200 * MiB, "a floor above the cap pins the budget at the cap");
+}
+
+} // namespace
+
+int main() {
+    test_starts_at_initial();
+    test_residency_triggers_a_cut();
+    test_unmeasured_residency_is_not_pressure();
+    test_fault_reflex_needs_a_baseline();
+    test_small_fault_counts_are_noise();
+    test_cooldown_collapses_a_burst();
+    test_never_cuts_below_a_token_demand();
+    test_growth_is_additive_and_capped();
+    test_growth_retreats_from_a_known_ceiling();
+    test_probe_forgets_a_stale_ceiling();
+    test_converges_on_a_synthetic_device();
+    test_degenerate_caps();
+
+    if (failures) {
+        std::fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("cache governor: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
Off by default (`--cache-dynamic`, plus an app switch). Opt-in until the device says otherwise.

## Why

The rewarm result (#28) established that on a >RAM model the engine asks for more memory than the
device concedes, and that restoring the stolen pages cannot win: the kernel takes them back
mid-decode and the turn stays at 0.3 tok/s. The conclusion was that **the ask has to shrink**.

The obvious follow-up — pick a smaller number — is the thing this PR is trying not to do. A cache
budget cannot be a constant: it depends on the model (one gpt-oss token at top-2 routes ~536 MiB,
one Qwen3-30B token at top-8 routes ~1051 MiB), the top-k, the phone, and whatever else the user has
open right now. `--cache-mb 1000` measures well on gpt-oss on this device today, and that is exactly
the kind of fact that does not survive a new model or a new phone.

## What it does

Treat the configured budget as a **ceiling**, and find the largest cache the device actually
concedes.

Not by asking the OS — on Android every signal for this is unusable: `MemAvailable` counts our own
mmap'd weights as free (which is why `--cache-mb auto` over-asks by construction), PSI is
SELinux-blocked for apps, `onTrimMemory` is late and never signals relief, `mlock` is capped at
64 KiB. So the engine watches **its own pages** instead — the one thing every device lets a process
ask about, no permission and no vendor cooperation required:

- **Sense** — `mincore()` over the cache's own buffers, walking the LRU cold end (the pages reclaim
  takes first). Absolute signal: our pages are in RAM or they are not. Plus `getrusage` major-fault
  deltas as the reflex between samples (already measured for telemetry).
- **Decide** — AIMD with hysteresis (`bmoe/cache_governor.h`). Pure policy: no syscalls, no clocks,
  no llama.cpp. The shape TCP uses against an unobservable bottleneck.
- **Act** — the existing `set_cache_budget`, ticked once per token *after* the decode: the only
  point where nothing is staged for a generation in flight.

## The floor is measured, not guessed

`cache_min_mb` (1500) encodes a real bound — below one token's routed working set, every token
evicts what the next one needs — but encodes it as a constant that is model-specific, which is why
the app's 500/1000 rungs need `--force-cache` to measure the very thing the floor is guessing at.

A token's pass over the stack is monotonic in layer index, so the bytes demanded between two visits
to the same layer **is** the working set. The streamer now measures it (`token_demand_MiB`), and it
is what floors the governor. That is what makes this work on a model nobody has benchmarked yet.

## Verification

- New unit tests (`tests/cache_governor_test.cpp`): the governor is pure policy, so the device is a
  function and the properties that matter are testable without a phone — converges just under a
  hidden concession **and stops**, never cuts below a token's demand, a missing sample is not read as
  pressure. They caught a real bug: the cooldown, starting unspent, delayed the *first* cut, leaving
  a session opened onto an already-pressured device inert exactly when it mattered.
- Byte-identity gates green. Output verified identical across static / dynamic / dynamic+overlap /
  cache-off on both architectures — the loop changes what is resident, never what is computed.
- Host build: no residency signal, so the loop stays calm and the budget behaves exactly as a static
  one. That is the intended degradation, not an accident.
- One drive-by: the `occ` line in `cli/main.cpp` already violated clang-format on main; the format
  gate runs whole files, so it is fixed here.

## Not verified yet

**On-device A/B is outstanding** — that is the whole point of the switch. The claim to test on
gpt-oss: the governor should match the best static budget (1000 MiB today) *without being told it*,
and not regress Qwen/Gemma, where the cache genuinely pays (53-82% hit) and `auto` currently
over-asks. It stays off by default until those numbers exist.

Also carried but unwired: `MADV_PAGEOUT` was considered for the evicted tail and left out —
`MADV_DONTNEED` already frees those pages more cheaply. It would only make sense against the
*retained* cold tail, which is a separate experiment.

See [docs/pressure.md](docs/pressure.md).