### PR TITLE
chore: ignore .claude/ so agent-local settings can't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ examples/android/captures/
 # IDE / editor
 .vscode/
 .idea/
+.claude/
 *.swp
 *~
 


### PR DESCRIPTION
`.claude/settings.local.json` lives at the repo root and is currently kept out of git only by a machine-global ignore rule. On any other clone that rule is absent, so the file could be committed by accident. This ignores `.claude/` in-tree alongside the existing `.idea/`/`.vscode/` entries.

No code or behaviour change.