### PR TITLE
--dense-odirect — stream dense weights via O_DIRECT into anon buffers

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -341,6 +341,7 @@ static void print_usage(const char * argv0) {
         "      --io-threads N      parallel expert-read lanes [1..%d] (default 4)\n"
         "      --no-odirect        do not bypass the page cache\n"
         "      --no-warm-dense     skip the load-time sweep that page-caches the non-expert weights\n"
+        "      --dense-odirect     read the dense weights via O_DIRECT into our buffers (experiment)\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -419,6 +420,8 @@ int main(int argc, char ** argv) {
             cfg.moe.o_direct = false;
         else if (a == "--no-warm-dense")
             cfg.moe.warm_dense = false;
+        else if (a == "--dense-odirect")
+            cfg.moe.dense_odirect = true;
         else if (a == "--load-all")
             cfg.moe.load_all = true;
         else if (a == "--force-cache")

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -78,6 +78,12 @@ struct MoeStreamConfig {
     // moves that cost into load_seconds at sequential-read bandwidth. Off for A/B measurements.
     bool warm_dense = true;
 
+    // Experiment (default off, in-app toggle): read the dense (non-expert) weights once via O_DIRECT
+    // into our own buffers and rebind their tensors onto them, instead of leaving them mmap'd. Makes
+    // the dense anonymous, so a reclaim swaps it to zram (fast refault) rather than dropping it to a
+    // slow 4 KiB flash refault — at the cost of holding it as (incompressible-Q4) anon. A/B only.
+    bool dense_odirect = false;
+
     // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
     // thread, before returning. This defeats the latency-hiding purpose (the reads no longer
     // overlap compute) but makes speculative integration deterministic, so the byte-identity

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -145,6 +145,7 @@ struct RunInfo {
     bool overlap = false;
     int prefetch_layers = 0;
     bool warm_dense = false;
+    bool dense_odirect = false;
 };
 
 // Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_run_info once before the

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -324,6 +324,33 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         std::vector<uint64_t> dense_bytes;
         if (route_trace) dense_bytes = dense_bytes_per_layer(offs, layers, im.n_layer);
 
+        // --dense-odirect: hand the streamer the dense (non-expert) model weights to read into anon
+        // buffers. The list is every captured weight leaf that IS a gguf tensor (dropping graph
+        // inputs and KV, which share the leaf shape) and is NOT one of the streamed experts. Built
+        // before init consumes `layers`. Set even when empty is harmless; the streamer no-ops it.
+        if (cfg.moe.dense_odirect) {
+            std::unordered_set<std::string> expert_names;
+            for (const LayerExperts & L : layers) {
+                if (!L.bound) continue;
+                for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                    if (L.proj[p].tensor) expert_names.insert(L.proj[p].tensor->name);
+            }
+            std::vector<DenseTensorRef> dense;
+            for (const auto & kv : im.hook->captured_weights()) {
+                const std::string & name = kv.first;
+                if (expert_names.count(name)) continue;
+                auto off = offs.off_by_name.find(name);
+                auto sz = offs.size_by_name.find(name);
+                if (off == offs.off_by_name.end() || sz == offs.size_by_name.end()) continue; // not a file tensor
+                DenseTensorRef d;
+                d.tensor = kv.second;
+                d.file_off = off->second;
+                d.size = sz->second;
+                dense.push_back(d);
+            }
+            im.source.set_dense_tensors(std::move(dense));
+        }
+
         if (!im.source.init(cfg.model_path, n_expert, std::move(layers), cfg.moe))
             return fail("expert stream source init failed");
         im.hook->set_source(&im.source);
@@ -425,6 +452,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
         ri.warm_dense = cfg.moe.enabled && cfg.moe.warm_dense;
+        ri.dense_odirect = cfg.moe.enabled && cfg.moe.dense_odirect;
         if (cfg.moe.enabled) {
             const IExpertSource::Stats st = im.source.stats();
             ri.cache_mb = (int) (st.cache_budget_bytes / (1024ull * 1024ull));

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -98,6 +98,10 @@ void vm_evict(void * p, size_t sz) {
 void vm_release(void * p, size_t /*sz*/) {
     if (p) VirtualFree(p, 0, MEM_RELEASE);
 }
+void vm_drop_file_pages(void * /*p*/, size_t /*sz*/) {
+    // File-backed views cannot be decommitted (MEM_DECOMMIT is only valid for VirtualAlloc'd pages),
+    // and the host build never mmaps the model for streaming — so there is nothing to drop.
+}
 
 // Unmeasured on the host build, like the fault counters below and for the same reason: the gates
 // prove byte-identity, they do not size a cache against a phone's reclaim. QueryWorkingSetEx could
@@ -193,6 +197,12 @@ void vm_evict(void * p, size_t sz) {
 }
 void vm_release(void * p, size_t sz) {
     if (p) munmap(p, sz);
+}
+void vm_drop_file_pages(void * p, size_t sz) {
+    // MADV_DONTNEED on the model's clean, read-only MAP_PRIVATE mapping drops the resident pages; the
+    // next access refaults them from the file. The tensor was rebound onto its anon copy, so nothing
+    // touches this range again — the drop just reclaims the double residency, it does not lose data.
+    if (sz) madvise(p, sz, MADV_DONTNEED);
 }
 
 bool vm_resident_sample(const void * p, size_t sz, size_t * sampled, size_t * resident) {

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -49,6 +49,15 @@ bool vm_commit(void * p, size_t sz);
 void vm_evict(void * p, size_t sz);
 void vm_release(void * p, size_t sz);
 
+// Drop the resident pages of a FILE-BACKED mapping (the model's mmap) so a later touch refaults them
+// from the file. Distinct from vm_evict, which decommits ANONYMOUS reserved-cache pages: this is for
+// the clean, read-only weight mapping — MADV_DONTNEED discards the resident copy without writing
+// anything back. Used after --dense-odirect copies a dense tensor into its own anon buffer and
+// rebinds onto it, to hand the now-unreferenced mmap pages back instead of leaving them double-
+// resident until reclaim. A no-op where the platform cannot (Windows host: a file view is not
+// VirtualFree-able, and the host build never streams). The range must be page-aligned by the caller.
+void vm_drop_file_pages(void * p, size_t sz);
+
 // How many of a committed range's pages the kernel still has in RAM. Counts only the pages fully
 // inside [p, p+sz) — the same clipping vm_evict's callers apply — and ADDS to *sampled/*resident,
 // so several ranges can be summed into one fraction (the caller zeroes them first).

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -23,9 +23,9 @@ public:
                      r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx);
         std::fprintf(f_,
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d cache_dynamic=%d force_cache=%d "
-                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d warm_dense=%d\n",
+                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d warm_dense=%d dense_odirect=%d\n",
                      r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.cache_dynamic, r.force_cache,
-                     r.io_threads, r.o_direct, r.overlap, r.prefetch_layers, r.warm_dense);
+                     r.io_threads, r.o_direct, r.overlap, r.prefetch_layers, r.warm_dense, r.dense_odirect);
         write_header();
     }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -357,6 +357,7 @@ bool ExpertStreamSource::read_dense_odirect() {
     const uint64_t chunk = 8ull << 20;
     uint64_t total = 0;
     dense_bufs_.reserve(dense_tensors_.size());
+    dense_buf_sz_.reserve(dense_tensors_.size());
     for (const DenseTensorRef & d : dense_tensors_) {
         if (!d.tensor || d.size == 0) continue;
         void * buf = pio::alloc_aligned(align_, (size_t) d.size);
@@ -365,6 +366,7 @@ bool ExpertStreamSource::read_dense_odirect() {
             return false;
         }
         dense_bufs_.push_back(buf); // tracked for shutdown even if a chunk read below fails
+        dense_buf_sz_.push_back((size_t) d.size); // paired size, for the anon-residency sample
         for (uint64_t done = 0; done < d.size;) {
             IoJob j;
             j.dst = (char *) buf + done;
@@ -378,6 +380,46 @@ bool ExpertStreamSource::read_dense_odirect() {
     }
     std::fprintf(stderr, "bmoe: --dense-odirect — %llu MiB of dense weights in %zu anon buffers\n",
                  (unsigned long long) (total >> 20), dense_bufs_.size());
+
+    // Hand the mmap copies back. The capture warm-up decode faulted these dense pages in mmap-
+    // resident, and we have just read them again into anon buffers and rebound every tensor onto
+    // those — so the file-backed pages are now referenced by nobody. Left alone they sit resident
+    // until reclaim, doubling the dense footprint at the worst moment (right before prefill, when the
+    // governor's entry test reads MemAvailable). Drop them explicitly instead: a clean read-only
+    // mapping, so MADV_DONTNEED loses no data and nothing will refault the range. Best-effort — it
+    // needs /proc/self/maps to turn a file offset into an address; where that is unreadable (or the
+    // host build) the pages simply stay, which only forfeits the saving.
+    std::vector<pio::MappedRegion> vmas;
+    const size_t slash = gguf_path_.find_last_of("/\\");
+    const std::string base = slash == std::string::npos ? gguf_path_ : gguf_path_.substr(slash + 1);
+    if (pio::file_mapped_regions(base.c_str(), vmas) && !vmas.empty()) {
+        const size_t pg = pio::vm_page();
+        auto addr_of = [&](uint64_t off) -> char * {
+            for (const auto & v : vmas) {
+                const uint64_t span = (uint64_t) (v.end - v.start);
+                if (off >= v.file_offset && off < v.file_offset + span) return (char *) v.start + (off - v.file_offset);
+            }
+            return nullptr;
+        };
+        uint64_t dropped = 0;
+        for (const DenseTensorRef & d : dense_tensors_) {
+            if (!d.tensor || d.size == 0) continue;
+            char * a = addr_of(d.file_off);
+            if (!a) continue;
+            // Align INWARD to whole pages (round the start up, the end down), so a page shared with an
+            // adjacent tensor that stays mmap-resident — an expert slice, or the next dense tensor — is
+            // never dropped out from under it. Same clipping the residency sampler applies.
+            uintptr_t a0 = ((uintptr_t) a + pg - 1) & ~(uintptr_t) (pg - 1);
+            uintptr_t a1 = ((uintptr_t) a + d.size) & ~(uintptr_t) (pg - 1);
+            if (a1 > a0) {
+                pio::vm_drop_file_pages((void *) a0, (size_t) (a1 - a0));
+                dropped += a1 - a0;
+            }
+        }
+        if (dropped)
+            std::fprintf(stderr, "bmoe: --dense-odirect — dropped %llu MiB of now-unused mmap pages\n",
+                         (unsigned long long) (dropped >> 20));
+    }
     return true;
 }
 
@@ -678,9 +720,37 @@ void ExpertStreamSource::sample_residency() {
 // calls, and only every residency_probe_every load. Shares probe_tick_ with sample_residency, so it
 // fires on the same throttle without a second counter.
 void ExpertStreamSource::sample_dense_residency() {
-    // Under --dense-odirect the dense weights are our anon buffers, not the mmap this samples, so the
-    // mmap residency it would report is meaningless — leave dense_resident_frac_ at its sentinel.
-    if (dense_odirect_) return;
+    // Under --dense-odirect the dense weights are our own anon buffers, not the mmap the block below
+    // samples. But anon memory is reclaimed too (to zram), and mincore reports resident anon pages
+    // exactly as it does file pages — so sample the buffers directly and dense_resident_frac keeps its
+    // meaning ("how much of the dense set the kernel still has in RAM") instead of reading unmeasured.
+    if (dense_odirect_) {
+        if (dense_bufs_.empty()) return;
+        // Share sample_residency's throttle: it has just done the ++ this load, so fire on the same
+        // loads and skip the rest, without a second counter.
+        if (probe_tick_ % residency_probe_every != 0) return;
+        uint64_t total = 0;
+        for (size_t sz : dense_buf_sz_)
+            total += sz;
+        if (total == 0) return;
+        size_t sampled = 0, resident = 0;
+        for (int k = 0; k < dense_sample_pages; ++k) {
+            // Stratified: the k-th of dense_sample_pages evenly spaced points across the summed buffer
+            // bytes, one page each — the same shape as the mmap path, so the two modes are comparable.
+            uint64_t target = (total * (uint64_t) k) / (uint64_t) dense_sample_pages;
+            for (size_t i = 0; i < dense_bufs_.size(); ++i) {
+                if (target < dense_buf_sz_[i]) {
+                    const char * a = (const char *) dense_bufs_[i] + target;
+                    const char * pg = (const char *) ((uintptr_t) a & ~(uintptr_t) (page_ - 1));
+                    pio::vm_resident_sample(pg, page_, &sampled, &resident);
+                    break;
+                }
+                target -= dense_buf_sz_[i];
+            }
+        }
+        dense_resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
+        return;
+    }
     if (dense_ranges_.empty()) return;
     // Share sample_residency's throttle without a second counter: it has just done the ++, so this
     // fires exactly on the loads where it did, and skips the rest.
@@ -1302,6 +1372,7 @@ void ExpertStreamSource::shutdown() {
     for (void * b : dense_bufs_)
         if (b) pio::aligned_free(b);
     dense_bufs_.clear();
+    dense_buf_sz_.clear();
     dense_tensors_.clear();
     for (int lane = 0; lane < (int) fds_.size(); ++lane) {
         if (pio::fd_ok(fds_[lane])) pio::close_fd(fds_[lane]);

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -39,6 +39,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     overlap_ = cfg.overlap;
     prefetch_sync_ = cfg.prefetch_sync && !cfg.overlap; // serial only: overlap lane 0 is a worker
     cache_dynamic_ = cfg.cache_dynamic;
+    dense_odirect_ = cfg.dense_odirect;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
 
@@ -266,11 +267,20 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         if (pos < fsize_) dense_ranges_.push_back({pos, fsize_});
     }
 
+    // --dense-odirect: read the dense weights into our own anon buffers and rebind their tensors,
+    // once, on lane 0 while it is still the caller's thread and no worker is running. Must precede
+    // warm_dense (which becomes pointless — the dense is no longer mmap'd) and the workers.
+    if (dense_odirect_ && !dense_tensors_.empty() && !read_dense_odirect()) {
+        std::fprintf(stderr, "bmoe: --dense-odirect read failed\n");
+        return false;
+    }
+
     // Warm the dense (non-expert) regions into the page cache before the first token, so the early
     // decodes do not fault them in one scattered 4 KiB page at a time. Independent of the cache
     // budget: it only pre-faults the mmap-resident pages, it neither pins nor reserves them. Runs on
-    // the caller's thread (the workers are not started yet).
-    if (cfg.warm_dense) warm_dense_regions(gguf_path);
+    // the caller's thread (the workers are not started yet). Skipped under --dense-odirect: those
+    // weights are our anon buffers now, not the mmap this would warm.
+    if (cfg.warm_dense && !dense_odirect_) warm_dense_regions(gguf_path);
 
     active_ = true;
     // Serial: lane 0 is the calling thread (it drains inline), workers own lanes 1..N-1.
@@ -337,6 +347,38 @@ void ExpertStreamSource::warm_dense_regions(const std::string & gguf_path) {
     const double s = std::chrono::duration<double>(clock_t_::now() - t0).count();
     std::fprintf(stderr, "bmoe: dense warm-up — %llu MiB in %.1f s%s\n", (unsigned long long) (warmed >> 20), s,
                  ok ? "" : " (partial)");
+}
+
+// ── --dense-odirect: read each dense tensor whole into an anon buffer and rebind onto it ──
+bool ExpertStreamSource::read_dense_odirect() {
+    // Chunked so read_slice's per-lane bounce stays bounded (a dense tensor can be hundreds of MiB);
+    // each chunk re-reads at most one partial page at its boundary, which is harmless. Lane 0 only —
+    // this runs before the workers start, so there is no contention on the bounce or fd.
+    const uint64_t chunk = 8ull << 20;
+    uint64_t total = 0;
+    dense_bufs_.reserve(dense_tensors_.size());
+    for (const DenseTensorRef & d : dense_tensors_) {
+        if (!d.tensor || d.size == 0) continue;
+        void * buf = pio::alloc_aligned(align_, (size_t) d.size);
+        if (!buf) {
+            std::fprintf(stderr, "bmoe: dense buffer alloc %llu failed\n", (unsigned long long) d.size);
+            return false;
+        }
+        dense_bufs_.push_back(buf); // tracked for shutdown even if a chunk read below fails
+        for (uint64_t done = 0; done < d.size;) {
+            IoJob j;
+            j.dst = (char *) buf + done;
+            j.off = d.file_off + done;
+            j.nbytes = std::min<uint64_t>(chunk, d.size - done);
+            if (!read_slice(0, j)) return false;
+            done += j.nbytes;
+        }
+        d.tensor->data = buf; // rebind the model weight onto its private anon copy
+        total += d.size;
+    }
+    std::fprintf(stderr, "bmoe: --dense-odirect — %llu MiB of dense weights in %zu anon buffers\n",
+                 (unsigned long long) (total >> 20), dense_bufs_.size());
+    return true;
 }
 
 // ── one aligned slice read on a lane ────────────────────────────────────────────────
@@ -636,6 +678,9 @@ void ExpertStreamSource::sample_residency() {
 // calls, and only every residency_probe_every load. Shares probe_tick_ with sample_residency, so it
 // fires on the same throttle without a second counter.
 void ExpertStreamSource::sample_dense_residency() {
+    // Under --dense-odirect the dense weights are our anon buffers, not the mmap this samples, so the
+    // mmap residency it would report is meaningless — leave dense_resident_frac_ at its sentinel.
+    if (dense_odirect_) return;
     if (dense_ranges_.empty()) return;
     // Share sample_residency's throttle without a second counter: it has just done the ++, so this
     // fires exactly on the loads where it did, and skips the rest.
@@ -1251,6 +1296,13 @@ void ExpertStreamSource::shutdown() {
         if (b) pio::aligned_free(b);
     bounces_.clear();
     bounce_sz_.clear();
+    // --dense-odirect anon buffers. Safe here: the context (whose rebound dense tensors point at
+    // these) is torn down after the source, and no decode is in flight — same contract as the slot
+    // and LRU buffers freed above.
+    for (void * b : dense_bufs_)
+        if (b) pio::aligned_free(b);
+    dense_bufs_.clear();
+    dense_tensors_.clear();
     for (int lane = 0; lane < (int) fds_.size(); ++lane) {
         if (pio::fd_ok(fds_[lane])) pio::close_fd(fds_[lane]);
         if (pio::fd_ok(fds_buf_[lane])) pio::close_fd(fds_buf_[lane]);

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -40,6 +40,15 @@ struct ExpertTensorRef {
     uint64_t nb2 = 0;               // bytes per expert (== tensor->nb[2])
 };
 
+// One dense (non-expert) weight tensor to read once via O_DIRECT and rebind onto our own
+// anonymous buffer, for the --dense-odirect experiment. Unlike an expert slice, a dense tensor is
+// read whole and contiguous: `size` bytes from `file_off`, matching its gguf on-disk layout.
+struct DenseTensorRef {
+    ggml_tensor * tensor = nullptr; // persistent weight tensor whose ->data we rebind
+    uint64_t file_off = 0;          // absolute file offset of the tensor's data
+    uint64_t size = 0;              // its data size in bytes (== ggml_nbytes)
+};
+
 // The expert weight tensors of one MoE layer, one per recipe suffix slot. The split
 // layout fills all three ({gate, up, down}); a fused-gate_up layout fills two and leaves
 // the tail slot empty (tensor == nullptr). Unbound layers (dense, or non-MoE) stay false.
@@ -61,6 +70,12 @@ public:
     // Returns false on any allocation/open failure or an inconsistent tensor.
     bool
     init(const std::string & gguf_path, int n_expert, std::vector<LayerExperts> layers, const MoeStreamConfig & cfg);
+
+    // Supply the dense (non-expert) weight tensors to read via O_DIRECT and rebind, for the
+    // --dense-odirect experiment. Call BEFORE init (which does the read); a no-op unless
+    // cfg.dense_odirect is set. The runtime builds the list from the captured weight leaves and the
+    // gguf offsets. See docs/pressure.md.
+    void set_dense_tensors(std::vector<DenseTensorRef> dense) { dense_tensors_ = std::move(dense); }
 
     // IExpertSource
     bool load_layer(int il, const int32_t * ids, int n_ids) override;
@@ -133,6 +148,12 @@ private:
     // dense tensors do not demand-fault 4 KiB at a time inside the first decodes. Best-effort:
     // a read failure only leaves the corresponding pages cold.
     void warm_dense_regions(const std::string & gguf_path);
+
+    // Experiment (--dense-odirect): read every dense tensor once via O_DIRECT into an aligned anon
+    // buffer and rebind its ->data onto it, so the dense weights are anonymous (a reclaim swaps
+    // them to zram instead of dropping them to a 4 KiB flash refault). Done once in init, on lane 0,
+    // before the workers start; the buffers are freed in shutdown(). Returns false on any failure.
+    bool read_dense_odirect();
 
     // Adaptive sizing (cache_auto): re-probe device memory (throttled) and nudge cache_max_ so it
     // tracks free RAM. Eval-thread only, called in the mgmt section of load_layer; the eviction
@@ -212,7 +233,10 @@ private:
     static constexpr int residency_sample_entries = 16;    // coldest entries read per probe
     static constexpr int dense_sample_pages = 256;         // stratified probe points over the dense weights
     bool cache_dynamic_ = false;
-    double resident_frac_ = -1.0;       // last sampled cache residency; -1 = never measured
+    bool dense_odirect_ = false; // --dense-odirect: read dense weights via O_DIRECT into our buffers
+    std::vector<DenseTensorRef> dense_tensors_; // set before init; read+rebound when dense_odirect_
+    std::vector<void *> dense_bufs_;            // the anon buffers backing them; freed in shutdown()
+    double resident_frac_ = -1.0;               // last sampled cache residency; -1 = never measured
     double dense_resident_frac_ = -1.0; // last sampled dense-weight residency; -1 = never measured
 
     // The dense weights' byte ranges in the file (complement of the expert ranges), and the mmap VMAs

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -236,6 +236,7 @@ private:
     bool dense_odirect_ = false; // --dense-odirect: read dense weights via O_DIRECT into our buffers
     std::vector<DenseTensorRef> dense_tensors_; // set before init; read+rebound when dense_odirect_
     std::vector<void *> dense_bufs_;            // the anon buffers backing them; freed in shutdown()
+    std::vector<size_t> dense_buf_sz_;          // dense_bufs_[i]'s byte size, for the anon-residency sample
     double resident_frac_ = -1.0;               // last sampled cache residency; -1 = never measured
     double dense_resident_frac_ = -1.0; // last sampled dense-weight residency; -1 = never measured
 

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -77,6 +77,7 @@ void RouterHook::begin_capture() {
     capturing_ = true;
     for (auto & L : captured_)
         L = LayerExperts{};
+    captured_weights_.clear();
 }
 void RouterHook::end_capture() {
     capturing_ = false;
@@ -212,12 +213,20 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 if (!src || src->name[0] == '\0') continue;
                 int il = -1;
                 const int p = match_expert(src->name, recipe_, il);
-                if (p < 0 || il < 0 || il >= n_layer_) continue;
-                if (src->ne[2] <= 0) continue; // expert dim is dim-2
-                LayerExperts & L = captured_[il];
-                L.bound = true;
-                L.proj[p].tensor = src;
-                L.proj[p].nb2 = (uint64_t) src->nb[2];
+                if (p >= 0) {
+                    // An expert-named tensor: streamed, never a dense-rebind candidate.
+                    if (il >= 0 && il < n_layer_ && src->ne[2] > 0) { // expert dim is dim-2
+                        LayerExperts & L = captured_[il];
+                        L.bound = true;
+                        L.proj[p].tensor = src;
+                        L.proj[p].nb2 = (uint64_t) src->nb[2];
+                    }
+                    continue;
+                }
+                // A weight LEAF (op NONE, named) that is not an expert: the persistent dense weights
+                // --dense-odirect may rebind. Graph inputs and KV tensors share this shape but are
+                // filtered out downstream by the gguf tensor set, so recording them here is harmless.
+                if (src->op == GGML_OP_NONE) captured_weights_[src->name] = src;
             }
         }
         return false; // capture never isolates a node

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -28,6 +28,8 @@
 
 #include <chrono>
 #include <cstdint>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -50,6 +52,13 @@ public:
     // by the runtime from the gguf; here only .tensor is set.
     const std::vector<LayerExperts> & captured() const { return captured_; }
     std::vector<LayerExperts> & captured() { return captured_; }
+
+    // After capture, the non-expert weight LEAVES seen in the graph, keyed by tensor name. These
+    // are the persistent model weights the streamer leaves mmap-resident (embeddings, attention,
+    // norms, lm_head); the --dense-odirect experiment rebinds them onto O_DIRECT buffers. The map
+    // also holds graph inputs and KV tensors (same op-NONE leaf shape); the runtime filters it
+    // against the gguf tensor set, which those do not belong to. Only .tensor is meaningful here.
+    const std::unordered_map<std::string, ggml_tensor *> & captured_weights() const { return captured_weights_; }
 
     void set_source(IExpertSource * src) { source_ = src; } // non-null → stream mode
 
@@ -113,7 +122,8 @@ private:
     bool capturing_ = false;
     IExpertSource * source_ = nullptr; // non-null → stream mode
     std::vector<LayerExperts> captured_;
-    std::vector<int32_t> gathered_; // reused scratch for stream-mode id gather
+    std::unordered_map<std::string, ggml_tensor *> captured_weights_; // non-expert weight leaves (see captured_weights)
+    std::vector<int32_t> gathered_;                                   // reused scratch for stream-mode id gather
 
     // Temporal prefetch: K, and the previous token's routed experts per layer (last-token row
     // during prefill). Empty when prefetch is off or a layer has not been seen yet.

--- a/docs/pressure.md
+++ b/docs/pressure.md
@@ -123,6 +123,26 @@ near the demand holds about one token of routing history and its hits come from 
 correlation only; a budget far above it is either buying real reuse or buying a war, and
 `cache_cuts` says which.
 
+## `--dense-odirect`: make the dense weights anonymous
+
+The governor above manages the *cache*. The other half of the war is the *dense* (non-expert)
+weights, which are mmap'd file-backed: the kernel reclaims them by simply dropping the pages, and a
+later touch demand-faults them back 4 KiB at a time from flash. `--dense-odirect` is an experiment
+(default off, in-app toggle) that removes that half of the mmap from the picture: at load it reads
+each dense tensor once via O_DIRECT into an aligned anonymous buffer and rebinds the tensor onto it.
+A reclaim of anonymous memory swaps to zram rather than dropping to flash, so a refault is a fast
+zram decompress instead of a scattered 4 KiB flash read.
+
+The mechanism reuses the expert-capture path: the router hook already records every weight leaf it
+sees in the warm-up graph, and the runtime pairs the non-expert ones with their gguf offsets
+(`ExpertStreamSource::read_dense_odirect`). It is a strict A/B lever, and the analysis says its
+upside is narrow — Q4 weights are close to incompressible, so on a model whose dense set already fits
+resident, moving it flash→zram frees nothing and is a wash. Where it can pay is a model actively
+losing its dense set to reclaim. With the flag on, `warm_dense` is skipped (the dense is no longer
+the mmap it would warm) and the dense-residency sensor is inert (it samples the now-unused mmap), so
+`dense_resident_frac` reads unmeasured. Byte-identity gate: `G6` in `tests/moe_gates.cpp` proves the
+rebind changes not a single output byte against the mmap-resident reference.
+
 ## Portability
 
 The sensors are the platform's half, and they are deliberately the least exotic syscalls available:

--- a/docs/pressure.md
+++ b/docs/pressure.md
@@ -138,10 +138,21 @@ sees in the warm-up graph, and the runtime pairs the non-expert ones with their 
 (`ExpertStreamSource::read_dense_odirect`). It is a strict A/B lever, and the analysis says its
 upside is narrow — Q4 weights are close to incompressible, so on a model whose dense set already fits
 resident, moving it flash→zram frees nothing and is a wash. Where it can pay is a model actively
-losing its dense set to reclaim. With the flag on, `warm_dense` is skipped (the dense is no longer
-the mmap it would warm) and the dense-residency sensor is inert (it samples the now-unused mmap), so
-`dense_resident_frac` reads unmeasured. Byte-identity gate: `G6` in `tests/moe_gates.cpp` proves the
-rebind changes not a single output byte against the mmap-resident reference.
+losing its dense set to reclaim.
+
+Two details keep the A/B honest rather than measuring load-time artefacts. First, the capture warm-up
+decode faults the dense pages in *mmap-resident* before the read copies them into the anon buffers, so
+for a moment the dense set is resident twice; once every tensor is rebound, `read_dense_odirect` drops
+those now-unreferenced mmap pages with `MADV_DONTNEED` (`pio::vm_drop_file_pages`), so prefill starts
+from the true anonymous-only footprint instead of a doubled peak that the governor's entry test would
+misread. Second, the dense-residency sensor does not go blind: it samples the anon buffers directly
+(`mincore` reports resident anon pages too), so `dense_resident_frac` keeps its meaning under the flag
+— whether zram is holding the dense set — rather than reading unmeasured. `warm_dense` is skipped (the
+dense is no longer the mmap it would warm).
+
+Byte-identity gates: `G6` proves the rebind changes not a single output byte against the mmap-resident
+reference, and `G7` proves the same with O_DIRECT off (the read may bypass the page cache or not; the
+rebound bytes are identical either way).
 
 ## Portability
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -23,6 +23,7 @@ data class AppSettings(
     val oDirect: Boolean = true,        // bypass the page cache
     val overlap: Boolean = true,        // read the next experts while the current layer computes
     val warmDense: Boolean = true,      // page-cache the non-expert weights at load (kills >RAM slow-start)
+    val denseOdirect: Boolean = false,  // experiment: read dense weights via O_DIRECT into our buffers
     val prefetchLayers: Int = 0,        // temporal prefetch depth K (0 = off); needs the cache
     val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
     val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
@@ -73,6 +74,8 @@ data class AppSettings(
             if (overlap) a += "--overlap"
             // Warm-up is on by default in the engine; only surface the opt-out flag.
             if (!warmDense) a += "--no-warm-dense"
+            // Experiment (default off): dense weights via O_DIRECT into our own buffers.
+            if (denseOdirect) a += "--dense-odirect"
             // Auto sizing is a live LRU cache, so it satisfies the prefetch cache requirement.
             val cacheOn = cacheMb == CACHE_AUTO || cacheMb > 0
             if (prefetchLayers > 0 && cacheOn) a += listOf("--prefetch", prefetchLayers.toString())
@@ -90,7 +93,7 @@ data class AppSettings(
      */
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, cacheDynamic, ioThreads, threads, nExpertUsed, oDirect,
-               overlap, warmDense, prefetchLayers)
+               overlap, warmDense, denseOdirect, prefetchLayers)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -102,6 +105,7 @@ data class AppSettings(
             .putInt("nExpertUsed", nExpertUsed)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
             .putBoolean("overlap", overlap).putBoolean("warmDense", warmDense)
+            .putBoolean("denseOdirect", denseOdirect)
             .putInt("prefetchLayers", prefetchLayers)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
@@ -179,6 +183,7 @@ data class AppSettings(
                 oDirect = p.getBoolean("oDirect", d.oDirect),
                 overlap = p.getBoolean("overlap", d.overlap),
                 warmDense = p.getBoolean("warmDense", d.warmDense),
+                denseOdirect = p.getBoolean("denseOdirect", d.denseOdirect),
                 prefetchLayers = p.getInt("prefetchLayers", d.prefetchLayers),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -110,6 +110,11 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     "Page-cache the non-expert weights at load. Removes the slow first tokens on models larger than RAM",
                     current.warmDense, enabled = stream,
                 ) { onChange(current.copy(warmDense = it)) }
+                SwitchRow(
+                    "Dense via O_DIRECT",
+                    "Experiment: read the dense weights into our own buffers (anon) so a reclaim swaps to zram (fast) instead of a slow flash refault. A/B vs off",
+                    current.denseOdirect, enabled = stream,
+                ) { onChange(current.copy(denseOdirect = it)) }
                 IntSetting(
                     "Temporal prefetch (layers)", AppSettings.PREFETCH_CHOICES, current.prefetchLayers,
                     format = { if (it == 0) "off" else "$it" },

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -10,6 +10,8 @@
 //   G3  streaming, selective           == streaming, --load-all (every expert each token)
 //   G6  resident                       == streaming + --dense-odirect (dense weights rebound to
 //                                          O_DIRECT anon buffers — the rebind must be byte-identical)
+//   G7  resident                       == streaming + --dense-odirect with O_DIRECT off (the rebind
+//                                          is byte-identical whether or not the read bypasses the cache)
 //   G4  overlap (async reads + per-expert wait hook) == serial streaming, cache off
 //         a) overlap, cache off              b) overlap, small forced cache
 //         c) overlap, cache off, io_threads=1 (single lane → maximal stalls)
@@ -177,7 +179,13 @@ int main(int argc, char ** argv) {
     dense_od.moe.warm_dense = false;
     dense_od.moe.dense_odirect = true;
 
-    std::string s_res, s_s0, s_sc, s_all, s_dod, err;
+    // Same, but with O_DIRECT off: the dense read then lands buffered through read_slice's shared fd.
+    // The rebound bytes must still equal the mmap reference — proves --dense-odirect does not depend on
+    // the underlying read bypassing the page cache.
+    RunConfig dense_od_buf = dense_od;
+    dense_od_buf.moe.o_direct = false;
+
+    std::string s_res, s_s0, s_sc, s_all, s_dod, s_dodb, err;
     if (!gen(resident, s_res, err)) {
         std::fprintf(stderr, "resident run failed: %s\n", err.c_str());
         return 2;
@@ -198,6 +206,10 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "dense-odirect run failed: %s\n", err.c_str());
         return 2;
     }
+    if (!gen(dense_od_buf, s_dodb, err)) {
+        std::fprintf(stderr, "dense-odirect(no O_DIRECT) run failed: %s\n", err.c_str());
+        return 2;
+    }
 
     int fails = 0;
     fails += check("G1 resident == streaming(cache off)", s_res, s_s0);
@@ -207,6 +219,8 @@ int main(int argc, char ** argv) {
     // bytes, same offsets, so identical output to the mmap-resident reference. This is the
     // correctness proof for --dense-odirect (the risk is rebinding the wrong tensor).
     fails += check("G6 dense-odirect(rebind) == resident", s_res, s_dod);
+    // G7: the rebind is byte-identical whether or not the dense read bypassed the page cache.
+    fails += check("G7 dense-odirect(no O_DIRECT) == resident", s_res, s_dodb);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -8,6 +8,8 @@
 //   G1  resident (no streaming)        == streaming, cache off
 //   G2  streaming, cache off           == streaming, small LRU cache (forces evictions)
 //   G3  streaming, selective           == streaming, --load-all (every expert each token)
+//   G6  resident                       == streaming + --dense-odirect (dense weights rebound to
+//                                          O_DIRECT anon buffers — the rebind must be byte-identical)
 //   G4  overlap (async reads + per-expert wait hook) == serial streaming, cache off
 //         a) overlap, cache off              b) overlap, small forced cache
 //         c) overlap, cache off, io_threads=1 (single lane → maximal stalls)
@@ -166,7 +168,16 @@ int main(int argc, char ** argv) {
     streamall.moe.cache_mb = 0;
     streamall.moe.load_all = true;
 
-    std::string s_res, s_s0, s_sc, s_all, err;
+    // streaming, cache off, dense weights read via O_DIRECT into anon buffers and rebound. warm_dense
+    // off so the gate exercises the rebind alone: the rebound bytes must equal the mmap reference.
+    RunConfig dense_od = base(model);
+    dense_od.moe.enabled = true;
+    dense_od.moe.cache_mb = 0;
+    dense_od.moe.io_threads = 4;
+    dense_od.moe.warm_dense = false;
+    dense_od.moe.dense_odirect = true;
+
+    std::string s_res, s_s0, s_sc, s_all, s_dod, err;
     if (!gen(resident, s_res, err)) {
         std::fprintf(stderr, "resident run failed: %s\n", err.c_str());
         return 2;
@@ -183,11 +194,19 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "load-all run failed: %s\n", err.c_str());
         return 2;
     }
+    if (!gen(dense_od, s_dod, err)) {
+        std::fprintf(stderr, "dense-odirect run failed: %s\n", err.c_str());
+        return 2;
+    }
 
     int fails = 0;
     fails += check("G1 resident == streaming(cache off)", s_res, s_s0);
     fails += check("G2 streaming(cache off) == streaming(LRU cache)", s_s0, s_sc);
     fails += check("G3 streaming(selective) == streaming(load-all)", s_s0, s_all);
+    // G6: rebinding the dense weights onto O_DIRECT anon buffers must not change a byte — same
+    // bytes, same offsets, so identical output to the mmap-resident reference. This is the
+    // correctness proof for --dense-odirect (the risk is rebinding the wrong tensor).
+    fails += check("G6 dense-odirect(rebind) == resident", s_res, s_dod);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off


### PR DESCRIPTION
## What

`--dense-odirect` (default off, in-app toggle "Dense via O_DIRECT"): read the dense (non-expert)
weights once via O_DIRECT into aligned anonymous buffers and rebind their tensors onto them, instead
of leaving them mmap'd file-backed. A reclaim of anonymous memory swaps to zram (fast decompress)
rather than dropping to a scattered 4 KiB flash refault. A strict A/B lever — the analysis says its
upside is narrow (Q4 is near-incompressible; it is a wash unless the model is actively losing its
dense set to reclaim).

**Stacked on `feat/cache-gov2`** — base this PR on that one; it was split out of the same original
commit so the two features have independent A/B outcomes.

## Mechanism (no llama.cpp patch)

Reuses the expert-capture seam: `RouterHook` records every non-expert weight leaf in the warm-up
graph (`captured_weights()`); `Session` pairs those with their gguf offsets, minus the streamed
expert set, and hands them to `ExpertStreamSource::read_dense_odirect()`, which reads each tensor
chunked on lane 0 before the workers start and rebinds `->data`. Buffers freed in `shutdown()`.

## Hardening for a trustworthy A/B (second commit)

- **Drop the doubled residency (P4).** The capture warm-up faults the dense pages in mmap-resident
  before they are copied into the anon buffers, so for a moment the set is resident twice — right
  before prefill, when the gov2 entry test reads `MemAvailable`. After the rebind, the now-
  unreferenced mmap pages are dropped with `MADV_DONTNEED` via a new file-mapping-safe primitive
  `pio::vm_drop_file_pages` (POSIX `madvise`, Windows no-op), page-aligned inward off
  `/proc/self/maps` so a page shared with a still-resident tensor is never dropped.
- **Keep the sensor live (P5).** `sample_dense_residency` samples the anon buffers directly instead
  of going inert, so `dense_resident_frac` keeps its meaning (whether zram is holding the dense set)
  under the flag rather than reading unmeasured.

## Tests

- **G6** (byte-identity): the rebind changes not a single output byte vs the mmap-resident reference.
- **G7** (byte-identity): the same holds with O_DIRECT off (the dense read then lands buffered).

Host build + full `ctest` green (G6, G7, S1–S4 on both fixtures). Default off pending the on-device
A/B on both phones. See `docs/pressure.md`.


