### PR TITLE
gov2 cache governor — attribution, plateau, and a real off state

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -338,6 +338,9 @@ static void print_usage(const char * argv0) {
         "      --cache-dynamic     treat --cache-mb as a ceiling and find the budget the device\n"
         "                          concedes: shrink when reclaim starts taking the cache, grow back\n"
         "                          when it stops (needs the cache; see docs/pressure.md)\n"
+        "      --cache-gov2        --cache-dynamic plus a hit-rate plateau, fault attribution, and an\n"
+        "                          OFF state (demote the cache to slots on a >RAM model where cutting\n"
+        "                          cannot end the war); default off, promoted per model+device by A/B\n"
         "      --io-threads N      parallel expert-read lanes [1..%d] (default 4)\n"
         "      --no-odirect        do not bypass the page cache\n"
         "      --no-warm-dense     skip the load-time sweep that page-caches the non-expert weights\n"
@@ -413,7 +416,10 @@ int main(int argc, char ** argv) {
             cfg.moe.cache_dynamic = true;
         else if (a == "--no-cache-dynamic")
             cfg.moe.cache_dynamic = false;
-        else if (a == "--io-threads")
+        else if (a == "--cache-gov2") {
+            cfg.moe.cache_gov2 = true;
+            cfg.moe.cache_dynamic = true; // gov2 is the dynamic loop plus attribution + an off state
+        } else if (a == "--io-threads")
             cfg.moe.io_threads = std::atoi(next("--io-threads"));
         else if (a == "--no-odirect")
             cfg.moe.o_direct = false;

--- a/core/include/bmoe/cache_governor.h
+++ b/core/include/bmoe/cache_governor.h
@@ -13,13 +13,22 @@
 // too much costs a continuous war mid-decode, asking too little costs only a few points of hit
 // rate.
 //
+// Two states, because a budget the device will not concede is not always a cut away from working.
+// On a >RAM model one token routes more than the device will ever hold, so the LRU cache can earn
+// no hits at any budget it is allowed — and it still pays the churn of committing and evicting a
+// token's worth of pages every step, which is itself a source of the reclaim war. Measured: cutting
+// such a cache to the floor did NOT end the war (majflt stayed in the thousands), but turning it
+// off — shared slots, zero commit/evict — did. So the governor can also DEMOTE the cache to slot
+// mode, and re-arm it (promote back) if the device later concedes the room. See docs/pressure.md.
+//
 // Pure policy: no syscalls, no clocks, no config reads, no llama.cpp. The caller feeds sensor
-// readings per token and applies the returned budget. That keeps it unit-testable against a
-// synthetic device, and portable — the Android sensors are getrusage + mincore, but an iOS port
-// (os_proc_available_memory, DISPATCH_SOURCE_TYPE_MEMORYPRESSURE) only has to fill the same
-// struct.
+// readings per token and applies the returned budget/mode. That keeps it unit-testable against a
+// synthetic device, and portable — the Android sensors are getrusage + mincore + /proc/self/status,
+// but an iOS port (os_proc_available_memory, DISPATCH_SOURCE_TYPE_MEMORYPRESSURE) only has to fill
+// the same struct.
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 
@@ -29,19 +38,53 @@ namespace bmoe {
 struct CacheSignals {
     // Major page faults during this decode (getrusage ru_majflt delta). The fast reflex: it costs
     // one syscall and it is already measured per token for the telemetry. Reads 0 on platforms
-    // that cannot report it, which reads as calm.
+    // that cannot report it, which reads as calm. This is the one HEALTH signal — every other
+    // reading below only attributes a fault load to a culprit, it does not judge severity.
     uint64_t majflt = 0;
 
     // Sampled fraction of the cache's own pages still in RAM (mincore over the LRU cold end), or
-    // < 0 when not sampled this token (the sampler is throttled) or unsupported. This is the
-    // primary signal: it is absolute — no baseline, no device knowledge — and it sees the theft
-    // before those pages fault back and cost a read.
+    // < 0 when not sampled this token (the sampler is throttled) or unsupported. Absolute — no
+    // baseline, no device knowledge — and it sees theft of OUR cache before those pages fault back.
     double resident_frac = -1.0;
 
     // The largest single layer's routed working set in bytes, measured by the streamer (0 = not yet
     // known). This is the floor, and it is a mechanical one: the cache must be able to hold the
     // layer currently being staged. It is NOT "one token's working set" — see the note below.
     size_t floor = 0;
+
+    // Sampled fraction of the DENSE weights (the mmap'd model) still in RAM, or < 0 when not
+    // sampled/unsupported. The companion to resident_frac: that one watches our anon cache, this
+    // one the file-backed weights it is blind to. A decline here from its own plateau, while the
+    // cache holds, means the faults are the MODEL being reclaimed — a different war, and shrinking
+    // the cache is the wrong lever for it (dense is file-backed; the cut frees anon).
+    double dense_resident_frac = -1.0;
+
+    // Change in VmSwap since the previous token, in bytes (signed; may be negative; 0 on the first
+    // token or when unknown). Rising swap with a fault load, while our cache and the dense weights
+    // both hold, is the signature of the ANON war: the kernel is compressing our own live memory
+    // (KV, cache entries) into zram and we re-fault it — a war that cutting the cache does not end,
+    // because the churn of a hit-starved cache is itself feeding it.
+    int64_t swap_delta = 0;
+
+    // Distinct expert bytes one token routes, as measured during DECODE (0 = not yet a decode
+    // value — the caller withholds the prefill union, which is far larger and would read as
+    // infeasible). Below it the cache holds nothing between tokens; far above what the device
+    // concedes it can earn no hits at any allowed budget. The feasibility test reads it against the
+    // room the device will give.
+    size_t token_demand = 0;
+
+    // MemAvailable in bytes (0 = unknown). It LIES for sizing — it counts our own mmap'd weights as
+    // reclaimable — so it is never the sole authority. Used only as a coarse growth gate and, with
+    // token_demand, a feasibility hint; the measured-residency machinery outranks it.
+    uint64_t mem_available = 0;
+
+    // Cumulative cache hits and lookups (the streamer's running totals). The governor diffs its own
+    // windows across grow steps to see whether more budget is still buying hits, and stops growing
+    // when it is not — the utility bound that replaces a hand-set ceiling. Frozen counters (Δ == 0,
+    // e.g. in slot mode or a test that supplies no cache activity) simply disable the plateau test,
+    // leaving pure AIMD.
+    long long cache_hits = 0;
+    long long cache_lookups = 0;
 };
 
 // A note on the floor, because the obvious choice is wrong and it was measured to be wrong.
@@ -60,12 +103,21 @@ struct CacheSignals {
 // ignores that the memory itself is the cost: an unaffordable cache does not merely fail to earn
 // its hits, it starts a reclaim war that costs several times what any hit rate could return. Losing
 // inter-token hits is bounded and cheap; losing the war is neither. So usefulness must yield to
-// pressure, and the only floor that may not yield is the mechanical one.
+// pressure, and the only floor that may not yield is the mechanical one. When even the floor is
+// refused — the war survives repeated cuts — the answer is not a smaller cache but no cache: demote
+// to slot mode (see the header banner).
 
 struct CacheGovernorParams {
-    size_t user_cap = 0; // never exceed: the configured budget (--cache-mb, or the auto ceiling)
-    size_t initial = 0;  // starting budget
-    size_t min_cap = 0;  // hard lower bound, used when CacheSignals::floor is still unknown
+    // user_cap 0 means "unbounded by configuration": the budget is then held only by the physical
+    // expert-set size, the learned reclaim ceiling, the hit-rate plateau, and the device's free RAM.
+    // A non-zero value (an explicit --cache-mb, or the auto ceiling) is honoured as a hard cap.
+    size_t user_cap = 0;
+    size_t initial = 0; // starting budget
+    size_t min_cap = 0; // hard lower bound, used when CacheSignals::floor is still unknown
+
+    // ── bounds discovered/passed at runtime (0 = not applied) ──
+    size_t phys_cap = 0;       // total expert-set bytes: no cache is ever larger than this
+    size_t floor_headroom = 0; // RAM to leave the rest of the system free (the cache_floor)
 
     // ── tunables ──
     // Deliberately compiled in rather than exposed: they are control-loop policy, not per-device
@@ -76,38 +128,97 @@ struct CacheGovernorParams {
     // reclaim, so anything short of ~all-resident means the kernel already disagrees with the ask.
     double resident_min = 0.90;
 
-    // Reflex threshold between residency samples: cut when majflt exceeds baseline*ratio + margin.
-    // The margin keeps a near-zero baseline from making single faults look like a war; at roughly
-    // 100 us per fault from flash, 32 faults is ~3 ms — noise against a token, not a signal.
+    // Reflex threshold between residency samples: a fault load counts as a war when majflt exceeds
+    // baseline*ratio + margin. The margin keeps a near-zero baseline from making single faults look
+    // like a war; at roughly 100 us per fault from flash, 32 faults is ~3 ms — noise, not a signal.
     double fault_ratio = 3.0;
     uint64_t fault_margin = 32;
     double baseline_decay = 0.9; // EWMA weight for the calm-token fault baseline
 
-    double cut_factor = 0.7;                // multiplicative decrease
+    double cut_factor = 0.7;                // multiplicative decrease for a cache/dense war
+    double cut_factor_hard = 0.5;           // sharper decrease for an anon war (cut hard, it does not yield gently)
     int cut_cooldown = 4;                   // tokens to wait after a cut before another (let the shrink land)
     int calm_tokens = 32;                   // consecutive calm tokens before growing
     size_t grow_step = 64ull * 1024 * 1024; // additive increase
     double ceiling_retreat = 0.9;           // grow freely only below ceiling*this
     int probe_after = 512;                  // calm tokens pinned at the ceiling before re-testing it
+
+    // Attribution / demotion.
+    uint64_t swap_margin = 32ull * 1024 * 1024; // bytes/token of fresh swap that reads as an anon war
+    double dense_decline = 0.85;                // dense war when dense_frac < plateau * this
+    int demote_after = 3;                       // unrelieved cuts in one war episode → demote to slots
+    double rearm_margin = 1.25;                 // re-arm when free room > token_demand * this
+    int rearm_persist = 3;                      // consecutive re-arm probes required before promoting
+    int probe_every = 64;                       // tokens between re-arm probes while demoted
+
+    // Utility demotion — the ground truth the attribution signals can miss. In a never-calm war the
+    // fault baseline cannot self-calibrate (there is no quiet token to learn from), and MemAvailable
+    // is unreliable for feasibility, so the governor also demotes on what it CAN measure directly:
+    // the cache is not earning. Two independent reads of that, either sufficient after grace:
+    //   • the budget was cut below one token's demand — it holds nothing between tokens; or
+    //   • a measured window of near-zero hit rate — the model has no reuse the cache can exploit.
+    // (Measured: gpt-oss sits at ~2% hit in a fault war; --cache-mb 0 runs the same model ~6x faster.)
+    double demote_hit_floor = 0.10; // windowed hit rate below this reads as "not earning"
+    int demote_window = 4;          // tokens per hit-rate window (grace skips the first, cold-fill one)
+    // A sustained major-fault load this high (EWMA of majflt/token) is a memory war no cache is
+    // winning — the ground truth when hit rate and attribution disagree. Measured on device: a
+    // HEALTHY gpt-oss run (the cache earning, ~1.2 tok/s) settles at an EWMA near 1000 with brief
+    // spikes to ~1500; the WAR runs (~0.1–0.3 tok/s) sit sustained at 4600–12000. 2500 sits in the
+    // gap with margin both ways, and Qwen's booster stays in the low hundreds regardless. When the
+    // EWMA holds above this past the warm-up grace, demote — cutting has not, and cannot, end it.
+    uint64_t war_fault_abs = 2500;
+    double fault_ewma_decay = 0.7;
+
+    // Plateau: after a grow step, compare the hit rate over the next window against the previous
+    // cap's. Improvement must clear two binomial standard errors (measurement noise) to count;
+    // plateau_confirm consecutive non-improvements freeze growth at the last cap that helped.
+    int hit_window = 32;
+    int plateau_confirm = 2;
 };
+
+// The largest budget the device will sustain, computed once at load before prefill can fill an
+// unsustainable one. MemAvailable overstates the room (it counts our own weights as free), so this
+// is a clamp, not an authority — the runtime loop still has to discover the true concession.
+inline size_t entry_budget(size_t configured, uint64_t mem_available, size_t floor, size_t min_cap) {
+    if (mem_available == 0) return configured; // unknown → trust what was asked for
+    const size_t sustainable = mem_available > floor ? (size_t) (mem_available - floor) : min_cap;
+    size_t e = std::min(configured, sustainable);
+    return std::max(e, std::min(min_cap, configured));
+}
 
 class CacheGovernor {
 public:
     explicit CacheGovernor(const CacheGovernorParams & p);
 
+    // The cache's residency policy, which the governor can switch between at a token boundary.
+    enum class Mode : uint8_t {
+        keep,  // no change this tick
+        lru,   // promote to (or stay) the LRU cache
+        slots, // demote to shared-slot mode: no cache, no commit/evict churn
+    };
+
+    // Why the loop last acted, for telemetry and tests. Not every token is a war; foreign_faults is
+    // a fault load our own memory is demonstrably innocent of — the loop must NOT cut for it.
+    enum class War : uint8_t { none, cache, dense, anon, foreign };
+    enum class State : uint8_t { on, off };
+
     struct Decision {
-        size_t cap = 0;       // the budget after this tick
-        bool changed = false; // true ⇒ the caller must apply cap to the cache now
+        size_t cap = 0;            // the budget after this tick
+        bool changed = false;      // true ⇒ apply cap to the cache now
+        Mode mode = Mode::keep;    // a mode switch to apply BEFORE the cap (slots makes cap moot)
+        bool rewarm_dense = false; // re-run the dense warm-up once, after a dense-war cut
     };
 
     // One tick per generated token, after the decode (the only point where the cache has no
-    // decode in flight, so an evicting shrink is safe).
+    // decode in flight, so an evicting shrink or a mode switch is safe).
     Decision on_token(const CacheSignals & s);
 
     // Telemetry.
     size_t cap() const { return cap_; }
     long long cuts() const { return cuts_; }
     double baseline() const { return baseline_; }
+    State state() const { return state_; }
+    War war() const { return war_; }
     // The smallest budget observed to provoke reclaim, i.e. what the device would not concede.
     // no_ceiling while none has been found (or after a probe forgets it).
     size_t ceiling() const { return ceiling_; }
@@ -116,16 +227,52 @@ public:
 
 private:
     size_t floor_of(const CacheSignals & s) const;
-    size_t grow_limit() const;
+    size_t grow_limit(const CacheSignals & s) const;
+    War classify(const CacheSignals & s, bool & swap_rising, bool & dense_declining);
 
     CacheGovernorParams p_;
     size_t cap_ = 0;
     size_t ceiling_ = no_ceiling;
-    double baseline_ = -1.0; // EWMA of calm-token majflt; < 0 until the first calm token
+    size_t plateau_cap_ = no_ceiling; // budget past which more RAM stopped buying hits
+    double baseline_ = -1.0;          // EWMA of calm-token majflt; < 0 until the first calm token
+    State state_ = State::on;
+    War war_ = War::none;
+
     int calm_ = 0;
     int since_cut_ = 0;
     int since_probe_ = 0;
     long long cuts_ = 0;
+
+    // Attribution state.
+    double swap_ewma_ = 0.0;
+    double dense_plateau_ = -1.0; // running high-watermark of sampled dense residency
+    int dense_samples_ = 0;
+    int war_cuts_ = 0;      // cuts made since the last calm token (one war episode)
+    bool rewarmed_ = false; // dense re-warm already emitted this episode
+
+    // Plateau bookkeeping: sample (hits, lookups) at each grow step and compare the interval just
+    // ended against the previous one. Two consecutive non-improvements freeze growth at plateau_cap_.
+    long long grow_hits_ = 0, grow_lookups_ = 0;
+    bool grow_sampled_ = false;
+    double prev_hitrate_ = -1.0;
+    int plateau_miss_ = 0;
+
+    // Re-arm bookkeeping (while demoted).
+    int rearm_ok_ = 0;
+    int since_rearm_probe_ = 0;
+
+    // Utility-demote bookkeeping.
+    int below_demand_ = 0;                     // consecutive tokens with cap below one token's demand
+    long long hr_hits0_ = 0, hr_lookups0_ = 0; // hit-rate window anchors
+    int hr_win_ = 0;                           // tokens elapsed in the current hit-rate window
+    int hr_grace_ = 2;                         // hit-rate windows to skip (the cold cache fill)
+    double fault_ewma_ = 0.0;                  // smoothed majflt/token, the sustained-war detector
+
+    void plateau_on_grow(const CacheSignals & s);
+    bool infeasible(const CacheSignals & s) const;
+    Decision demote();
+    Decision off_tick(const CacheSignals & s);
+    Decision promote(const CacheSignals & s);
 };
 
 } // namespace bmoe

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -48,6 +48,15 @@ struct MoeStreamConfig {
     // See docs/pressure.md and bmoe/cache_governor.h.
     bool cache_dynamic = false;
 
+    // The second-generation governor: everything cache_dynamic does, plus a hit-rate plateau that
+    // replaces a hand-set ceiling, attribution of a fault load to its culprit (our cache, the dense
+    // weights, or the anon/zram war), and a real OFF state — when a >RAM model routes more than the
+    // device concedes, cutting the budget cannot end the war (its churn feeds it), so the governor
+    // demotes the cache to slot mode and re-arms it only if the device later frees the room. Implies
+    // cache_dynamic; requires the LRU cache at init (it can REACH the off state at runtime, it cannot
+    // START there). Default off, promoted per model+device by the on-device A/B. See docs/pressure.md.
+    bool cache_gov2 = false;
+
     // Parallel expert-slice read lanes (incl. the calling thread). 1 = serial baseline.
     // Clamped to [1, io_threads_max]. 4 is the measured sweet spot on UFS4 phones.
     int io_threads = 4;

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -87,6 +87,9 @@ public:
         // Bytes the widest single layer routes, measured (0 = not yet known). The mechanical floor:
         // the cache must hold the layer being staged.
         uint64_t layer_demand_bytes = 0;
+        // Every expert of every bound layer resident at once: the full expert set. The physical
+        // ceiling on any cache — no budget is ever larger than this, whatever the device concedes.
+        uint64_t total_expert_bytes = 0;
     };
     virtual Stats stats() const = 0;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -63,6 +63,12 @@ struct TokenMetrics {
     double cache_budget_mib = 0.0;
     int turn = 0; // session turn this token belongs to (0 for a one-shot run)
 
+    // Governor v2 (--cache-gov2) trajectory: state (0 = on/LRU, 1 = off/slots) and the war it last
+    // attributed the pressure to (0 none, 1 cache, 2 dense, 3 anon, 4 foreign). Both 0 otherwise.
+    // A demotion shows as gov_state flipping to 1 and cache_budget_mib dropping to 0.
+    int gov_state = 0;
+    int gov_war = 0;
+
     std::string piece; // text of just this token (delta, for inline streaming)
     std::string text;  // full generated text so far (for UI streaming)
 };
@@ -139,6 +145,7 @@ struct RunInfo {
     bool cache_auto = false;
     int cache_ceil_mb = 0;
     bool cache_dynamic = false;
+    bool cache_gov2 = false;
     bool force_cache = false;
     int io_threads = 0;
     bool o_direct = false;

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -95,6 +95,12 @@ public:
     // when the cache is off. Complements --cache-mb auto's automatic tracking with explicit control.
     void set_cache_budget_mb(int mib);
 
+    // Force the expert cache into shared-slot (off) mode, or back to the LRU. PRECONDITION: no
+    // generate() in flight. The governor drives this itself under --cache-gov2; this is the manual
+    // entry (an app's onTrimMemory, or the mode-flip byte-identity gate). Returns false if the
+    // switch could not be made (e.g. slot allocation failed); a no-op if already in that mode.
+    bool set_cache_mode_slots(bool slots);
+
 private:
     Session();
     struct Impl;

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -78,6 +78,11 @@ ValidationResult validate(const RunConfig & cfg) {
                         "sizes a cache budget at runtime, and there is no budget to size with the "
                         "cache off.");
         }
+        if (m.cache_gov2 && !cache_on) {
+            return fail("moe.cache_gov2 requires the LRU cache (cache_mb > 0 or cache_auto): the "
+                        "governor can DEMOTE to slot mode at runtime but cannot start there. Use "
+                        "--cache-mb auto --cache-gov2.");
+        }
     }
 
     return r;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -126,6 +126,11 @@ struct Session::Impl {
     // last turn learned about this device is exactly what the next turn needs.
     std::unique_ptr<CacheGovernor> gov;
 
+    // Previous token's VmSwap, to hand the governor a per-token delta (rising swap under a fault
+    // load is the anon/zram war's signature). swap_known_ guards the first token, which has no prior.
+    uint64_t prev_swap_bytes = 0;
+    bool swap_known = false;
+
     // Stated once to a metrics sink, before the first token: the model and configuration every row
     // it writes was produced under. info_sent guards a session's many generate() calls from
     // interleaving preambles between turns.
@@ -160,6 +165,10 @@ int Session::n_ctx() const {
 }
 void Session::set_cache_budget_mb(int mib) {
     impl_->source.set_cache_budget((size_t) std::max(0, mib) * 1024ull * 1024ull);
+}
+bool Session::set_cache_mode_slots(bool slots) {
+    return impl_->source.set_cache_mode(slots ? ExpertStreamSource::CacheMode::SharedSlot
+                                              : ExpertStreamSource::CacheMode::Lru);
 }
 void Session::cancel() {
     impl_->cancel_requested.store(true, std::memory_order_relaxed);
@@ -331,7 +340,8 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // The budget the streamer settled on — an explicit cache_mb, or what auto sized to — is the
         // most the user sanctioned, so it becomes the governor's ceiling and its starting point. The
         // loop only ever asks for less than this, and climbs back toward it when the device allows.
-        const uint64_t configured = im.source.stats().cache_budget_bytes;
+        const IExpertSource::Stats st0 = im.source.stats();
+        const uint64_t configured = st0.cache_budget_bytes;
         if (cfg.moe.cache_dynamic && configured > 0) {
             CacheGovernorParams gp;
             gp.user_cap = (size_t) configured;
@@ -342,6 +352,37 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             // rounder number. Being briefly too small costs hits for a few tokens; being too big
             // costs the war this loop exists to end.
             gp.min_cap = std::min<size_t>(64ull * 1024 * 1024, (size_t) configured);
+
+            if (cfg.moe.cache_gov2) {
+                // The second-generation governor's extra bounds and the entry test. floor_headroom
+                // is the RAM to leave the system; phys_cap is the whole expert set (no cache is ever
+                // larger). Both flow from measured/config values, no model constants.
+                gp.floor_headroom = (size_t) std::max(0, cfg.moe.cache_floor_mb) * 1024ull * 1024ull;
+                gp.phys_cap = (size_t) st0.total_expert_bytes;
+
+                // Entry test: prefill runs before the governor's first tick, so a budget the device
+                // cannot sustain would be filled — and the device knocked over — before any decision.
+                // MemAvailable is the trap here: it counts this process's OWN mmap'd model weights as
+                // reclaimable ("free"), so trusting it makes the auto budget over-ask by roughly the
+                // resident model size, and the huge prefill commit then OOMs (measured: --cache-mb
+                // auto asked 6.6 GiB on an 8 GiB device and segfaulted mid-prefill). So discount the
+                // dense (non-expert) weight bytes — the part MemAvailable double-counts — from the
+                // reserve before clamping. dense = every tensor in the file minus the expert set; it
+                // is an over-estimate of what stays resident (cold embeddings get dropped), which is
+                // the safe direction. KV and compute buffers are anon and already allocated by now,
+                // so MemAvailable already excludes them — only the file-backed lie needs correcting.
+                uint64_t total_tensor_bytes = 0;
+                for (const auto & kv : offs.size_by_name)
+                    total_tensor_bytes += kv.second;
+                const size_t dense_bytes = total_tensor_bytes > st0.total_expert_bytes
+                                               ? (size_t) (total_tensor_bytes - st0.total_expert_bytes)
+                                               : 0;
+                const uint64_t avail = pio::mem_available_bytes();
+                const size_t reserve = gp.floor_headroom + dense_bytes;
+                const size_t entry = entry_budget((size_t) configured, avail, reserve, gp.min_cap);
+                gp.initial = entry;
+                if (entry < (size_t) configured) im.source.set_cache_budget(entry);
+            }
             im.gov = std::make_unique<CacheGovernor>(gp);
         }
 
@@ -419,6 +460,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.cache_auto = cfg.moe.cache_auto;
         ri.cache_ceil_mb = cfg.moe.cache_ceil_mb;
         ri.cache_dynamic = cfg.moe.cache_dynamic;
+        ri.cache_gov2 = cfg.moe.cache_gov2;
         ri.force_cache = cfg.moe.force_cache;
         ri.io_threads = cfg.moe.enabled ? cfg.moe.io_threads : 0;
         ri.o_direct = cfg.moe.enabled && cfg.moe.o_direct;
@@ -739,18 +781,23 @@ RunResult Session::generate(const GenerateRequest & req,
         // Read the memory picture AFTER the decode, outside the s0..s1 bracket: two /proc reads are
         // cheap but they are not this token's work, and billing them to wall_ms would corrupt the
         // very number the reader is here to trust.
+        uint64_t swap_bytes_now = 0, mem_avail_now = 0;
+        bool swap_ok = false;
         pio::ProcessMemory pm;
         if (pio::process_memory(&pm)) {
             m.rss_mib = pm.rss_bytes / (1024.0 * 1024.0);
             m.rss_anon_mib = pm.rss_anon_bytes / (1024.0 * 1024.0);
             m.rss_file_mib = pm.rss_file_bytes / (1024.0 * 1024.0);
             m.swap_mib = pm.swap_bytes / (1024.0 * 1024.0);
+            swap_bytes_now = pm.swap_bytes;
+            swap_ok = true;
         }
         pio::DeviceMemory dm;
         if (pio::device_memory(&dm)) {
             m.mem_available_mib = dm.available_bytes / (1024.0 * 1024.0);
             m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
             m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
+            mem_avail_now = dm.available_bytes;
         }
         if (moe.enabled) {
             IExpertSource::Stats st = im.source.stats();
@@ -779,14 +826,42 @@ RunResult Session::generate(const GenerateRequest & req,
 
             // Size the cache to what the device concedes, here and nowhere else: between two decodes
             // nothing is staged for a generation in flight, which is exactly the precondition
-            // set_cache_budget needs to evict the cold tail without a cstamp guard.
+            // set_cache_budget (and a mode switch) needs to act without a decode in flight.
             if (im.gov) {
                 CacheSignals sig;
                 sig.majflt = m.majflt;
                 sig.resident_frac = st.cache_resident_frac;
                 sig.floor = (size_t) st.layer_demand_bytes;
+                if (moe.cache_gov2) {
+                    // The v2 attribution + feasibility signals. Only fed under --cache-gov2 so
+                    // --cache-dynamic alone stays the PR#35 baseline for the A/B.
+                    sig.dense_resident_frac = st.dense_resident_frac;
+                    sig.mem_available = mem_avail_now;
+                    sig.cache_hits = st.cache_hits;
+                    sig.cache_lookups = st.cache_lookups;
+                    // Withhold the demand until the second decode token: the first still carries the
+                    // prefill batch UNION (far larger than one decode token), which reads as infeasible.
+                    if (n_gen >= 2) sig.token_demand = (size_t) st.token_demand_bytes;
+                    if (im.swap_known && swap_ok)
+                        sig.swap_delta = (int64_t) swap_bytes_now - (int64_t) im.prev_swap_bytes;
+                }
                 const CacheGovernor::Decision d = im.gov->on_token(sig);
+                if (moe.cache_gov2) {
+                    // Apply the mode BEFORE the budget: a demotion makes the budget moot, and a
+                    // promotion must switch to LRU before the new budget is set on it.
+                    if (d.mode == CacheGovernor::Mode::slots)
+                        im.source.set_cache_mode(ExpertStreamSource::CacheMode::SharedSlot);
+                    else if (d.mode == CacheGovernor::Mode::lru)
+                        im.source.set_cache_mode(ExpertStreamSource::CacheMode::Lru);
+                    if (d.rewarm_dense) im.source.rewarm_dense();
+                }
                 if (d.changed) im.source.set_cache_budget(d.cap);
+                m.gov_state = (int) im.gov->state();
+                m.gov_war = (int) im.gov->war();
+            }
+            if (swap_ok) {
+                im.prev_swap_bytes = swap_bytes_now;
+                im.swap_known = true;
             }
         } else {
             m.compute_ms = m.wall_ms;

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -22,10 +22,10 @@ public:
         std::fprintf(f_, "# model=%s arch=%s n_layer=%d n_expert=%d n_expert_used=%d threads=%d n_ctx=%d\n",
                      r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx);
         std::fprintf(f_,
-                     "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d cache_dynamic=%d force_cache=%d "
-                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d warm_dense=%d\n",
-                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.cache_dynamic, r.force_cache,
-                     r.io_threads, r.o_direct, r.overlap, r.prefetch_layers, r.warm_dense);
+                     "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d cache_dynamic=%d cache_gov2=%d "
+                     "force_cache=%d io_threads=%d o_direct=%d overlap=%d prefetch=%d warm_dense=%d\n",
+                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.cache_dynamic, r.cache_gov2,
+                     r.force_cache, r.io_threads, r.o_direct, r.overlap, r.prefetch_layers, r.warm_dense);
         write_header();
     }
 
@@ -33,11 +33,12 @@ public:
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f\n",
+                     "%.1f,%.1f,%.1f,%d,%d\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms, m.resident_frac,
                      m.dense_resident_frac, m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib,
-                     m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib);
+                     m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib, m.gov_state,
+                     m.gov_war);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -72,7 +73,7 @@ private:
         // (how much of the cache the kernel still has; -1 = unmeasured), then the memory block.
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
                          "resident_frac,dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,"
-                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib\n");
+                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib,gov_state,gov_war\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/core/src/moe/cache_governor.cpp
+++ b/core/src/moe/cache_governor.cpp
@@ -1,12 +1,24 @@
 #include "bmoe/cache_governor.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace bmoe {
 
+namespace {
+// The upper bound configuration puts on the budget: an explicit cap, else the physical expert set,
+// else unbounded. Used wherever v1 wrote p_.user_cap directly, so a 0 user_cap means "no config cap".
+size_t config_hi(const CacheGovernorParams & p) {
+    if (p.user_cap) return p.user_cap;
+    if (p.phys_cap) return p.phys_cap;
+    return CacheGovernor::no_ceiling;
+}
+} // namespace
+
 CacheGovernor::CacheGovernor(const CacheGovernorParams & p) : p_(p) {
-    cap_ = std::min(p_.initial, p_.user_cap);
-    cap_ = std::max(cap_, std::min(p_.min_cap, p_.user_cap));
+    const size_t hi = config_hi(p_);
+    cap_ = std::min(p_.initial, hi);
+    cap_ = std::max(cap_, std::min(p_.min_cap, hi));
     // The cooldown paces cuts APART; it must not delay the first one. Starting it spent lets the
     // very first token act — which is the token that matters most, because a session opened onto an
     // already-pressured device is in the war before it generates anything.
@@ -15,75 +27,257 @@ CacheGovernor::CacheGovernor(const CacheGovernorParams & p) : p_(p) {
 
 // The mechanical floor: the largest layer we must be able to stage, once the streamer has measured
 // it, and the configured minimum until then. Deliberately NOT one token's working set — see the
-// note in the header. Never above the cap the user allowed.
+// note in the header. Never above the cap configuration allowed.
 size_t CacheGovernor::floor_of(const CacheSignals & s) const {
-    return std::min(s.floor ? s.floor : p_.min_cap, p_.user_cap);
+    return std::min(s.floor ? s.floor : p_.min_cap, config_hi(p_));
 }
 
-// Grow freely up to the user's cap, but stay a margin below any budget already known to provoke
-// reclaim — re-touching the ceiling just to be cut again is a war with extra steps.
-size_t CacheGovernor::grow_limit() const {
-    if (ceiling_ == no_ceiling) return p_.user_cap;
-    return std::min(p_.user_cap, (size_t) ((double) ceiling_ * p_.ceiling_retreat));
+// Grow freely up to the configured cap, but stay below any budget already known to provoke reclaim,
+// the physical set size, and the hit-rate plateau. Re-touching a bound just to be cut again is a war
+// with extra steps.
+size_t CacheGovernor::grow_limit(const CacheSignals & /*s*/) const {
+    size_t lim = config_hi(p_);
+    if (ceiling_ != no_ceiling) lim = std::min(lim, (size_t) ((double) ceiling_ * p_.ceiling_retreat));
+    if (plateau_cap_ != no_ceiling) lim = std::min(lim, plateau_cap_);
+    return lim;
+}
+
+// The device will not concede a cache big enough to hold one token's demand, so no budget it allows
+// can earn hits — the cache is pure churn. A rare clean fast-path to demotion; the workhorse is the
+// unrelieved-war test. Needs a decode-measured demand and a device reading (both 0 in unit tests
+// with default signals, so this stays inert there).
+bool CacheGovernor::infeasible(const CacheSignals & s) const {
+    if (s.token_demand == 0 || s.mem_available == 0) return false;
+    const size_t room = s.mem_available > p_.floor_headroom ? (size_t) (s.mem_available - p_.floor_headroom) : 0;
+    const size_t sustainable = cap_ + room; // the largest cache the device would concede right now
+    return s.token_demand > sustainable;
+}
+
+CacheGovernor::War CacheGovernor::classify(const CacheSignals & s, bool & swap_rising, bool & dense_declining) {
+    // Swap EWMA: only positive deltas (fresh compression of our anon memory) feed it; a calm token's
+    // zero or negative delta decays it back down.
+    const double inc = s.swap_delta > 0 ? (double) s.swap_delta : 0.0;
+    swap_ewma_ = 0.5 * swap_ewma_ + 0.5 * inc;
+    // A single large jump is a war on the spot (the kernel swaps a chunk at once); the EWMA catches
+    // a slower, sustained climb the raw delta alone would miss.
+    swap_rising = s.swap_delta > (int64_t) p_.swap_margin || swap_ewma_ > (double) p_.swap_margin;
+
+    // Dense plateau: the running high-watermark of what the model's working set normally holds, so a
+    // decline is judged relative to THIS model on THIS device, not an absolute the sensor never hits.
+    if (s.dense_resident_frac >= 0.0) {
+        if (dense_plateau_ < 0.0 || s.dense_resident_frac > dense_plateau_) dense_plateau_ = s.dense_resident_frac;
+        ++dense_samples_;
+    }
+    dense_declining = s.dense_resident_frac >= 0.0 && dense_plateau_ >= 0.0 && dense_samples_ >= 4 &&
+                      s.dense_resident_frac < dense_plateau_ * p_.dense_decline;
+
+    const bool resident_sampled = s.resident_frac >= 0.0;
+    const bool cache_reclaim = resident_sampled && s.resident_frac < p_.resident_min;
+    const bool cache_fine = resident_sampled && s.resident_frac >= p_.resident_min;
+    const bool fault_reflex =
+        baseline_ >= 0.0 && (double) s.majflt > baseline_ * p_.fault_ratio + (double) p_.fault_margin;
+
+    // Order is deliberate: a directly observed cache reclaim first (no baseline needed), then the
+    // dense war (an early warning that fires on the residency dip, before the faults pile up), then
+    // the anon war (swap climbing under a fault load), then the reflex as a proxy for cache reclaim
+    // when we could not sample it, and finally faults we can prove are not ours.
+    if (cache_reclaim) return War::cache;
+    if (dense_declining) return War::dense;
+    if (swap_rising && fault_reflex) return War::anon;
+    if (fault_reflex && !cache_fine) return War::cache; // faults, cache not provably resident → assume ours
+    if (fault_reflex) return War::foreign;              // faults, cache demonstrably resident → someone else
+    return War::none;
+}
+
+// Measure the hit rate over the interval just ended (at the current cap) against the previous one.
+// Called just before a grow: if the extra budget of the last step stopped buying hits, freeze here.
+void CacheGovernor::plateau_on_grow(const CacheSignals & s) {
+    if (grow_sampled_) {
+        const long long dl = s.cache_lookups - grow_lookups_;
+        if (dl > 0) {
+            const double h = (double) (s.cache_hits - grow_hits_) / (double) dl;
+            if (prev_hitrate_ >= 0.0) {
+                const double noise = 2.0 * std::sqrt(std::max(0.0, h * (1.0 - h)) / (double) dl);
+                if (h - prev_hitrate_ <= noise) {
+                    if (++plateau_miss_ >= p_.plateau_confirm) plateau_cap_ = cap_; // more RAM stopped earning
+                } else {
+                    plateau_miss_ = 0;
+                }
+            }
+            prev_hitrate_ = h;
+        }
+    }
+    grow_hits_ = s.cache_hits;
+    grow_lookups_ = s.cache_lookups;
+    grow_sampled_ = true;
+}
+
+CacheGovernor::Decision CacheGovernor::demote() {
+    state_ = State::off;
+    rearm_ok_ = 0;
+    since_rearm_probe_ = 0;
+    // No dense re-warm here: measured, the memory war has hysteresis. Once the war has pushed the
+    // dense weights off the kernel's active list, the slot-mode read churn reclaims them again before
+    // a re-warm's pages can be re-referenced, so restoring them cannot win (the refuted PR #28). The
+    // only cure is prevention — not entering the war — which is why demoting mid-war on a >RAM
+    // no-reuse model recovers poorly and cache-off from cold is the real ceiling for such a model.
+    // cap_ is kept as the last LRU budget so re-arm has a level to return toward.
+    return {cap_, false, Mode::slots, false};
+}
+
+CacheGovernor::Decision CacheGovernor::off_tick(const CacheSignals & s) {
+    war_ = War::none;
+    if (++since_rearm_probe_ < p_.probe_every) return {cap_, false, Mode::keep, false};
+    since_rearm_probe_ = 0;
+    bool ok = false;
+    if (s.mem_available > 0 && s.token_demand > 0) {
+        const size_t room = s.mem_available > p_.floor_headroom ? (size_t) (s.mem_available - p_.floor_headroom) : 0;
+        ok = (double) room > (double) s.token_demand * p_.rearm_margin;
+    }
+    if (ok) {
+        if (++rearm_ok_ >= p_.rearm_persist) return promote(s);
+    } else {
+        rearm_ok_ = 0;
+    }
+    return {cap_, false, Mode::keep, false};
+}
+
+CacheGovernor::Decision CacheGovernor::promote(const CacheSignals & s) {
+    state_ = State::on;
+    war_ = War::none;
+    ceiling_ = no_ceiling;
+    plateau_cap_ = no_ceiling;
+    calm_ = 0;
+    since_cut_ = p_.cut_cooldown;
+    war_cuts_ = 0;
+    rewarmed_ = false;
+    grow_sampled_ = false;
+    prev_hitrate_ = -1.0;
+    plateau_miss_ = 0;
+    below_demand_ = 0;
+    hr_win_ = 0;
+    hr_grace_ = 2;
+    fault_ewma_ = 0.0;
+    // Restart the LRU at a demand-sized budget within the room we just confirmed, then climb by
+    // utility. Never below the mechanical floor.
+    const size_t room = s.mem_available > p_.floor_headroom ? (size_t) (s.mem_available - p_.floor_headroom) : 0;
+    cap_ = std::max(floor_of(s), std::min(cap_, room ? room : cap_));
+    return {cap_, true, Mode::lru, false};
 }
 
 CacheGovernor::Decision CacheGovernor::on_token(const CacheSignals & s) {
     if (since_cut_ < p_.cut_cooldown) ++since_cut_;
 
-    // Residency first: it is absolute (our pages are either in RAM or they are not), so it needs
-    // no baseline and cannot be fooled by faults that belong to someone else's memory. The fault
-    // reflex only covers the tokens between samples, and only once a calm baseline exists to
-    // compare against — without one, every value looks extreme.
-    const bool sampled = s.resident_frac >= 0.0;
-    bool pressure = false;
-    if (sampled && s.resident_frac < p_.resident_min) {
-        pressure = true;
-    } else if (baseline_ >= 0.0 && (double) s.majflt > baseline_ * p_.fault_ratio + (double) p_.fault_margin) {
-        pressure = true;
-    }
+    if (state_ == State::off) return off_tick(s);
 
+    bool swap_rising = false, dense_declining = false;
+    war_ = classify(s, swap_rising, dense_declining);
     const size_t floor = floor_of(s);
 
-    if (pressure) {
+    // Feasibility fast-path: if the device will not concede a cache large enough to hold one token's
+    // demand, no allowed budget can earn hits and the churn is pure cost — go straight to slots
+    // rather than fight a war for a cache that cannot work. Inert until a decode demand is known.
+    if (infeasible(s)) return demote();
+
+    // Utility demote — the direct, measured read of "the cache is not earning", which the fault
+    // reflex (baseline can't calibrate in a never-calm war) and the MemAvailable feasibility test can
+    // both miss. Two independent triggers, either sufficient:
+    //   (a) a cut has driven the budget below one token's demand: it holds nothing between tokens; or
+    //   (b) a window of near-zero hit rate: the model has no reuse the cache can exploit.
+    // Either way the LRU is pure commit/evict churn, and slot mode (no churn) is strictly better.
+    fault_ewma_ = p_.fault_ewma_decay * fault_ewma_ + (1.0 - p_.fault_ewma_decay) * (double) s.majflt;
+    if (s.token_demand > 0) {
+        if (ceiling_ != no_ceiling && cap_ < s.token_demand) {
+            if (++below_demand_ >= p_.demote_after) return demote();
+        } else {
+            below_demand_ = 0;
+        }
+        if (++hr_win_ >= p_.demote_window && s.cache_lookups > hr_lookups0_) {
+            const long long dl = s.cache_lookups - hr_lookups0_;
+            const double hr = (double) (s.cache_hits - hr_hits0_) / (double) dl;
+            hr_hits0_ = s.cache_hits;
+            hr_lookups0_ = s.cache_lookups;
+            hr_win_ = 0;
+            if (hr_grace_ > 0)
+                --hr_grace_; // skip the warm-up windows: the cache is still filling, hits are low anyway
+            else if (hr < p_.demote_hit_floor || fault_ewma_ > (double) p_.war_fault_abs)
+                return demote(); // earns almost nothing, or a sustained fault war cutting cannot end
+        }
+    }
+
+    const bool cutting_war = war_ == War::cache || war_ == War::dense || war_ == War::anon;
+
+    if (cutting_war) {
         calm_ = 0;
-        // Keep cutting for as long as the device keeps taking memory, all the way down to the
-        // mechanical floor. There is no budget worth defending against a kernel that will not
-        // concede it: the hits a smaller cache gives up are bounded, the war is not.
+        grow_sampled_ = false; // the plateau baseline is stale once a war moves the cap
+        Decision d{cap_, false, Mode::keep, false};
+
         if (since_cut_ >= p_.cut_cooldown && cap_ > floor) {
             ceiling_ = cap_;
-            cap_ = std::max((size_t) ((double) cap_ * p_.cut_factor), floor);
+            const double f = war_ == War::anon ? p_.cut_factor_hard : p_.cut_factor;
+            cap_ = std::max((size_t) ((double) cap_ * f), floor);
             since_cut_ = 0;
             ++cuts_;
-            return {cap_, true};
+            ++war_cuts_;
+            d = {cap_, true, Mode::keep, false};
+            if (war_ == War::dense && !rewarmed_) {
+                d.rewarm_dense = true;
+                rewarmed_ = true;
+            }
         }
-        return {cap_, false};
+
+        // Demote when cutting cannot end the war. The anon/zram war is churn the LRU itself feeds, so
+        // cutting only slows the bleed; measured, it survived repeated cuts to the floor while slot
+        // mode ended it. Also demote on the clean feasibility fast-path.
+        const bool churn_war = war_ == War::anon;
+        const bool at_floor = cap_ <= floor;
+        if ((churn_war && war_cuts_ >= p_.demote_after) || (churn_war && at_floor && war_cuts_ >= 1)) return demote();
+        return d;
     }
 
-    // Calm. Learn what this device's quiet fault rate looks like, so the reflex is calibrated to
-    // it rather than to a number we guessed. Only calm tokens feed the baseline — sampling a storm
-    // would teach the loop that the storm is normal.
-    baseline_ = baseline_ < 0.0 ? (double) s.majflt
-                                : p_.baseline_decay * baseline_ + (1.0 - p_.baseline_decay) * (double) s.majflt;
+    // ── not a war we cut for ──
+    war_cuts_ = 0;
+    rewarmed_ = false;
 
-    if (++calm_ < p_.calm_tokens) return {cap_, false};
-
-    const size_t limit = grow_limit();
-    if (cap_ < limit) {
-        cap_ = std::min(cap_ + p_.grow_step, limit);
+    if (war_ == War::foreign) {
+        // Faults, but our cache and the dense weights are demonstrably resident — the load is the
+        // device's, not ours. Absorb it into the baseline so we stop re-flagging it, but do not grow
+        // this token: someone else is under pressure and growing would join their war.
+        baseline_ = baseline_ < 0.0 ? (double) s.majflt
+                                    : p_.baseline_decay * baseline_ + (1.0 - p_.baseline_decay) * (double) s.majflt;
         calm_ = 0;
-        since_probe_ = 0;
-        return {cap_, true};
+        return {cap_, false, Mode::keep, false};
     }
 
-    // Pinned at a remembered ceiling and calm for a long time: the concession may have moved (a
-    // background app exited, the user left the camera). Forget the ceiling and let ordinary growth
-    // re-discover it. Being wrong costs exactly one cut, which is the price of not staying small
-    // forever because of one bad minute.
-    if (ceiling_ != no_ceiling && ++since_probe_ >= p_.probe_after) {
+    // Calm. Learn the quiet fault rate, but never from a token whose swap or dense already say a war
+    // is brewing even if the fault reflex has not caught up — that is the baseline-poisoning fix.
+    if (!swap_rising && !dense_declining)
+        baseline_ = baseline_ < 0.0 ? (double) s.majflt
+                                    : p_.baseline_decay * baseline_ + (1.0 - p_.baseline_decay) * (double) s.majflt;
+
+    if (++calm_ < p_.calm_tokens) return {cap_, false, Mode::keep, false};
+
+    size_t limit = grow_limit(s);
+    const bool room = s.mem_available == 0 || s.mem_available > p_.floor_headroom + p_.grow_step;
+    if (cap_ < limit && room) {
+        plateau_on_grow(s); // may lower plateau_cap_ and thus the limit
+        limit = grow_limit(s);
+        if (cap_ < limit) {
+            cap_ = std::min(cap_ + p_.grow_step, limit);
+            calm_ = 0;
+            since_probe_ = 0;
+            return {cap_, true, Mode::keep, false};
+        }
+    }
+
+    // Pinned (at a ceiling, a plateau, the physical size, or out of headroom) and calm for a long
+    // time: the concession may have moved. Forget the learned bounds and let growth re-test them.
+    if ((ceiling_ != no_ceiling || plateau_cap_ != no_ceiling) && ++since_probe_ >= p_.probe_after) {
         since_probe_ = 0;
         ceiling_ = no_ceiling;
+        plateau_cap_ = no_ceiling;
     }
-    return {cap_, false};
+    return {cap_, false, Mode::keep, false};
 }
 
 } // namespace bmoe

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -55,8 +55,10 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         }
     }
     size_t max_full_any = 0;
-    for (int p = 0; p < MoeRecipe::max_exps; ++p)
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
         max_full_any = std::max(max_full_any, max_full[p]);
+        max_full_[p] = max_full[p]; // kept for a lazy slot allocation on a runtime demotion
+    }
     if (max_full_any == 0) {
         std::fprintf(stderr, "bmoe: no MoE layers were bound\n");
         return false;
@@ -91,6 +93,12 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         }
         cache_target_ = cache_max_;
     }
+
+    // The runtime residency mode, decided AFTER auto-sizing has set the final cache_max_ (with
+    // --cache-mb auto the budget is 0 until the block above computes it, so this must follow it —
+    // deciding it earlier stranded the auto path in slot mode with unallocated slots). The governor
+    // can flip it later (demote LRU → slots, or promote back).
+    slot_mode_ = cache_max_ == 0;
 
     if (cache_max_ == 0) {
         // One shared slot per present projection, reused across layers (one layer computes
@@ -471,7 +479,7 @@ void ExpertStreamSource::io_worker(int lane) {
 // Prefetch: on the eval thread, commit pages and enqueue speculative per-projection reads for the
 // given experts of layer il. LRU-safe (same thread as load_layer); workers only read the bytes.
 void ExpertStreamSource::prefetch(int il, const int32_t * ids, int n_ids) {
-    if (!active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0) return;
+    if (!active_ || slot_mode_ || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0) return;
     const LayerExperts & L = layers_[il];
     bool any = false;
     std::lock_guard<std::mutex> lk(io_mtx_);
@@ -707,7 +715,12 @@ void ExpertStreamSource::account_demand(int il, int n_unique) {
 // Explicit budget change from outside a decode (memory-pressure callback, the governor, or the
 // shrink gate).
 void ExpertStreamSource::set_cache_budget(size_t bytes) {
-    if (cache_max_ == 0) return; // initialised off (shared-slot mode); the LRU buffers do not exist
+    if (slot_mode_) {
+        // No LRU to size in slot mode. Remember the request so a later promotion has a budget to
+        // return to, but evict nothing — nothing is resident here.
+        cache_max_ = std::min(bytes, total_expert_bytes_);
+        return;
+    }
     if (bytes > cache_max_) {
         // Growing evicts nothing, so it needs no quiesce — and must not do one: cancelling the
         // speculative reads in flight on every grow would quietly defeat --prefetch.
@@ -727,6 +740,69 @@ void ExpertStreamSource::set_cache_budget(size_t bytes) {
     // every resident entry (coldest first) is a valid eviction target.
     while (cresident_ > cache_max_ && ctail_ != -1)
         evict_tail();
+}
+
+// Switch residency policy at a token boundary. PRECONDITION: no decode in flight. This is the
+// governor's OFF/ON lever: on a >RAM model where the LRU can earn no hits and its commit/evict churn
+// feeds the reclaim war, demoting to shared slots removes that churn entirely; promoting back rebinds
+// onto the reserved per-layer buffers when the device concedes the room again.
+bool ExpertStreamSource::set_cache_mode(CacheMode m) {
+    if (!active_) return false;
+    const bool want_slot = m == CacheMode::SharedSlot;
+    if (want_slot == slot_mode_) return true; // already there
+
+    // Drain any in-flight batch (an overlap decode leaves the last layer's surplus reads running)
+    // and quiesce speculation, so no worker is mid-write into either buffer family when we rebind.
+    {
+        std::unique_lock<std::mutex> lk(io_mtx_);
+        io_cv_done_.wait(lk, [&] { return done_cnt_ == batch_njobs_ || io_stop_; });
+    }
+    quiesce_spec();
+
+    if (want_slot) {
+        // Lazily allocate the shared slots on the first demotion and keep them for the session.
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            if (max_full_[p] == 0 || slot_[p]) continue;
+            slot_[p] = pio::alloc_aligned(align_, max_full_[p]);
+            if (!slot_[p]) {
+                std::fprintf(stderr, "bmoe: slot alloc %zu failed on demote — staying in LRU mode\n", max_full_[p]);
+                return false; // leave the mode unchanged rather than half-switched
+            }
+            slot_sz_[p] = max_full_[p];
+        }
+        // Release every resident LRU entry (physical pages back to the OS); the address reservations
+        // stay, so a later promotion can re-commit into them.
+        while (ctail_ != -1)
+            evict_tail();
+        // Rebind every bound layer's expert tensors onto the shared slots.
+        for (LayerExperts & L : layers_) {
+            if (!L.bound) continue;
+            for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                if (L.proj[p].tensor) L.proj[p].tensor->data = slot_[p];
+        }
+        // Reset LRU bookkeeping coherently: nothing resident, and the stamps refer to the old epoch.
+        std::fill(cstamp_.begin(), cstamp_.end(), (uint32_t) 0);
+        chead_ = ctail_ = -1;
+        cresident_ = 0;
+        resident_frac_ = -1.0; // there is no LRU to sample while in slot mode
+        slot_mode_ = true;
+    } else {
+        // Promote: rebind onto the per-(layer, projection) reserved buffers. The LRU is already empty
+        // (left so on the demotion, or fresh from init), so there is no bookkeeping to rebuild.
+        for (int il = 0; il < n_layer_; ++il) {
+            LayerExperts & L = layers_[il];
+            if (!L.bound) continue;
+            for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                if (L.proj[p].tensor && lbuf_[p][il]) L.proj[p].tensor->data = lbuf_[p][il];
+        }
+        slot_mode_ = false;
+    }
+    ++cache_resizes_;
+    return true;
+}
+
+void ExpertStreamSource::rewarm_dense() {
+    if (active_) warm_dense_regions(gguf_path_);
 }
 
 // ── LRU plumbing ────────────────────────────────────────────────────────────────────
@@ -797,14 +873,14 @@ void ExpertStreamSource::settle_spec() {
     // makes the one inside the load_layer that follows a cheap no-op: nothing left queued, and
     // nothing in flight. The cost is that its time lands outside the mgmt_ns_ window — which is
     // why a traced run is not a benchmark run.
-    if (active_ && cache_max_) quiesce_spec();
+    if (active_ && !slot_mode_) quiesce_spec();
 }
 
 void ExpertStreamSource::query_residency(int il, const int32_t * ids, int n_ids, uint8_t * out) const {
     for (int i = 0; i < n_ids; ++i)
         out[i] = 0;
     if (!active_ || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids) return;
-    if (cache_max_ == 0) return; // shared-slot mode: nothing is kept, so every routing re-reads
+    if (slot_mode_) return; // shared-slot mode: nothing is kept, so every routing re-reads
     for (int i = 0; i < n_ids; ++i) {
         const int e = ids[i];
         if (e < 0 || e >= n_expert_) continue;
@@ -833,7 +909,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
 
     // Integrate / discard any speculative prefetch before this layer's real staging touches the
     // cache. After this returns no spec read is in flight and completed ones are resident hits.
-    if (cache_max_) {
+    if (!slot_mode_) {
         quiesce_spec();
         // Exactly one hand on the budget: with the governor on it owns cache_max_ (from the token
         // loop, where an evicting shrink is safe) and we only sense here; otherwise the legacy
@@ -847,7 +923,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     }
 
     auto stage = [&](int e) -> bool {
-        if (cache_max_ == 0) {
+        if (slot_mode_) {
             for (int p = 0; p < MoeRecipe::max_exps; ++p) {
                 const uint64_t slice = L.proj[p].nb2;
                 if (slice == 0) continue; // absent slot in a fused layout
@@ -900,7 +976,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
             // keeps the prompt tail's experts hot across prefill. Reads are scheduled only once
             // (the seen_ guard below), so this is bookkeeping only. In decode (n=1) the top-k ids
             // are distinct, so this branch never runs and behaviour is unchanged.
-            if (cache_max_) {
+            if (!slot_mode_) {
                 const int32_t id = il * n_expert_ + e;
                 lru_unlink(id);
                 lru_push_front(id);
@@ -949,7 +1025,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     }
     read_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
 
-    if (cache_max_) {
+    if (!slot_mode_) {
         const auto te0 = clock_t_::now();
         while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
             evict_tail();
@@ -986,7 +1062,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
 
     // Integrate / discard speculative prefetch before this layer's real staging (the previous
     // batch is already drained above, so this only waits on in-flight spec reads).
-    if (cache_max_) {
+    if (!slot_mode_) {
         quiesce_spec();
         // See the serial path: the governor owns the budget when it is on, and only senses here.
         if (cache_dynamic_) {
@@ -1026,7 +1102,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
     std::sort(staged_.begin(), staged_.end());
     account_demand(il, (int) staged_.size());
 
-    if (cache_max_ == 0) {
+    if (slot_mode_) {
         // Cache off: every (projection, expert) is a fresh read into the shared full-size slot
         // at its canonical offset e*slice. Emit projection-major.
         for (int p = 0; p < MoeRecipe::max_exps; ++p) {
@@ -1120,7 +1196,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
     // 5. Evict cold entries to budget. Safe to run concurrently with this batch's reads: step 1
     //    guaranteed no stale in-flight jobs, and current-gen entries (cstamp_ == cgen_) — the
     //    ones just staged — are never chosen, so eviction only releases pages nobody is reading.
-    if (cache_max_) {
+    if (!slot_mode_) {
         while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
             evict_tail();
     }
@@ -1196,12 +1272,15 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     s.cache_lookups = clookups_;
     s.cache_resident_bytes = (uint64_t) cresident_;
     s.stall_seconds = stall_ns_.load() / 1e9;
-    s.cache_budget_bytes = (uint64_t) cache_max_;
+    // In slot mode the effective budget is zero (no cache), whatever cache_max_ remembers for a
+    // possible promotion — report it honestly so the telemetry reads the run as cache-off.
+    s.cache_budget_bytes = slot_mode_ ? 0 : (uint64_t) cache_max_;
     s.cache_resizes = cache_resizes_;
     s.cache_resident_frac = resident_frac_;
     s.dense_resident_frac = dense_resident_frac_;
     s.token_demand_bytes = (uint64_t) token_demand_;
     s.layer_demand_bytes = (uint64_t) layer_demand_;
+    s.total_expert_bytes = (uint64_t) total_expert_bytes_;
     return s;
 }
 

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -86,6 +86,22 @@ public:
     // and exercised by the shrink gate. Clamped up: an explicit raise also lifts the grow ceiling.
     void set_cache_budget(size_t bytes);
 
+    // The cache's residency policy, switchable at a token boundary by the governor's OFF/ON state.
+    enum class CacheMode { Lru, SharedSlot };
+
+    // Switch between the LRU cache and shared-slot (no-cache) mode at runtime. PRECONDITION: no
+    // decode in flight (same contract as set_cache_budget). Drains any in-flight/speculative reads,
+    // rebinds every expert tensor onto the target buffers, and releases the LRU's resident pages on
+    // a demotion (keeping the address reservations for a later promotion). The slots are allocated
+    // lazily on the first demotion and kept for the session. Returns false on an allocation failure
+    // (the mode is left unchanged). A no-op that returns true if already in the requested mode.
+    bool set_cache_mode(CacheMode m);
+    CacheMode cache_mode() const { return slot_mode_ ? CacheMode::SharedSlot : CacheMode::Lru; }
+
+    // Re-run the dense warm-up sweep once (a governor's dense-war response). Best-effort; safe
+    // between tokens. Populates the page cache with the dense weights the kernel just reclaimed.
+    void rewarm_dense();
+
     // ── I/O trace (diagnostics; see bmoe/decode_trace.h) ────────────────────────────
     // When on, every read_slice records one row. Rows are appended under a dedicated leaf mutex
     // (reads happen on N lanes at once), so this costs a lock per read and is off by default.
@@ -185,9 +201,14 @@ private:
 
     std::vector<LayerExperts> layers_;
 
-    // shared-slot mode (cache off): one full-size slot per projection, reused by layers
+    // shared-slot mode (cache off): one full-size slot per projection, reused by layers. Chosen at
+    // init when cache_max_ == 0, and reachable at runtime when the governor demotes (slot_mode_).
+    // max_full_ is the full-tensor byte size per projection, kept so the slots can be allocated
+    // lazily on the first runtime demotion rather than only at init.
     void * slot_[MoeRecipe::max_exps] = {nullptr, nullptr, nullptr};
     size_t slot_sz_[MoeRecipe::max_exps] = {0, 0, 0};
+    size_t max_full_[MoeRecipe::max_exps] = {0, 0, 0};
+    bool slot_mode_ = false; // true = shared-slot (no LRU); the runtime mode, not just the init one
 
     // LRU mode (cache on): per-(layer, projection) reserved buffers
     size_t cache_max_ = 0; // live budget in bytes; mutated at runtime when cache_auto_

--- a/docs/adaptive-cache.md
+++ b/docs/adaptive-cache.md
@@ -66,16 +66,26 @@ the rest of the system.
 
 `auto` is a real LRU cache, so it satisfies the cache requirement of `--prefetch`.
 
+`auto` is also the natural starting point for `--cache-dynamic` and `--cache-gov2`: it makes the
+ceiling itself a measured, device-sized number rather than a hand-set one, which is what those loops
+then treat as a ceiling to shrink under and — for gov2 — to demote away from entirely when even that
+is more than the device concedes. See [pressure.md](pressure.md).
+
 ## Explicit control
 
 Embedders that link the engine can also resize the cache directly with
 `Session::set_cache_budget_mb(int)` — for an app's own memory-pressure callback. It must be called
 between generations (never during a decode); it evicts to the new budget immediately. The Android
 example instead relies on the automatic tracking above, because it runs `bmoe-cli` as a subprocess
-that reads `/proc/meminfo` itself.
+that reads `/proc/meminfo` itself. `Session::set_cache_mode_slots(bool)` is the companion for a hard
+off/on: it flips the cache between the LRU and shared-slot (no-cache) mode, the same lever the gov2
+governor pulls when it demotes.
 
 ## Gate
 
 **S3** proves a runtime resize is byte-safe: it opens a session with a warm cache, drops the budget
 to force a full eviction, and asserts the next generation still matches the resident reference —
-only residency changes, never the produced bytes.
+only residency changes, never the produced bytes. **S4** proves the same for a runtime *mode* switch:
+it flips the cache LRU → shared-slot → LRU across generations (serial and overlap) and asserts every
+generation still matches the resident reference — the byte-identity guarantee the gov2 governor's
+demote/promote rests on.

--- a/docs/pressure.md
+++ b/docs/pressure.md
@@ -111,6 +111,11 @@ knowing; it is simply not the same claim as where the cache must stop.
 Per token (`--csv`, `BMOE_PROGRESS`): `resident_frac` — the sampled fraction of the cache still in
 RAM, `-1` when unmeasured (throttled sample, streaming off, or a host that cannot report).
 
+Per token, under `--cache-gov2` also: `dense_resident_frac` (the model's own residency, `-1` when
+unmeasured), and `gov_state` (0 = LRU, 1 = demoted to slots) with `gov_war` (0 none, 1 cache, 2
+dense, 3 anon, 4 foreign) — the classifier's verdict each token. A demotion shows as `gov_state`
+flipping to 1 and `cache_budget_mib` dropping to 0.
+
 Per run (`# summary`, `BMOE_DONE`): `token_demand_MiB` (what one token demands), `layer_demand_MiB`
 (the mechanical floor), `cache_budget_MiB` (where the loop settled), `cache_cuts` (how often the
 device pushed back), `cache_resizes`.
@@ -122,6 +127,64 @@ Reading `cache_budget_MiB` against `token_demand_MiB` is how a budget stops bein
 near the demand holds about one token of routing history and its hits come from inter-token
 correlation only; a budget far above it is either buying real reuse or buying a war, and
 `cache_cuts` says which.
+
+## `--cache-gov2`: attribution, a plateau, and an off state
+
+`--cache-dynamic` cuts when it senses reclaim and grows when it does not. That is the right reflex
+for the case it was built for — the device slowly conceding a Qwen-sized cache — but three device
+runs on 2026-07-16 showed it is not enough on its own. `--cache-gov2` is the same loop plus the parts
+those runs demanded. It implies `--cache-dynamic`; the plain flag stays the A/B baseline.
+
+**The one health signal is `majflt`. Everything else only attributes it.** A fault load is the only
+evidence that pressure is *costing* something; residency and swap say *whose* pages are moving, which
+decides *which lever* to pull — but a residency that dips on cold, never-reused pages is not a
+problem, and cutting the cache is the wrong answer to a fault load that is not the cache's. So the
+governor classifies each token's pressure before it acts:
+
+| War | Signature | Action |
+|---|---|---|
+| cache | `resident_frac` below 0.90 (our anon cache is being taken) | cut ×0.7 |
+| dense | `dense_resident_frac` fell below its own plateau ×0.85 (the model's weights are going) | cut, and re-warm the dense set once |
+| anon | swap climbing under a fault load, while cache *and* dense both hold | cut ×0.5 (hard) |
+| foreign | faults, but cache and dense are demonstrably resident and swap is flat | **do not cut** — absorb it as the new calm |
+
+The foreign case is why `--cache-dynamic` alone over-cuts: measured on the new device, a run held
+`dense_resident_frac` at 1.000 while `majflt` sat in the thousands and `swap_mib` climbed 1.8 → 3.1
+GiB — the kernel was compressing our *anon* memory into zram, not touching the cache. v1 read the
+resident cache as calm, folded the 3000-fault storm into its baseline, and then *grew* mid-war. v2
+attributes it to the anon war, never poisons the baseline (a token any war signal fires on cannot
+teach the "calm" rate), and cuts hard.
+
+**Cutting is not always the answer — sometimes the cache has to turn off.** On a >RAM model one token
+routes more than the device will ever hold (gpt-oss at top-4: `token_demand_MiB` 1815), so the LRU
+earns no hits at any allowed budget *and* pays the commit/evict churn of a token's worth of pages
+every step — churn that is itself a source of the war. Measured: the governor cut that cache all the
+way to 470 MiB and the war did not end (`majflt/tok` stayed 3000–6000); a same-day `--cache-mb 0` run
+of the same model sat at `majflt/tok` ≈ 1. So the governor has a real **off state**: when an anon war
+survives repeated cuts, or a decode-measured `token_demand` exceeds what the device will concede, it
+**demotes** the cache to shared-slot mode (the byte-identical no-cache path, gates S4a–f), where the
+churn disappears. It re-arms — promotes back to the LRU — only after several probes agree the device
+has freed room for a demand-sized cache with margin.
+
+**Growth stops where hits stop.** With no configured ceiling (`--cache-mb auto` sizes the ceiling
+dynamically to `MemAvailable − floor`, itself not a constant), the budget is held by four measured
+bounds: the physical expert-set size, the learned reclaim ceiling, the device's free RAM, and a
+**hit-rate plateau** — the governor samples the hit rate at each grow step and freezes when more
+budget stops buying hits beyond two binomial standard errors. On the old device this is the
+difference between the governed run (1.64 tok/s, cuts once, then calm) and a fixed 4000 MiB run
+(same 1.64 tok/s but a permanent 1582 fault/tok war): the extra 10 points of hit rate bought nothing
+but the war.
+
+**Entry test.** Prefill runs before the governor's first tick, so a budget the device cannot sustain
+is filled — and the war started — before any decision. Measured: `--cache-mb 4000` on gpt-oss had
+`swap_mib` at 1.8 GiB by step 1. So under gov2 the *starting* budget is clamped at load to
+`entry_budget(configured, MemAvailable, floor, min_cap)` and the streamer shrunk to it before the
+first prefill token. `MemAvailable` overstates the room (it counts our own weights as free), so this
+is a clamp, not an authority — the runtime loop still discovers the true concession.
+
+None of this hard-codes a model or a device: `token_demand` and the hit rate are measured, the four
+bounds are measured or configured, and the same machine routes Qwen to a 2.8 GiB cache and gpt-oss to
+the off state on the *same* phone, purely on the numbers.
 
 ## Portability
 
@@ -139,9 +202,12 @@ governor and the actuator do not change.
 
 Off by default, and the app exposes it as a switch ("Pressure-aware cache sizing"). It stays off
 until the on-device A/B says otherwise — the same discipline that turned the rewarm pass off after
-it was measured. The tunables (0.90 residency, ×3 faults, ×0.7 cut, 64 MiB growth) are compiled in
-rather than exposed: they are control-loop policy, not per-device facts, and the loop discovers the
-device's concession at runtime regardless.
+it was measured. `--cache-gov2` (attribution, the plateau, and the off state) is a second, likewise
+default-off switch, promoted per model+device by the A/B: Qwen and Gemma must not regress from their
+~5 tok/s benchmark, and gpt-oss must reach the off state and match a hand-set `--cache-mb 0`. The
+tunables (0.90 residency, ×3 faults, ×0.7 cut, 64 MiB growth, and gov2's ×0.5 anon cut, 0.85 dense
+decline, 3-cut demote) are compiled in rather than exposed: they are control-loop policy, not
+per-device facts, and the loop discovers the device's concession at runtime regardless.
 
 See also: [android-memory.md](android-memory.md) for what reclaims the engine's memory and which
 levers exist, [adaptive-cache.md](adaptive-cache.md) for `--cache-mb auto` and the ceiling.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -106,7 +106,7 @@ prints just the summary lines.
 ```
 step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,resident_frac,
 dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,
-mem_available_mib,mem_free_mib,swap_free_mib
+mem_available_mib,mem_free_mib,swap_free_mib,gov_state,gov_war
 ```
 
 followed by a `# summary ...` comment line. Intended for the benchmark sweep.
@@ -137,8 +137,9 @@ The trailing block is the memory picture, added so a run can be diagnosed from i
 | `swap_mib` | anonymous memory already lost to zram (`VmSwap`). |
 | `rss_mib` | total resident (`VmRSS`). |
 | `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |
+| `gov_state` / `gov_war` | `--cache-gov2` only, else `0`. `gov_state`: 0 = LRU, 1 = demoted to shared slots (the off state). `gov_war`: what the governor attributed this token's pressure to — 0 none, 1 cache, 2 dense, 3 anon, 4 foreign. A demotion reads as `gov_state` → 1 with `cache_budget_mib` → 0. See [pressure.md](pressure.md). |
 
-All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split).
+All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split). The `# bmoe_metrics` preamble also gains `cache_gov2=<0|1>`.
 
 ## Route trace
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -76,8 +76,12 @@ data class AppSettings(
             // Auto sizing is a live LRU cache, so it satisfies the prefetch cache requirement.
             val cacheOn = cacheMb == CACHE_AUTO || cacheMb > 0
             if (prefetchLayers > 0 && cacheOn) a += listOf("--prefetch", prefetchLayers.toString())
-            // Same requirement: there is no budget to size at runtime with the cache off.
-            if (cacheDynamic && cacheOn) a += "--cache-dynamic"
+            // Same requirement: there is no budget to size at runtime with the cache off. The
+            // "pressure-aware cache" toggle now drives the second-generation governor (--cache-gov2,
+            // which implies --cache-dynamic): it discovers the budget, attributes reclaim to its
+            // cause, and demotes the cache to slot mode on a >RAM model where cutting cannot end the
+            // war — so a hand-set ceiling is no longer needed to keep it sane. See docs/pressure.md.
+            if (cacheDynamic && cacheOn) a += "--cache-gov2"
         }
         return a
     }

--- a/tests/cache_governor_test.cpp
+++ b/tests/cache_governor_test.cpp
@@ -7,6 +7,7 @@
 
 #include "bmoe/cache_governor.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -235,6 +236,313 @@ void test_degenerate_caps() {
     check(g2.cap() == 200 * MiB, "a floor above the cap pins the budget at the cap");
 }
 
+// ── governor v2: attribution, demotion, plateau, entry test ──
+// The new signals default to inert values (dense/swap/demand/mem all 0 or -1) so the v1 scenarios
+// above exercise pure AIMD unchanged; these drive the new fields to reach the new behaviour.
+
+constexpr size_t GiB = 1024ull * MiB;
+
+// Learn a quiet baseline: a handful of calm, fully-resident, fault-light tokens.
+void learn_calm(CacheGovernor & g, int n = 8, uint64_t majflt = 10) {
+    for (int i = 0; i < n; ++i) {
+        CacheSignals s = calm();
+        s.majflt = majflt;
+        g.on_token(s);
+    }
+}
+
+// Regression (R1, device new): an anon/zram war — high faults, swap climbing — while the cache and
+// the dense weights are BOTH fully resident. v1 read the resident cache as "calm" and absorbed the
+// 3000-fault storm into its baseline, then grew mid-war. v2 must attribute it to the anon war, never
+// poison the baseline, and never grow.
+void test_anon_war_does_not_poison_baseline_or_grow() {
+    CacheGovernorParams p = params(4000 * MiB, 2000 * MiB);
+    p.calm_tokens = 4;
+    CacheGovernor g(p);
+    learn_calm(g);
+    const double calm_baseline = g.baseline();
+
+    const size_t cap_before_war = g.cap();
+    size_t max_cap = cap_before_war;
+    for (int i = 0; i < 200; ++i) {
+        CacheSignals s;
+        s.resident_frac = 1.0;             // our cache is resident…
+        s.dense_resident_frac = 1.0;       // …and so are the dense weights
+        s.swap_delta = 40 * (int64_t) MiB; // but the kernel is compressing our anon memory
+        s.majflt = 3000;                   // which we re-fault
+        s.floor = 50 * MiB;
+        g.on_token(s);
+        max_cap = g.cap() > max_cap ? g.cap() : max_cap;
+    }
+    check(g.baseline() < calm_baseline + 50.0, "an anon war never poisons the calm baseline");
+    check(max_cap <= cap_before_war, "the governor never grows into an anon war");
+    check(g.war() == CacheGovernor::War::anon || g.state() == CacheGovernor::State::off,
+          "the war is attributed to anon (or already demoted)");
+}
+
+// Regression (R4): the anon war survives cutting — measured, cuts to 470 MiB left it burning. The
+// governor must stop cutting and DEMOTE to slot mode, where the churn that fed the war disappears.
+void test_anon_war_demotes_when_cuts_do_not_help() {
+    CacheGovernorParams p = params(4000 * MiB, 3000 * MiB);
+    CacheGovernor g(p);
+    learn_calm(g);
+
+    CacheGovernor::Decision d{};
+    bool demoted = false;
+    for (int i = 0; i < 500 && !demoted; ++i) {
+        CacheSignals s;
+        s.resident_frac = 1.0;
+        s.dense_resident_frac = 1.0;
+        s.swap_delta = 60 * (int64_t) MiB;
+        s.majflt = 5000;
+        s.floor = 50 * MiB;
+        d = g.on_token(s);
+        if (d.mode == CacheGovernor::Mode::slots) demoted = true;
+    }
+    check(demoted, "an unrelieved anon war demotes the cache to slot mode");
+    check(g.state() == CacheGovernor::State::off, "the governor is now in the off state");
+    // And once off it stays quiet — no more budget churn to feed the war.
+    for (int i = 0; i < 10; ++i) {
+        CacheSignals s;
+        s.resident_frac = 1.0;
+        s.swap_delta = 60 * (int64_t) MiB;
+        s.majflt = 5000;
+        check(!g.on_token(s).changed, "a demoted governor stops acting");
+    }
+}
+
+// A fault load whose cause is demonstrably NOT ours — cache and dense both fully resident, swap
+// flat. The governor must not cut for someone else's pressure; it absorbs the load as the new calm.
+void test_foreign_faults_do_not_cut() {
+    CacheGovernor g(params(2000 * MiB, 2000 * MiB));
+    learn_calm(g);
+    for (int i = 0; i < 500; ++i) {
+        CacheSignals s = calm();
+        s.dense_resident_frac = 1.0;
+        s.swap_delta = 0;
+        s.majflt = 500; // well above the learned baseline, but with no attributable cause
+        check(!g.on_token(s).changed, "foreign faults never cut the budget");
+    }
+    check(g.cuts() == 0, "no cuts for third-party faults");
+    check(g.state() == CacheGovernor::State::on, "and no demotion");
+}
+
+// The dense weights declining from their own plateau is an early warning — cut before the faults
+// pile up, and re-warm the dense set exactly once per episode.
+void test_dense_decline_cuts_early_and_rewarms_once() {
+    CacheGovernorParams p = params(2000 * MiB, 2000 * MiB);
+    CacheGovernor g(p);
+    // Establish a dense plateau near 0.98 over several calm tokens.
+    for (int i = 0; i < 8; ++i) {
+        CacheSignals s = calm();
+        s.majflt = 10;
+        s.dense_resident_frac = 0.98;
+        g.on_token(s);
+    }
+    int rewarms = 0;
+    bool cut = false;
+    for (int i = 0; i < 10; ++i) {
+        CacheSignals s = calm();
+        s.majflt = 100;
+        s.dense_resident_frac = 0.70; // a hard drop below plateau*0.85
+        s.floor = 50 * MiB;
+        CacheGovernor::Decision d = g.on_token(s);
+        if (d.changed) cut = true;
+        if (d.rewarm_dense) ++rewarms;
+    }
+    check(cut, "a dense-residency collapse triggers a cut");
+    check(rewarms == 1, "the dense set is re-warmed exactly once per war episode");
+    check(g.war() == CacheGovernor::War::dense, "the war is attributed to the dense weights");
+}
+
+// Feasibility: a token demands more than the device will ever concede (its whole free room, above
+// the reserve, plus the current cache, is still short). No budget can earn hits → demote at once.
+void test_infeasible_demand_demotes_immediately() {
+    CacheGovernorParams p = params(4000 * MiB, 1000 * MiB);
+    p.floor_headroom = 1536 * MiB;
+    CacheGovernor g(p);
+    CacheSignals s = calm();
+    s.token_demand = 1815 * MiB;  // one token routes this much
+    s.mem_available = 2000 * MiB; // room above the 1536 reserve is only 464 MiB
+    CacheGovernor::Decision d = g.on_token(s);
+    check(d.mode == CacheGovernor::Mode::slots, "a demand the device cannot concede demotes to slots");
+    check(g.state() == CacheGovernor::State::off, "and enters the off state");
+}
+
+// Off → on: once the device concedes room for a demand-sized cache with margin, and it holds for a
+// few probes, promote back to the LRU. A single lucky probe must not.
+void test_rearm_promotes_when_room_returns() {
+    CacheGovernorParams p = params(4000 * MiB, 1000 * MiB);
+    p.floor_headroom = 1536 * MiB;
+    p.probe_every = 2;
+    p.rearm_persist = 3;
+    CacheGovernor g(p);
+    // Demote first (infeasible).
+    {
+        CacheSignals s = calm();
+        s.token_demand = 1815 * MiB;
+        s.mem_available = 2000 * MiB;
+        g.on_token(s);
+    }
+    check(g.state() == CacheGovernor::State::off, "demoted");
+
+    // A single good probe amid bad ones must not promote.
+    auto good = [&] {
+        CacheSignals s = calm();
+        s.token_demand = 1000 * MiB;
+        s.mem_available = 4 * GiB; // room 4096-1536 = 2560 > 1000*1.25
+        return g.on_token(s);
+    };
+    auto bad = [&] {
+        CacheSignals s = calm();
+        s.token_demand = 1000 * MiB;
+        s.mem_available = 1600 * MiB; // room 64 < demand
+        return g.on_token(s);
+    };
+    for (int i = 0; i < 4; ++i) {
+        good();
+        bad();
+    }
+    check(g.state() == CacheGovernor::State::off, "an intermittent good probe does not re-arm");
+
+    // Sustained room re-arms.
+    CacheGovernor::Decision d{};
+    for (int i = 0; i < 20 && g.state() == CacheGovernor::State::off; ++i)
+        d = good();
+    check(g.state() == CacheGovernor::State::on, "sustained conceded room promotes back to the LRU");
+    check(d.mode == CacheGovernor::Mode::lru, "the promotion asks for LRU mode");
+}
+
+// The utility bound with NO configured cap (user_cap = 0): growth must stop where more budget stops
+// buying hits, not run up to the physical expert-set size.
+void test_plateau_stops_growth_without_a_configured_cap() {
+    CacheGovernorParams p;
+    p.user_cap = 0;          // unbounded by configuration
+    p.phys_cap = 4000 * MiB; // only the physical set bounds it from above
+    p.initial = 200 * MiB;
+    p.min_cap = 64 * MiB;
+    p.calm_tokens = 4;
+    p.grow_step = 64 * MiB;
+    p.plateau_confirm = 2;
+    CacheGovernor g(p);
+
+    const double SAT = 1000.0 * MiB; // hit rate saturates once the budget reaches here
+    long long hits = 0, lookups = 0;
+    for (int i = 0; i < 4000; ++i) {
+        CacheSignals s = calm();
+        const double hr = std::min(1.0, (double) g.cap() / SAT);
+        lookups += 200;
+        hits += (long long) (200.0 * hr);
+        s.cache_hits = hits;
+        s.cache_lookups = lookups;
+        g.on_token(s);
+    }
+    check(g.cap() >= 900 * MiB, "growth climbs to where hits still improve");
+    check(g.cap() <= 1300 * MiB, "and stops at the hit-rate plateau, not the physical size");
+    check(g.cap() < 2000 * MiB, "well below the 4000 MiB expert set");
+}
+
+// gpt-oss in a fault war (device CSV 2026-07-16): the fault baseline is poisoned by the cold-start
+// storm so the reflex never fires, and MemAvailable reads high so feasibility looks fine — yet the
+// budget was cut below one token's demand. The utility demote must catch it on that structural fact.
+void test_demotes_when_cut_below_token_demand() {
+    CacheGovernorParams p = params(4000 * MiB, 4000 * MiB, /*min_cap*/ 16 * MiB);
+    CacheGovernor g(p);
+    CacheGovernor::Decision d{};
+    bool demoted = false;
+    for (int i = 0; i < 200 && !demoted; ++i) {
+        CacheSignals s = reclaiming(0.5, 50 * MiB); // cache war → the governor cuts
+        s.token_demand = 1815 * MiB;                // but one token needs more than any budget it keeps
+        d = g.on_token(s);
+        if (d.mode == CacheGovernor::Mode::slots) demoted = true;
+    }
+    check(demoted, "cutting the budget below one token's demand demotes to slots");
+    check(g.state() == CacheGovernor::State::off, "and enters the off state");
+}
+
+// A model with no expert reuse: the budget is comfortably above one token's demand, the cache is
+// resident, there is no fault war — but the hit rate sits near zero because routing has no locality.
+// The cache is pure churn; the windowed-hit-rate demote must retire it.
+void test_demotes_on_near_zero_hit_rate() {
+    CacheGovernorParams p = params(4000 * MiB, 4000 * MiB);
+    p.demote_window = 4;
+    CacheGovernor g(p);
+    long long hits = 0, lookups = 0;
+    CacheGovernor::Decision d{};
+    bool demoted = false;
+    for (int i = 0; i < 100 && !demoted; ++i) {
+        CacheSignals s = calm();
+        s.token_demand = 1000 * MiB; // below the 4000 cap, so the below-demand trigger stays silent
+        lookups += 100;
+        hits += 2; // 2% hit rate: the model has no reuse the cache can exploit
+        s.cache_hits = hits;
+        s.cache_lookups = lookups;
+        d = g.on_token(s);
+        if (d.mode == CacheGovernor::Mode::slots) demoted = true;
+    }
+    check(demoted, "a sustained near-zero hit rate demotes even with budget above demand");
+    check(g.state() == CacheGovernor::State::off, "and enters the off state");
+}
+
+// gpt-oss's harder case (device CSV): budget above demand AND a middling hit rate (~15%), so neither
+// the below-demand nor the near-zero-hit trigger fires — but a sustained thousands-of-faults/token
+// war rages (the dense working set churning). The fault-load demote must catch it.
+void test_demotes_on_sustained_fault_war() {
+    CacheGovernorParams p = params(4000 * MiB, 4000 * MiB);
+    p.demote_window = 4;
+    CacheGovernor g(p);
+    long long hits = 0, lookups = 0;
+    CacheGovernor::Decision d{};
+    bool demoted = false;
+    for (int i = 0; i < 100 && !demoted; ++i) {
+        CacheSignals s;
+        s.resident_frac = 1.0;
+        s.token_demand = 1000 * MiB; // below the 4000 cap → below-demand stays silent
+        s.majflt = 12000;            // thousands of faults/token: a memory war
+        lookups += 100;
+        hits += 15; // 15% hit — above the near-zero floor, so only the fault load can catch this
+        s.cache_hits = hits;
+        s.cache_lookups = lookups;
+        d = g.on_token(s);
+        if (d.mode == CacheGovernor::Mode::slots) demoted = true;
+    }
+    check(demoted, "a sustained heavy fault war demotes even at a middling hit rate");
+    check(g.state() == CacheGovernor::State::off, "and enters the off state");
+}
+
+// A healthy booster (Qwen-like): budget above demand, climbing hit rate. It must NOT be demoted by
+// the utility triggers — the whole point is that gov2 keeps the cache where it earns its keep.
+void test_healthy_cache_is_not_demoted() {
+    CacheGovernorParams p = params(4000 * MiB, 3000 * MiB);
+    p.demote_window = 4;
+    CacheGovernor g(p);
+    long long hits = 0, lookups = 0;
+    for (int i = 0; i < 300; ++i) {
+        CacheSignals s = calm();
+        s.token_demand = 1000 * MiB; // well below the budget
+        lookups += 100;
+        hits += 45; // 45% hit rate — the cache is clearly earning
+        s.cache_hits = hits;
+        s.cache_lookups = lookups;
+        check(g.on_token(s).mode != CacheGovernor::Mode::slots, "a cache earning 45% hits is never demoted");
+    }
+    check(g.state() == CacheGovernor::State::on, "the healthy cache stays on");
+}
+
+void test_entry_budget_helper() {
+    // Unknown available memory → trust the configured budget.
+    check(entry_budget(2000 * MiB, 0, 1536 * MiB, 64 * MiB) == 2000 * MiB, "unknown avail keeps the configured budget");
+    // Ample memory → configured fits under (avail - floor).
+    check(entry_budget(2000 * MiB, 8 * GiB, 1536 * MiB, 64 * MiB) == 2000 * MiB,
+          "ample memory keeps the configured budget");
+    // Tight memory → clamp to (avail - floor).
+    check(entry_budget(4000 * MiB, 3 * GiB, 1536 * MiB, 64 * MiB) == 3 * GiB - 1536 * MiB,
+          "tight memory clamps to the sustainable budget");
+    // Below the floor → never below min_cap (and never above configured).
+    check(entry_budget(2000 * MiB, 1000 * MiB, 1536 * MiB, 64 * MiB) == 64 * MiB,
+          "below the floor falls back to min_cap");
+}
+
 } // namespace
 
 int main() {
@@ -251,6 +559,18 @@ int main() {
     test_probe_forgets_a_stale_ceiling();
     test_converges_on_a_synthetic_device();
     test_degenerate_caps();
+    test_anon_war_does_not_poison_baseline_or_grow();
+    test_anon_war_demotes_when_cuts_do_not_help();
+    test_foreign_faults_do_not_cut();
+    test_dense_decline_cuts_early_and_rewarms_once();
+    test_infeasible_demand_demotes_immediately();
+    test_rearm_promotes_when_room_returns();
+    test_plateau_stops_growth_without_a_configured_cap();
+    test_demotes_when_cut_below_token_demand();
+    test_demotes_on_near_zero_hit_rate();
+    test_demotes_on_sustained_fault_war();
+    test_healthy_cache_is_not_demoted();
+    test_entry_budget_helper();
 
     if (failures) {
         std::fprintf(stderr, "%d check(s) failed\n", failures);

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -127,6 +127,57 @@ session_shrink_gen(const RunConfig & c, int shrink_mib, std::string & out1, std:
     return true;
 }
 
+// Open a Session (cache on), generate, then flip the cache to shared-slot (off) mode and back to
+// the LRU between generations — the governor's runtime demotion/promotion. Each generation must
+// still match the cold resident reference: switching residency policy mid-session changes what is
+// held in memory, never the produced bytes.
+static bool session_modeflip_gen(
+    const RunConfig & c, std::string & out1, std::string & out2, std::string & out3, std::string & err) {
+    SessionConfig sc;
+    sc.model_path = c.model_path;
+    sc.n_threads = c.n_threads;
+    sc.n_ctx = c.n_ctx;
+    sc.n_batch = c.n_ctx;
+    sc.chatml = c.chatml;
+    sc.moe = c.moe;
+
+    std::unique_ptr<Session> s = Session::open(sc, err);
+    if (!s) return false;
+
+    GenerateRequest req;
+    req.prompt = c.prompt;
+    req.n_predict = c.n_predict;
+    req.clear_kv = true;
+
+    RunResult r1 = s->generate(req);
+    if (!r1) {
+        err = r1.error;
+        return false;
+    }
+    if (!s->set_cache_mode_slots(true)) { // demote LRU → shared slots
+        err = "set_cache_mode_slots(true) failed";
+        return false;
+    }
+    RunResult r2 = s->generate(req);
+    if (!r2) {
+        err = r2.error;
+        return false;
+    }
+    if (!s->set_cache_mode_slots(false)) { // promote back to the LRU
+        err = "set_cache_mode_slots(false) failed";
+        return false;
+    }
+    RunResult r3 = s->generate(req);
+    if (!r3) {
+        err = r3.error;
+        return false;
+    }
+    out1 = r1.generated_text;
+    out2 = r2.generated_text;
+    out3 = r3.generated_text;
+    return true;
+}
+
 static int check(const char * name, const std::string & a, const std::string & b) {
     if (a == b) {
         std::printf("[PASS] %s\n", name);
@@ -260,6 +311,17 @@ int main(int argc, char ** argv) {
     fails += check("S3a session generate #1 == resident", s_res, s_sh1);
     fails += check("S3b session generate #2 (after budget shrink) == resident", s_res, s_sh2);
 
+    // S4: the governor's runtime cache-mode switch (LRU → shared slots → LRU). Each generation must
+    // still match the resident reference: a mode flip only changes residency, never the bytes.
+    std::string s_mf1, s_mf2, s_mf3;
+    if (!session_modeflip_gen(sess, s_mf1, s_mf2, s_mf3, err)) {
+        std::fprintf(stderr, "session mode-flip run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("S4a session generate #1 (LRU) == resident", s_res, s_mf1);
+    fails += check("S4b session generate #2 (demoted to slots) == resident", s_res, s_mf2);
+    fails += check("S4c session generate #3 (promoted back to LRU) == resident", s_res, s_mf3);
+
     // ── G5: temporal prefetch must not change bytes ──
     // A forced cache (prefetch needs one) plus a couple of look-ahead layers, exercising the
     // speculative queue, integration and eviction against the plain streamed reference.
@@ -311,6 +373,17 @@ int main(int argc, char ** argv) {
     }
     fails += check("S2a session+overlap generate #1 == resident", s_res, s_og1);
     fails += check("S2b session+overlap generate #2 (warm cache) == resident", s_res, s_og2);
+
+    // S4 under overlap: the mode flip must not race the async reads / ready-flag machinery. This is
+    // the proof that the demotion's drain+quiesce+rebind is safe with the fork hook live.
+    std::string s_omf1, s_omf2, s_omf3;
+    if (!session_modeflip_gen(sess_ov, s_omf1, s_omf2, s_omf3, err)) {
+        std::fprintf(stderr, "session+overlap mode-flip run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("S4d overlap generate #1 (LRU) == resident", s_res, s_omf1);
+    fails += check("S4e overlap generate #2 (demoted to slots) == resident", s_res, s_omf2);
+    fails += check("S4f overlap generate #3 (promoted back to LRU) == resident", s_res, s_omf3);
 #else
     std::printf("[SKIP] S2 (expert-ready hook not built)\n");
 #endif


### PR DESCRIPTION
## What

The second-generation cache governor, default off behind `--cache-gov2`. Split out of the previously
bundled commit so it has its own history and its own on-device A/B outcome, independent of
`--dense-odirect` (which stacks on this branch).

On top of `--cache-dynamic`'s shrink-to-what-the-device-concedes loop it adds:

- **Attribution** of a token's fault load to its culprit (our cache, the dense weights, or the
  anon/zram war), so a cut fires only when the cache is actually the cause.
- A **hit-rate plateau** that replaces a hand-set ceiling — growth stops where more budget stops
  buying hits (two binomial standard errors).
- A real **OFF state**: on a >RAM model that routes more than the device will hold, the LRU earns no
  hits and its commit/evict churn feeds the war, so the governor demotes the cache to shared-slot
  mode and re-arms only when the device frees the room.
- An **entry test** that clamps the starting budget before prefill can knock the device over
  (`MemAvailable` counts our own mmap'd weights as free, so it is discounted by the dense bytes).

## Mechanism

`ExpertStreamSource` gains a runtime LRU ⇄ shared-slot switch (`set_cache_mode`), with the slot
buffers allocated lazily on the first demotion; the slot-mode predicate becomes a mutable
`slot_mode_` member so the mode can flip between tokens. `Session` feeds the governor per-token
signals (dense residency, swap delta, hit rate, token demand) and applies its decisions once per
token, where no decode is in flight. `stats()` exposes `total_expert_bytes` (the physical cache
ceiling). No llama.cpp patch; no env vars in the library; no model constants.

## Telemetry

`gov_state` / `gov_war` columns and a `cache_gov2` preamble flag in the CSV.

## Tests

- **S4** (byte-identity): the runtime mode switch (LRU → slots → LRU) changes not a single output
  byte, serial and overlap, on both tiny fixtures.
- `cache_governor_test.cpp`: unit-tests the policy (demote/promote/plateau/attribution) against
  synthetic device signals.

Host build + full `ctest` green (G1–G5, S1–S4, `cache_governor`). Default off pending the on-device
A/B on both phones. See `docs/pressure.md`.


