### PR TITLE
Harmonize dense/expert O_DIRECT: FileReader + DenseWeights modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,11 @@ we do not fork llama.cpp. See `docs/architecture.md` and `docs/seam.md`.
 ## Project map
 
 - `core/include/bmoe/` — ports (interfaces) + config. Pure policy, no llama.cpp include.
-- `core/src/io/` — `platform_io`: cross-platform O_DIRECT reads + reserve/commit/evict VM.
-- `core/src/moe/` — `gguf_offsets`, `arch_registry`, `expert_stream_source`, `router_hook`.
+- `core/src/io/` — `platform_io` (cross-platform O_DIRECT reads + reserve/commit/evict VM);
+  `file_reader` (pooled positioned reader, per-consumer O_DIRECT — used by both the expert stream
+  and the dense loader).
+- `core/src/moe/` — `gguf_offsets`, `arch_registry`, `expert_stream_source`, `router_hook`;
+  `dense_weights` (the non-expert weight policy: mmap / warm / anon, plus the residency sensor).
 - `core/src/engine/runtime.cpp` — composition + greedy generation loop.
 - `cli/main.cpp` — `bmoe-cli`; the ONLY place environment variables are read.
 - `third_party/llama.cpp` — stock upstream submodule.

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -339,9 +339,10 @@ static void print_usage(const char * argv0) {
         "                          concedes: shrink when reclaim starts taking the cache, grow back\n"
         "                          when it stops (needs the cache; see docs/pressure.md)\n"
         "      --io-threads N      parallel expert-read lanes [1..%d] (default 4)\n"
-        "      --no-odirect        do not bypass the page cache\n"
-        "      --no-warm-dense     skip the load-time sweep that page-caches the non-expert weights\n"
-        "      --dense-odirect     read the dense weights via O_DIRECT into our buffers (experiment)\n"
+        "      --no-odirect        do not bypass the page cache for expert reads\n"
+        "      --dense-weights M   dense (non-expert) weight policy: mmap | warm (default) | anon\n"
+        "                          (warm = page-cache them at load; anon = read via O_DIRECT into our\n"
+        "                          own buffers and rebind, so a reclaim hits zram not flash)\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -418,10 +419,25 @@ int main(int argc, char ** argv) {
             cfg.moe.io_threads = std::atoi(next("--io-threads"));
         else if (a == "--no-odirect")
             cfg.moe.o_direct = false;
+        else if (a == "--dense-weights") {
+            const std::string m = next("--dense-weights");
+            if (m == "mmap")
+                cfg.moe.dense_weights = bmoe::DenseWeightsMode::Mmap;
+            else if (m == "warm")
+                cfg.moe.dense_weights = bmoe::DenseWeightsMode::Warmed;
+            else if (m == "anon")
+                cfg.moe.dense_weights = bmoe::DenseWeightsMode::Anonymous;
+            else {
+                std::fprintf(stderr, "bmoe: --dense-weights expects mmap|warm|anon, got '%s'\n", m.c_str());
+                return 2;
+            }
+        }
+        // Deprecated aliases, kept so existing scripts and the app keep working: --no-warm-dense is
+        // the Mmap policy, --dense-odirect is Anonymous. Prefer --dense-weights.
         else if (a == "--no-warm-dense")
-            cfg.moe.warm_dense = false;
+            cfg.moe.dense_weights = bmoe::DenseWeightsMode::Mmap;
         else if (a == "--dense-odirect")
-            cfg.moe.dense_odirect = true;
+            cfg.moe.dense_weights = bmoe::DenseWeightsMode::Anonymous;
         else if (a == "--load-all")
             cfg.moe.load_all = true;
         else if (a == "--force-cache")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_features(bmoe_core PUBLIC cxx_std_17)
 if(BMOE_HAVE_LLAMA)
     target_sources(bmoe_core PRIVATE
         src/io/platform_io.cpp
+        src/io/file_reader.cpp
         src/moe/gguf_offsets.cpp
         src/moe/expert_stream_source.cpp
         src/moe/router_hook.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -20,6 +20,7 @@ if(BMOE_HAVE_LLAMA)
     target_sources(bmoe_core PRIVATE
         src/io/platform_io.cpp
         src/io/file_reader.cpp
+        src/moe/dense_weights.cpp
         src/moe/gguf_offsets.cpp
         src/moe/expert_stream_source.cpp
         src/moe/router_hook.cpp

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -13,6 +13,14 @@
 
 namespace bmoe {
 
+// How the dense (non-expert) model weights are kept resident. See MoeStreamConfig::dense_weights and
+// core/src/moe/dense_weights.h. Ordered cheapest-effort first.
+enum class DenseWeightsMode {
+    Mmap,      // leave mmap'd, no help (the A/B baseline)
+    Warmed,    // mmap'd, but page-cached once at load
+    Anonymous, // read via O_DIRECT into our own anon buffers and rebind (swaps to zram, not flash)
+};
+
 // MoE expert-selective streaming knobs.
 struct MoeStreamConfig {
     bool enabled = false; // turn streaming on; init fails fast if the model is not MoE
@@ -70,19 +78,18 @@ struct MoeStreamConfig {
     // cache_mb == 0. See docs/prefetch.md.
     int prefetch_layers = 0;
 
-    // Warm the dense (non-expert) file regions into the page cache at init with one sequential
-    // buffered sweep: gguf header/metadata, embeddings, attention, norms, lm_head. Those tensors
-    // stay mmap-resident (the streamer only rebinds experts), so without warming they demand-page
-    // from flash in 4 KiB faults inside the first decodes — on a >RAM model that serialises into
-    // tens of seconds of apparent "compute" before the page cache settles. One sweep at load
-    // moves that cost into load_seconds at sequential-read bandwidth. Off for A/B measurements.
-    bool warm_dense = true;
-
-    // Experiment (default off, in-app toggle): read the dense (non-expert) weights once via O_DIRECT
-    // into our own buffers and rebind their tensors onto them, instead of leaving them mmap'd. Makes
-    // the dense anonymous, so a reclaim swaps it to zram (fast refault) rather than dropping it to a
-    // slow 4 KiB flash refault — at the cost of holding it as (incompressible-Q4) anon. A/B only.
-    bool dense_odirect = false;
+    // How the dense (non-expert) weights are treated. The streamer only rebinds experts; the rest —
+    // gguf header/metadata, embeddings, attention, norms, lm_head — is handled by one of three
+    // policies (see core/src/moe/dense_weights.h):
+    //   Mmap      leave them mmap'd; the kernel serves and reclaims them (a >RAM model then demand-
+    //             faults them 4 KiB at a time inside the first decodes — the slow-start this exists
+    //             to address). The A/B baseline.
+    //   Warmed    (default) leave them mmap'd, but page-cache them once at load with a sequential
+    //             sweep, so the first decodes do not fault them in. Moves the cost into load_seconds.
+    //   Anonymous read them once via O_DIRECT into our own anon buffers and rebind the tensors, so a
+    //             reclaim swaps them to zram (fast) instead of dropping them to a 4 KiB flash refault.
+    //             The measured win on a model actively losing its dense set to reclaim.
+    DenseWeightsMode dense_weights = DenseWeightsMode::Warmed;
 
     // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
     // thread, before returning. This defeats the latency-hiding purpose (the reads no longer

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -324,11 +324,12 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         std::vector<uint64_t> dense_bytes;
         if (route_trace) dense_bytes = dense_bytes_per_layer(offs, layers, im.n_layer);
 
-        // --dense-odirect: hand the streamer the dense (non-expert) model weights to read into anon
-        // buffers. The list is every captured weight leaf that IS a gguf tensor (dropping graph
-        // inputs and KV, which share the leaf shape) and is NOT one of the streamed experts. Built
-        // before init consumes `layers`. Set even when empty is harmless; the streamer no-ops it.
-        if (cfg.moe.dense_odirect) {
+        // Anonymous dense-weights mode: hand the streamer the dense (non-expert) model weights to
+        // read into anon buffers. The list is every captured weight leaf that IS a gguf tensor
+        // (dropping graph inputs and KV, which share the leaf shape) and is NOT one of the streamed
+        // experts. Built before init consumes `layers`. Only this mode needs them; the others ignore
+        // an empty list.
+        if (cfg.moe.dense_weights == DenseWeightsMode::Anonymous) {
             std::unordered_set<std::string> expert_names;
             for (const LayerExperts & L : layers) {
                 if (!L.bound) continue;
@@ -451,8 +452,9 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.o_direct = cfg.moe.enabled && cfg.moe.o_direct;
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
-        ri.warm_dense = cfg.moe.enabled && cfg.moe.warm_dense;
-        ri.dense_odirect = cfg.moe.enabled && cfg.moe.dense_odirect;
+        // The CSV keeps the two familiar flags, derived from the resolved dense-weights policy.
+        ri.warm_dense = cfg.moe.enabled && cfg.moe.dense_weights == DenseWeightsMode::Warmed;
+        ri.dense_odirect = cfg.moe.enabled && cfg.moe.dense_weights == DenseWeightsMode::Anonymous;
         if (cfg.moe.enabled) {
             const IExpertSource::Stats st = im.source.stats();
             ri.cache_mb = (int) (st.cache_budget_bytes / (1024ull * 1024ull));

--- a/core/src/io/file_reader.cpp
+++ b/core/src/io/file_reader.cpp
@@ -1,0 +1,147 @@
+#include "file_reader.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace bmoe {
+
+using clock_t_ = std::chrono::steady_clock;
+
+FileReader::~FileReader() {
+    close();
+}
+
+bool FileReader::open(const std::string & path, int lanes, bool direct, size_t align, size_t bounce_cap) {
+    if (is_open()) return false;
+    align_ = align ? align : 4096;
+    direct_ = direct;
+    const int n = lanes < 1 ? 1 : lanes;
+
+    pio::fd_t primary = pio::open_read(path.c_str(), direct_);
+    if (!pio::fd_ok(primary) && direct_) { // the platform refused O_DIRECT outright — try buffered
+        direct_ = false;
+        primary = pio::open_read(path.c_str(), false);
+    }
+    if (!pio::fd_ok(primary)) {
+        std::fprintf(stderr, "bmoe: open %s failed\n", path.c_str());
+        return false;
+    }
+    fsize_ = pio::file_size(primary);
+
+    // Verify O_DIRECT actually returns correct bytes on this storage. On some emulated / FUSE-backed
+    // volumes (e.g. an app-private dir under /storage/emulated) the open SUCCEEDS but direct reads
+    // return garbage, silently corrupting weights → nonsense output. Compare one aligned block read
+    // directly against the same block read buffered; on any mismatch, fall back to buffered I/O for
+    // this file. On real filesystems (adb-pushed models, desktop) the two match and O_DIRECT is kept.
+    if (direct_ && fsize_ >= (uint64_t) align_) {
+        uint64_t voff = (fsize_ / 2) & ~(uint64_t) (align_ - 1);
+        if (voff + align_ > fsize_) voff = 0;
+        void * dbuf = pio::alloc_aligned(align_, align_);
+        pio::fd_t vfd = pio::open_read(path.c_str(), false);
+        if (dbuf && pio::fd_ok(vfd)) {
+            std::vector<char> bbuf(align_);
+            const long long want = (long long) align_;
+            const long long gd = pio::pread_at(primary, dbuf, align_, voff);
+            const long long gb = pio::pread_at(vfd, bbuf.data(), align_, voff);
+            const bool bad = gd != want || gb != want || std::memcmp(dbuf, bbuf.data(), align_) != 0;
+            if (bad) {
+                std::fprintf(stderr, "bmoe: O_DIRECT returns wrong data on this storage — using buffered I/O\n");
+                direct_ = false;
+                pio::close_fd(primary);
+                primary = pio::open_read(path.c_str(), false);
+            }
+        }
+        if (dbuf) pio::aligned_free(dbuf);
+        if (pio::fd_ok(vfd)) pio::close_fd(vfd);
+        if (!pio::fd_ok(primary)) {
+            std::fprintf(stderr, "bmoe: reopen after O_DIRECT check failed\n");
+            return false;
+        }
+    }
+
+    // A private fd + bounce per lane so concurrent reads never contend. Lane 0 inherits the fd already
+    // opened (and verified) above; the rest open their own.
+    fds_.assign(n, pio::fd_invalid);
+    fds_buf_.assign(n, pio::fd_invalid);
+    bounces_.assign(n, nullptr);
+    bounce_sz_.assign(n, 0);
+    for (int lane = 0; lane < n; ++lane) {
+        fds_[lane] = (lane == 0) ? primary : pio::open_read(path.c_str(), direct_);
+        fds_buf_[lane] = direct_ ? pio::open_read(path.c_str(), false) : pio::fd_invalid;
+        if (!pio::fd_ok(fds_[lane])) {
+            std::fprintf(stderr, "bmoe: lane %d open failed\n", lane);
+            close();
+            return false;
+        }
+        bounces_[lane] = pio::alloc_aligned(align_, bounce_cap);
+        if (!bounces_[lane]) {
+            std::fprintf(stderr, "bmoe: lane %d bounce alloc failed\n", lane);
+            close();
+            return false;
+        }
+        bounce_sz_[lane] = bounce_cap;
+    }
+    return true;
+}
+
+long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) {
+    if (nbytes == 0) return 0;
+    const uint64_t a0 = off & ~(uint64_t) (align_ - 1);
+    const uint64_t a1 = (off + nbytes + align_ - 1) & ~(uint64_t) (align_ - 1);
+    const size_t len = (size_t) (a1 - a0);
+    if (bounce_sz_[lane] < len) {
+        if (bounces_[lane]) pio::aligned_free(bounces_[lane]);
+        bounces_[lane] = pio::alloc_aligned(align_, len);
+        if (!bounces_[lane]) {
+            std::fprintf(stderr, "bmoe: bounce realloc %zu failed\n", len);
+            return -1;
+        }
+        bounce_sz_[lane] = len;
+    }
+    char * b = (char *) bounces_[lane];
+    const pio::fd_t fd = fds_[lane];
+    const pio::fd_t fd_buf = fds_buf_[lane];
+    const uint64_t read_end = (fsize_ && a1 > fsize_) ? fsize_ : a1;
+    const uint64_t bulk_end = direct_ ? (read_end & ~(uint64_t) (align_ - 1)) : read_end;
+
+    const auto t0 = clock_t_::now();
+    for (uint64_t a = a0; a < bulk_end;) {
+        long long got = pio::pread_at(fd, b + (a - a0), (size_t) (bulk_end - a), a);
+        if (got <= 0) {
+            std::fprintf(stderr, "bmoe: pread failed at %llu\n", (unsigned long long) a);
+            return -1;
+        }
+        a += (uint64_t) got;
+    }
+    for (uint64_t a = bulk_end; a < read_end;) { // sub-alignment EOF tail via the buffered fd
+        long long got = pio::pread_at(pio::fd_ok(fd_buf) ? fd_buf : fd, b + (a - a0), (size_t) (read_end - a), a);
+        if (got <= 0) {
+            std::fprintf(stderr, "bmoe: tail pread failed at %llu\n", (unsigned long long) a);
+            return -1;
+        }
+        a += (uint64_t) got;
+    }
+    const auto t1 = clock_t_::now();
+    syscall_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+    std::memcpy(dst, b + (off - a0), (size_t) nbytes);
+    const long long window = (long long) (read_end - a0);
+    read_bytes_.fetch_add(window);
+    return window; // the aligned window pulled — what the effective bandwidth is judged against
+}
+
+void FileReader::close() {
+    for (pio::fd_t fd : fds_)
+        if (pio::fd_ok(fd)) pio::close_fd(fd);
+    for (pio::fd_t fd : fds_buf_)
+        if (pio::fd_ok(fd)) pio::close_fd(fd);
+    for (void * b : bounces_)
+        if (b) pio::aligned_free(b);
+    fds_.clear();
+    fds_buf_.clear();
+    bounces_.clear();
+    bounce_sz_.clear();
+}
+
+} // namespace bmoe

--- a/core/src/io/file_reader.h
+++ b/core/src/io/file_reader.h
@@ -1,0 +1,65 @@
+// A pooled, positioned file reader with optional cache-bypassing (O_DIRECT) I/O.
+//
+// One reader owns N lane fds and N bounce buffers, so N threads can read distinct byte ranges of the
+// same file concurrently without contending. Each read aligns its window to the device block size,
+// pulls it into the lane's bounce buffer, and memcpy's the requested interior out — the mechanics
+// O_DIRECT requires. `direct` is a property of the reader, chosen by whoever opens it: the expert
+// streamer and the dense-weights loader each construct their own, so one can bypass the page cache
+// while the other does not — the two O_DIRECT decisions are independent, not a shared global.
+//
+// The O_DIRECT request is verified once at open: on storage where a direct read returns garbage
+// (some FUSE-backed emulated volumes) the reader silently falls back to buffered I/O for the file,
+// so a caller never has to reason about the storage — it asks for direct and gets correct bytes.
+#pragma once
+
+#include "platform_io.h"
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+namespace bmoe {
+
+class FileReader {
+public:
+    FileReader() = default;
+    ~FileReader();
+
+    FileReader(const FileReader &) = delete;
+    FileReader & operator=(const FileReader &) = delete;
+
+    // Open `path` with `lanes` independent primary fds (+ a buffered fd per lane for the sub-alignment
+    // EOF tail an O_DIRECT read cannot cover) and a `bounce_cap`-byte aligned bounce per lane. `direct`
+    // requests O_DIRECT; it is verified and silently downgraded on storage that mis-serves it. Reads
+    // align to `align`. Returns false on any open/alloc failure. A reader is opened once and not reused.
+    bool open(const std::string & path, int lanes, bool direct, size_t align, size_t bounce_cap);
+    void close();
+
+    bool is_open() const { return !fds_.empty(); }
+    bool direct() const { return direct_; } // the effective mode after verification/fallback
+    uint64_t file_size() const { return fsize_; }
+    int lanes() const { return (int) fds_.size(); }
+
+    // Read `nbytes` at file offset `off` into `dst`, on `lane` (0 <= lane < lanes()). Thread-safe
+    // across distinct lanes — each has its own fd and bounce. Returns the aligned window actually
+    // pulled from the drive (>= nbytes; what the bandwidth must be judged against), or -1 on I/O
+    // error. A zero-length read is a no-op returning 0. The lane's bounce grows if a read needs more.
+    long long read(int lane, void * dst, uint64_t off, uint64_t nbytes);
+
+    // Aggregate accounting since open, summed across lanes.
+    long long read_bytes() const { return read_bytes_.load(std::memory_order_relaxed); }
+    long long syscall_ns() const { return syscall_ns_.load(std::memory_order_relaxed); }
+
+private:
+    std::vector<pio::fd_t> fds_;     // primary (maybe O_DIRECT) per lane
+    std::vector<pio::fd_t> fds_buf_; // buffered fallback per lane, for the sub-alignment EOF tail
+    std::vector<void *> bounces_;
+    std::vector<size_t> bounce_sz_;
+    size_t align_ = 4096;
+    uint64_t fsize_ = 0;
+    bool direct_ = false;
+    std::atomic<long long> read_bytes_{0};
+    std::atomic<long long> syscall_ns_{0};
+};
+
+} // namespace bmoe

--- a/core/src/moe/dense_weights.cpp
+++ b/core/src/moe/dense_weights.cpp
@@ -1,0 +1,242 @@
+#include "dense_weights.h"
+
+#include "ggml.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+
+namespace bmoe {
+
+using clock_t_ = std::chrono::steady_clock;
+
+DenseWeights::~DenseWeights() {
+    shutdown();
+}
+
+std::vector<std::pair<uint64_t, uint64_t>>
+DenseWeights::byte_ranges(std::vector<std::pair<uint64_t, uint64_t>> expert_ranges, uint64_t file_size) {
+    std::sort(expert_ranges.begin(), expert_ranges.end());
+    std::vector<std::pair<uint64_t, uint64_t>> dense;
+    uint64_t pos = 0;
+    for (const auto & r : expert_ranges) {
+        if (r.first > pos) dense.push_back({pos, r.first}); // the gap before this expert range is dense
+        pos = std::max(pos, r.second);
+    }
+    if (pos < file_size) dense.push_back({pos, file_size}); // the trailing dense tail (lm_head et al.)
+    return dense;
+}
+
+bool DenseWeights::init(DenseWeightsMode mode,
+                        const std::string & path,
+                        size_t align,
+                        std::vector<std::pair<uint64_t, uint64_t>> ranges,
+                        std::vector<DenseTensorRef> tensors) {
+    mode_ = mode;
+    path_ = path;
+    align_ = align ? align : 4096;
+    ranges_ = std::move(ranges);
+    tensors_ = std::move(tensors);
+    const size_t slash = path_.find_last_of("/\\");
+    basename_ = slash == std::string::npos ? path_ : path_.substr(slash + 1);
+
+    if (mode_ == DenseWeightsMode::Anonymous) {
+        if (tensors_.empty()) return true; // nothing captured to rebind — behave as Mmap
+        // A single-lane reader with a bounce large enough for our chunk; O_DIRECT independent of the
+        // expert stream. Sized to the largest tensor is unnecessary — we read in bounded chunks.
+        const size_t chunk = 8ull << 20;
+        if (!reader_.open(path_, 1, /*direct=*/true, align_, chunk + 2 * align_)) return false;
+        if (!read_anonymous(align_)) return false;
+        drop_mmap_copies(pio::vm_page());
+    } else if (mode_ == DenseWeightsMode::Warmed) {
+        warm();
+    }
+    return true;
+}
+
+// ── Anonymous: read each dense tensor whole into an anon buffer and rebind onto it ──
+bool DenseWeights::read_anonymous(size_t align) {
+    const uint64_t chunk = 8ull << 20;
+    uint64_t total = 0;
+    bufs_.reserve(tensors_.size());
+    buf_sz_.reserve(tensors_.size());
+    for (const DenseTensorRef & d : tensors_) {
+        if (!d.tensor || d.size == 0) continue;
+        void * buf = pio::alloc_aligned(align, (size_t) d.size);
+        if (!buf) {
+            std::fprintf(stderr, "bmoe: dense buffer alloc %llu failed\n", (unsigned long long) d.size);
+            return false;
+        }
+        bufs_.push_back(buf); // tracked for shutdown even if a chunk read below fails
+        buf_sz_.push_back((size_t) d.size);
+        for (uint64_t done = 0; done < d.size;) {
+            const uint64_t n = std::min<uint64_t>(chunk, d.size - done);
+            if (reader_.read(0, (char *) buf + done, d.file_off + done, n) < 0) return false;
+            done += n;
+        }
+        d.tensor->data = buf; // rebind the model weight onto its private anon copy
+        total += d.size;
+    }
+    std::fprintf(stderr, "bmoe: dense-weights=anon — %llu MiB in %zu anon buffers\n",
+                 (unsigned long long) (total >> 20), bufs_.size());
+    return true;
+}
+
+// Hand the mmap copies back. The capture warm-up decode faulted these dense pages in mmap-resident,
+// and read_anonymous has just copied them into anon buffers and rebound every tensor — so the file-
+// backed pages are referenced by nobody. Left alone they sit resident until reclaim, doubling the
+// dense footprint at the worst moment (right before prefill). Drop them with MADV_DONTNEED: a clean
+// read-only mapping, so nothing is lost and nothing will refault the range. Best-effort — needs
+// /proc/self/maps to turn a file offset into an address; where that is unreadable the pages stay.
+void DenseWeights::drop_mmap_copies(size_t page) {
+    std::vector<pio::MappedRegion> vmas;
+    if (!pio::file_mapped_regions(basename_.c_str(), vmas) || vmas.empty()) return;
+    auto addr_of = [&](uint64_t off) -> char * {
+        for (const auto & v : vmas) {
+            const uint64_t span = (uint64_t) (v.end - v.start);
+            if (off >= v.file_offset && off < v.file_offset + span) return (char *) v.start + (off - v.file_offset);
+        }
+        return nullptr;
+    };
+    uint64_t dropped = 0;
+    for (const DenseTensorRef & d : tensors_) {
+        if (!d.tensor || d.size == 0) continue;
+        char * a = addr_of(d.file_off);
+        if (!a) continue;
+        // Align INWARD to whole pages (start up, end down), so a page shared with an adjacent tensor
+        // that stays mmap-resident — an expert slice, or the next dense tensor — is never dropped.
+        uintptr_t a0 = ((uintptr_t) a + page - 1) & ~(uintptr_t) (page - 1);
+        uintptr_t a1 = ((uintptr_t) a + d.size) & ~(uintptr_t) (page - 1);
+        if (a1 > a0) {
+            pio::vm_drop_file_pages((void *) a0, (size_t) (a1 - a0));
+            dropped += a1 - a0;
+        }
+    }
+    if (dropped)
+        std::fprintf(stderr, "bmoe: dense-weights=anon — dropped %llu MiB of now-unused mmap pages\n",
+                     (unsigned long long) (dropped >> 20));
+}
+
+// ── Warmed: one sequential buffered sweep over the dense ranges to populate the page cache ──
+void DenseWeights::warm() {
+    pio::fd_t fd = pio::open_read(path_.c_str(), false);
+    if (!pio::fd_ok(fd)) return;
+    const size_t chunk = 8ull << 20;
+    void * buf = pio::alloc_aligned(align_, chunk);
+    if (!buf) {
+        pio::close_fd(fd);
+        return;
+    }
+    const auto t0 = clock_t_::now();
+    uint64_t warmed = 0;
+    bool ok = true;
+    for (const auto & r : ranges_) {
+        for (uint64_t a = r.first; a < r.second && ok;) {
+            const long long got = pio::pread_at(fd, buf, (size_t) std::min<uint64_t>(chunk, r.second - a), a);
+            if (got <= 0) {
+                ok = false; // best-effort: those pages just stay cold
+                break;
+            }
+            a += (uint64_t) got;
+            warmed += (uint64_t) got;
+        }
+    }
+    pio::aligned_free(buf);
+    pio::close_fd(fd);
+    const double s = std::chrono::duration<double>(clock_t_::now() - t0).count();
+    std::fprintf(stderr, "bmoe: dense warm-up — %llu MiB in %.1f s%s\n", (unsigned long long) (warmed >> 20), s,
+                 ok ? "" : " (partial)");
+}
+
+void DenseWeights::rewarm() {
+    if (mode_ == DenseWeightsMode::Warmed) warm();
+}
+
+// ── residency sensor ─────────────────────────────────────────────────────────────────
+void DenseWeights::sample_residency(size_t page) {
+    if (mode_ == DenseWeightsMode::Anonymous)
+        sample_anon(page);
+    else
+        sample_mmap(page);
+}
+
+// Anonymous: mincore the anon buffers directly. Anon memory is reclaimed to zram, and mincore reports
+// resident anon pages just as it does file pages, so resident_frac keeps its meaning under the flag.
+void DenseWeights::sample_anon(size_t page) {
+    if (bufs_.empty()) return;
+    uint64_t total = 0;
+    for (size_t sz : buf_sz_)
+        total += sz;
+    if (total == 0) return;
+    size_t sampled = 0, resident = 0;
+    for (int k = 0; k < sample_pages; ++k) {
+        uint64_t target = (total * (uint64_t) k) / (uint64_t) sample_pages;
+        for (size_t i = 0; i < bufs_.size(); ++i) {
+            if (target < buf_sz_[i]) {
+                const char * a = (const char *) bufs_[i] + target;
+                const char * pg = (const char *) ((uintptr_t) a & ~(uintptr_t) (page - 1));
+                pio::vm_resident_sample(pg, page, &sampled, &resident);
+                break;
+            }
+            target -= buf_sz_[i];
+        }
+    }
+    resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
+}
+
+// Mmap/Warmed: the weights are one mmap of the gguf; a dense file offset becomes an address through
+// the VMA that backs it (/proc/self/maps), which an app may read, being its own. Probe sample_pages
+// points spread evenly across the dense byte ranges, one page each.
+void DenseWeights::sample_mmap(size_t page) {
+    if (ranges_.empty()) return;
+    if (!vmas_tried_) { // resolve the mmap once; llama.cpp has mapped the file by the first decode
+        vmas_tried_ = true;
+        pio::file_mapped_regions(basename_.c_str(), vmas_);
+    }
+    if (vmas_.empty()) return; // maps unreadable → leave resident_frac_ at -1
+
+    uint64_t total = 0;
+    for (const auto & r : ranges_)
+        total += r.second - r.first;
+    if (total == 0) return;
+
+    auto addr_of = [&](uint64_t off) -> const char * {
+        for (const auto & v : vmas_) {
+            const uint64_t span = (uint64_t) (v.end - v.start);
+            if (off >= v.file_offset && off < v.file_offset + span) return (const char *) v.start + (off - v.file_offset);
+        }
+        return nullptr;
+    };
+
+    size_t sampled = 0, resident = 0;
+    for (int k = 0; k < sample_pages; ++k) {
+        uint64_t target = (total * (uint64_t) k) / (uint64_t) sample_pages;
+        uint64_t off = 0;
+        for (const auto & r : ranges_) {
+            const uint64_t len = r.second - r.first;
+            if (target < len) {
+                off = r.first + target;
+                break;
+            }
+            target -= len;
+        }
+        // Align the probe DOWN to its page: vm_resident_sample counts only pages fully inside the
+        // range, so a single page handed in at an arbitrary offset would clip to nothing.
+        if (const char * a = addr_of(off)) {
+            const char * pg = (const char *) ((uintptr_t) a & ~(uintptr_t) (page - 1));
+            pio::vm_resident_sample(pg, page, &sampled, &resident);
+        }
+    }
+    resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
+}
+
+void DenseWeights::shutdown() {
+    for (void * b : bufs_)
+        if (b) pio::aligned_free(b);
+    bufs_.clear();
+    buf_sz_.clear();
+    tensors_.clear();
+    reader_.close();
+}
+
+} // namespace bmoe

--- a/core/src/moe/dense_weights.h
+++ b/core/src/moe/dense_weights.h
@@ -1,0 +1,102 @@
+// The dense (non-expert) model weights, and the policy for keeping them resident.
+//
+// The streamer rebinds only the expert tensors; everything else in the gguf — header/metadata,
+// embeddings, attention, norms, lm_head — is "dense", and how it is kept in RAM is a policy of its
+// own (DenseWeightsMode): left mmap'd, mmap'd-and-warmed, or read once into anonymous buffers via
+// O_DIRECT and rebound. This module owns that policy, the buffers it may allocate, and the residency
+// sensor that reports how much of the dense set the kernel still has — the half the expert cache's
+// own residency sensor is blind to.
+//
+// It reads through its OWN FileReader, so its O_DIRECT choice is independent of the expert stream's:
+// the dense set may be pulled cache-bypassing while the experts are not, or the reverse. There is one
+// definition of "which bytes are dense" here (byte_ranges), shared by the warm sweep, the anonymous
+// read, and the sensor — the three used to compute it separately.
+#pragma once
+
+#include "../io/file_reader.h"
+#include "../io/platform_io.h"
+#include "bmoe/config.h" // DenseWeightsMode
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+struct ggml_tensor;
+
+namespace bmoe {
+
+// One dense weight tensor: where its bytes live in the gguf, and the tensor whose ->data we rebind.
+// Read whole and contiguous (`size` bytes from `file_off`), unlike an expert slice.
+struct DenseTensorRef {
+    ggml_tensor * tensor = nullptr;
+    uint64_t file_off = 0;
+    uint64_t size = 0;
+};
+
+class DenseWeights {
+public:
+    DenseWeights() = default;
+    ~DenseWeights();
+
+    DenseWeights(const DenseWeights &) = delete;
+    DenseWeights & operator=(const DenseWeights &) = delete;
+
+    // The dense byte ranges: the complement of `expert_ranges` within [0, file_size). Sorts the
+    // input; the result is the gaps between expert ranges plus the trailing tail. The single source
+    // of truth every consumer here shares.
+    static std::vector<std::pair<uint64_t, uint64_t>>
+    byte_ranges(std::vector<std::pair<uint64_t, uint64_t>> expert_ranges, uint64_t file_size);
+
+    // Apply `mode` for the model at `path` (dense `ranges` precomputed via byte_ranges; `tensors`
+    // needed only for Anonymous). `align` is the O_DIRECT block size. Runs once at load, before the
+    // streamer's workers start (Anonymous rebinds tensor->data on the caller's thread). Returns false
+    // only on a hard Anonymous failure (alloc/read); Mmap and Warmed cannot fail.
+    bool init(DenseWeightsMode mode,
+              const std::string & path,
+              size_t align,
+              std::vector<std::pair<uint64_t, uint64_t>> ranges,
+              std::vector<DenseTensorRef> tensors);
+
+    // Sample how much of the dense set the kernel still has in RAM (mincore), setting resident_frac().
+    // Anonymous samples the anon buffers; Mmap/Warmed sample the mmap ranges via /proc/self/maps.
+    // The caller throttles (calls this only when it wants a fresh sample); `page` is the OS page size.
+    void sample_residency(size_t page);
+    double resident_frac() const { return resident_frac_; }
+
+    // Re-run the warm sweep (a best-effort response to the dense set being reclaimed). A no-op unless
+    // the mode is Warmed — Mmap never warmed, Anonymous has no mmap left to warm.
+    void rewarm();
+
+    void shutdown();
+
+    static constexpr int sample_pages = 256; // stratified probe points across the dense bytes
+
+private:
+    bool read_anonymous(size_t align);
+    void warm();
+    void drop_mmap_copies(size_t page);
+    void sample_anon(size_t page);
+    void sample_mmap(size_t page);
+
+    DenseWeightsMode mode_ = DenseWeightsMode::Warmed;
+    std::string path_;
+    std::string basename_;
+    size_t align_ = 4096;
+
+    // Anonymous: our own reader, the tensors we read, the buffers backing them (paired with sizes).
+    FileReader reader_;
+    std::vector<DenseTensorRef> tensors_;
+    std::vector<void *> bufs_;
+    std::vector<size_t> buf_sz_;
+
+    // Mmap/Warmed: the dense byte ranges and the mmap VMAs that back them, resolved once from
+    // /proc/self/maps for the sensor.
+    std::vector<std::pair<uint64_t, uint64_t>> ranges_;
+    std::vector<pio::MappedRegion> vmas_;
+    bool vmas_tried_ = false;
+
+    double resident_frac_ = -1.0; // last sampled dense residency; -1 = never/unmeasured
+};
+
+} // namespace bmoe

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -34,7 +34,6 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     n_expert_ = n_expert;
     layers_ = std::move(layers);
     n_layer_ = (int) layers_.size();
-    o_direct_ = cfg.o_direct;
     load_all_ = cfg.load_all;
     overlap_ = cfg.overlap;
     prefetch_sync_ = cfg.prefetch_sync && !cfg.overlap; // serial only: overlap lane 0 is a worker
@@ -150,71 +149,12 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         clookups_ = 0;
     }
 
-    // Read pool: a private fd + bounce per lane so concurrent preads never contend.
+    // Read pool: the reader owns a private fd + bounce per lane so concurrent preads never contend,
+    // and the O_DIRECT request + its verify/fallback. The dense-weights loader opens its own reader,
+    // so its cache-bypass choice is independent of this one.
     const size_t max_slice = max_full_any / (size_t) n_expert_;
     const size_t bounce_cap = max_slice + 2 * align_;
-
-    pio::fd_t primary = pio::open_read(gguf_path.c_str(), o_direct_);
-    if (!pio::fd_ok(primary) && o_direct_) {
-        o_direct_ = false;
-        primary = pio::open_read(gguf_path.c_str(), false);
-    }
-    if (!pio::fd_ok(primary)) {
-        std::fprintf(stderr, "bmoe: open %s failed\n", gguf_path.c_str());
-        return false;
-    }
-    fsize_ = pio::file_size(primary);
-
-    // Verify O_DIRECT actually returns correct bytes on this storage. On some emulated / FUSE-backed
-    // volumes (e.g. an app-private dir under /storage/emulated) the open SUCCEEDS but direct reads
-    // return garbage, silently corrupting expert weights → nonsense output. Compare one aligned
-    // block read directly against the same block read buffered; on any mismatch, fall back to
-    // buffered I/O for this file. On real filesystems (adb-pushed models, desktop) the two match
-    // and O_DIRECT is kept.
-    if (o_direct_ && fsize_ >= (uint64_t) align_) {
-        uint64_t voff = (fsize_ / 2) & ~(uint64_t) (align_ - 1);
-        if (voff + align_ > fsize_) voff = 0;
-        void * dbuf = pio::alloc_aligned(align_, align_);
-        pio::fd_t vfd = pio::open_read(gguf_path.c_str(), false);
-        if (dbuf && pio::fd_ok(vfd)) {
-            std::vector<char> bbuf(align_);
-            const long long want = (long long) align_;
-            const long long gd = pio::pread_at(primary, dbuf, align_, voff);
-            const long long gb = pio::pread_at(vfd, bbuf.data(), align_, voff);
-            const bool bad = gd != want || gb != want || std::memcmp(dbuf, bbuf.data(), align_) != 0;
-            if (bad) {
-                std::fprintf(stderr, "bmoe: O_DIRECT returns wrong data on this storage — using buffered I/O\n");
-                o_direct_ = false;
-                pio::close_fd(primary);
-                primary = pio::open_read(gguf_path.c_str(), false);
-            }
-        }
-        if (dbuf) pio::aligned_free(dbuf);
-        if (pio::fd_ok(vfd)) pio::close_fd(vfd);
-        if (!pio::fd_ok(primary)) {
-            std::fprintf(stderr, "bmoe: reopen after O_DIRECT check failed\n");
-            return false;
-        }
-    }
-
-    fds_.assign(io_threads_, pio::fd_invalid);
-    fds_buf_.assign(io_threads_, pio::fd_invalid);
-    bounces_.assign(io_threads_, nullptr);
-    bounce_sz_.assign(io_threads_, 0);
-    for (int lane = 0; lane < io_threads_; ++lane) {
-        fds_[lane] = (lane == 0) ? primary : pio::open_read(gguf_path.c_str(), o_direct_);
-        fds_buf_[lane] = o_direct_ ? pio::open_read(gguf_path.c_str(), false) : pio::fd_invalid;
-        if (!pio::fd_ok(fds_[lane])) {
-            std::fprintf(stderr, "bmoe: lane %d open failed\n", lane);
-            return false;
-        }
-        bounces_[lane] = pio::alloc_aligned(align_, bounce_cap);
-        if (!bounces_[lane]) {
-            std::fprintf(stderr, "bmoe: lane %d bounce alloc failed\n", lane);
-            return false;
-        }
-        bounce_sz_[lane] = bounce_cap;
-    }
+    if (!reader_.open(gguf_path, io_threads_, cfg.o_direct, align_, bounce_cap)) return false;
 
     seen_.assign(n_expert_, 0);
     jobs_.reserve((size_t) n_expert_ * MoeRecipe::max_exps);
@@ -264,7 +204,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
             if (r.first > pos) dense_ranges_.push_back({pos, r.first});
             pos = std::max(pos, r.second);
         }
-        if (pos < fsize_) dense_ranges_.push_back({pos, fsize_});
+        if (pos < reader_.file_size()) dense_ranges_.push_back({pos, reader_.file_size()});
     }
 
     // --dense-odirect: read the dense weights into our own anon buffers and rebind their tensors,
@@ -291,7 +231,7 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         io_pool_.emplace_back(&ExpertStreamSource::io_worker, this, lane);
 
     std::fprintf(stderr, "bmoe: expert streaming ON  n_expert=%d o_direct=%d io_threads=%d cache=%zu MiB\n", n_expert_,
-                 (int) o_direct_, io_threads_, cache_max_ >> 20);
+                 (int) reader_.direct(), io_threads_, cache_max_ >> 20);
     return true;
 }
 
@@ -340,7 +280,7 @@ void ExpertStreamSource::warm_dense_regions(const std::string & gguf_path) {
         if (r.first > pos) sweep(pos, r.first); // gap before this expert range is dense
         pos = std::max(pos, r.second);
     }
-    if (pos < fsize_) sweep(pos, fsize_); // trailing dense tail (lm_head et al.)
+    if (pos < reader_.file_size()) sweep(pos, reader_.file_size()); // trailing dense tail (lm_head et al.)
 
     pio::aligned_free(buf);
     pio::close_fd(fd);
@@ -424,64 +364,27 @@ bool ExpertStreamSource::read_dense_odirect() {
 }
 
 // ── one aligned slice read on a lane ────────────────────────────────────────────────
+// The bytes come from the reader; this wraps it with the domain the reader must not know about — the
+// per-read I/O trace that attributes a read to its (layer, expert, projection). Latency is timed here
+// so the row carries this read's own cost, not the reader's running total.
 bool ExpertStreamSource::read_slice(int lane, const IoJob & j) {
-    void * const dst = j.dst;
-    const uint64_t off = j.off, nbytes = j.nbytes;
-    if (nbytes == 0) return true;
-    const uint64_t a0 = off & ~(uint64_t) (align_ - 1);
-    const uint64_t a1 = (off + nbytes + align_ - 1) & ~(uint64_t) (align_ - 1);
-    const size_t len = (size_t) (a1 - a0);
-    if (bounce_sz_[lane] < len) {
-        if (bounces_[lane]) pio::aligned_free(bounces_[lane]);
-        bounces_[lane] = pio::alloc_aligned(align_, len);
-        if (!bounces_[lane]) {
-            std::fprintf(stderr, "bmoe: bounce realloc %zu failed\n", len);
-            return false;
-        }
-        bounce_sz_[lane] = len;
-    }
-    char * b = (char *) bounces_[lane];
-    const pio::fd_t fd = fds_[lane];
-    const pio::fd_t fd_buf = fds_buf_[lane];
-    const uint64_t read_end = (fsize_ && a1 > fsize_) ? fsize_ : a1;
-    const uint64_t bulk_end = o_direct_ ? (read_end & ~(uint64_t) (align_ - 1)) : read_end;
-
+    if (j.nbytes == 0) return true;
     const auto t0 = clock_t_::now();
-    for (uint64_t a = a0; a < bulk_end;) {
-        long long got = pio::pread_at(fd, b + (a - a0), (size_t) (bulk_end - a), a);
-        if (got <= 0) {
-            std::fprintf(stderr, "bmoe: pread failed at %llu\n", (unsigned long long) a);
-            return false;
-        }
-        a += (uint64_t) got;
-    }
-    for (uint64_t a = bulk_end; a < read_end;) { // sub-alignment EOF tail via the buffered fd
-        long long got = pio::pread_at(pio::fd_ok(fd_buf) ? fd_buf : fd, b + (a - a0), (size_t) (read_end - a), a);
-        if (got <= 0) {
-            std::fprintf(stderr, "bmoe: tail pread failed at %llu\n", (unsigned long long) a);
-            return false;
-        }
-        a += (uint64_t) got;
-    }
-    const auto t1 = clock_t_::now();
-    const uint64_t lat_ns = (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-    io_syscall_ns_.fetch_add((long long) lat_ns);
-    std::memcpy(dst, b + (off - a0), (size_t) nbytes);
-    read_bytes_.fetch_add((long long) (read_end - a0));
+    const long long window = reader_.read(lane, j.dst, j.off, j.nbytes);
+    if (window < 0) return false;
 
-    // The trace records the read as issued, not as accounted: `read_bytes` is the aligned window
-    // actually pulled, which is what the drive was asked for and what the effective bandwidth must
-    // be judged against — `req_bytes` is only what the caller wanted out of it.
     if (io_trace_on_) {
+        const uint64_t lat_ns =
+            (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count();
         IoTraceRow r;
         r.layer = j.layer;
         r.expert = j.expert;
         r.proj = (int8_t) j.proj;
         r.lane = (int8_t) lane;
         r.spec = j.spec;
-        r.offset = off;
-        r.req_bytes = nbytes;
-        r.read_bytes = read_end - a0;
+        r.offset = j.off;
+        r.req_bytes = j.nbytes;
+        r.read_bytes = (uint64_t) window; // the aligned window pulled — what bandwidth is judged against
         r.latency_ns = lat_ns;
         std::lock_guard<std::mutex> lk(io_trace_mtx_);
         io_trace_rows_.push_back(r);
@@ -1298,11 +1201,11 @@ void ExpertStreamSource::enable_overlap_hook() {
 
 IExpertSource::Stats ExpertStreamSource::stats() const {
     Stats s;
-    s.read_bytes = (uint64_t) read_bytes_.load();
+    s.read_bytes = (uint64_t) reader_.read_bytes();
     // Serial: read_ns_ is the wall time the caller was blocked in the read phase. Overlap: the
-    // caller never blocks, so "I/O time" is instead the summed lane-busy time (io_syscall_ns_),
-    // which the runtime reports as lane-busy per token rather than as a slice of wall time.
-    s.read_seconds = (overlap_ ? io_syscall_ns_.load() : read_ns_.load()) / 1e9;
+    // caller never blocks, so "I/O time" is instead the summed lane-busy time (the reader's syscall
+    // ns), which the runtime reports as lane-busy per token rather than as a slice of wall time.
+    s.read_seconds = (overlap_ ? reader_.syscall_ns() : read_ns_.load()) / 1e9;
     s.mgmt_seconds = mgmt_ns_.load() / 1e9;
     s.spec_read_bytes = (uint64_t) spec_read_bytes_.load();
     s.spec_experts = spec_experts_.load();
@@ -1362,10 +1265,6 @@ void ExpertStreamSource::shutdown() {
         lbuf_[p].clear();
         lbuf_sz_[p].clear();
     }
-    for (void * b : bounces_)
-        if (b) pio::aligned_free(b);
-    bounces_.clear();
-    bounce_sz_.clear();
     // --dense-odirect anon buffers. Safe here: the context (whose rebound dense tensors point at
     // these) is torn down after the source, and no decode is in flight — same contract as the slot
     // and LRU buffers freed above.
@@ -1374,12 +1273,7 @@ void ExpertStreamSource::shutdown() {
     dense_bufs_.clear();
     dense_buf_sz_.clear();
     dense_tensors_.clear();
-    for (int lane = 0; lane < (int) fds_.size(); ++lane) {
-        if (pio::fd_ok(fds_[lane])) pio::close_fd(fds_[lane]);
-        if (pio::fd_ok(fds_buf_[lane])) pio::close_fd(fds_buf_[lane]);
-    }
-    fds_.clear();
-    fds_buf_.clear();
+    reader_.close(); // closes the lane fds and frees the bounces
     jobs_.clear();
     layers_.clear();
     active_ = false;

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -38,7 +38,6 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
     overlap_ = cfg.overlap;
     prefetch_sync_ = cfg.prefetch_sync && !cfg.overlap; // serial only: overlap lane 0 is a worker
     cache_dynamic_ = cfg.cache_dynamic;
-    dense_odirect_ = cfg.dense_odirect;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
 
@@ -185,11 +184,12 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         }
     }
 
-    // The dense byte ranges are the complement of the expert ranges in the file — the same set
-    // warm_dense_regions sweeps. Kept here so the dense-residency sensor can find them at runtime
-    // without recomputing; the path is kept alongside to locate the mmap in /proc/self/maps.
-    gguf_path_ = gguf_path;
-    if (cache_dynamic_) {
+    // Hand the dense (non-expert) weights to their policy module: it warms them into the page cache,
+    // or reads them into anon buffers and rebinds, and owns the residency sensor — all on the caller's
+    // thread before the workers start (the Anonymous mode rebinds tensor->data). The dense byte ranges
+    // are the complement of the expert ranges in the file, computed once here and shared by the warm
+    // sweep and the sensor.
+    {
         std::vector<std::pair<uint64_t, uint64_t>> exp;
         for (const LayerExperts & L : layers_) {
             if (!L.bound) continue;
@@ -198,29 +198,12 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
                 if (sz) exp.push_back({L.proj[p].file_off, L.proj[p].file_off + sz});
             }
         }
-        std::sort(exp.begin(), exp.end());
-        uint64_t pos = 0;
-        for (const auto & r : exp) {
-            if (r.first > pos) dense_ranges_.push_back({pos, r.first});
-            pos = std::max(pos, r.second);
+        auto ranges = DenseWeights::byte_ranges(std::move(exp), reader_.file_size());
+        if (!dense_.init(cfg.dense_weights, gguf_path, align_, std::move(ranges), std::move(dense_tensors_))) {
+            std::fprintf(stderr, "bmoe: dense-weights init failed\n");
+            return false;
         }
-        if (pos < reader_.file_size()) dense_ranges_.push_back({pos, reader_.file_size()});
     }
-
-    // --dense-odirect: read the dense weights into our own anon buffers and rebind their tensors,
-    // once, on lane 0 while it is still the caller's thread and no worker is running. Must precede
-    // warm_dense (which becomes pointless — the dense is no longer mmap'd) and the workers.
-    if (dense_odirect_ && !dense_tensors_.empty() && !read_dense_odirect()) {
-        std::fprintf(stderr, "bmoe: --dense-odirect read failed\n");
-        return false;
-    }
-
-    // Warm the dense (non-expert) regions into the page cache before the first token, so the early
-    // decodes do not fault them in one scattered 4 KiB page at a time. Independent of the cache
-    // budget: it only pre-faults the mmap-resident pages, it neither pins nor reserves them. Runs on
-    // the caller's thread (the workers are not started yet). Skipped under --dense-odirect: those
-    // weights are our anon buffers now, not the mmap this would warm.
-    if (cfg.warm_dense && !dense_odirect_) warm_dense_regions(gguf_path);
 
     active_ = true;
     // Serial: lane 0 is the calling thread (it drains inline), workers own lanes 1..N-1.
@@ -232,134 +215,6 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
 
     std::fprintf(stderr, "bmoe: expert streaming ON  n_expert=%d o_direct=%d io_threads=%d cache=%zu MiB\n", n_expert_,
                  (int) reader_.direct(), io_threads_, cache_max_ >> 20);
-    return true;
-}
-
-// ── dense warm-up: sequentially page-cache everything that is not an expert tensor ──
-void ExpertStreamSource::warm_dense_regions(const std::string & gguf_path) {
-    // The complement of the expert byte ranges is the dense set: gguf header/metadata plus every
-    // tensor the streamer leaves mmap-resident (embeddings, attention, norms, lm_head). Buffered
-    // reads land in the same page cache the mmap is served from, so one sequential sweep here
-    // replaces thousands of random 4 KiB major faults during the first decodes. Best-effort: a read
-    // failure only leaves the corresponding pages cold.
-    std::vector<std::pair<uint64_t, uint64_t>> expert_ranges;
-    for (const LayerExperts & L : layers_) {
-        if (!L.bound) continue;
-        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
-            const uint64_t sz = (uint64_t) L.proj[p].nb2 * (uint64_t) n_expert_;
-            if (sz) expert_ranges.push_back({L.proj[p].file_off, L.proj[p].file_off + sz});
-        }
-    }
-    std::sort(expert_ranges.begin(), expert_ranges.end());
-
-    pio::fd_t fd = pio::open_read(gguf_path.c_str(), false);
-    if (!pio::fd_ok(fd)) return;
-    const size_t chunk = 8ull << 20;
-    void * buf = pio::alloc_aligned(align_, chunk);
-    if (!buf) {
-        pio::close_fd(fd);
-        return;
-    }
-
-    const auto t0 = clock_t_::now();
-    uint64_t warmed = 0;
-    bool ok = true;
-    auto sweep = [&](uint64_t beg, uint64_t end) {
-        for (uint64_t a = beg; a < end && ok;) {
-            const long long got = pio::pread_at(fd, buf, (size_t) std::min<uint64_t>(chunk, end - a), a);
-            if (got <= 0) {
-                ok = false; // best-effort: those pages just stay cold
-                break;
-            }
-            a += (uint64_t) got;
-            warmed += (uint64_t) got;
-        }
-    };
-    uint64_t pos = 0;
-    for (const auto & r : expert_ranges) {
-        if (r.first > pos) sweep(pos, r.first); // gap before this expert range is dense
-        pos = std::max(pos, r.second);
-    }
-    if (pos < reader_.file_size()) sweep(pos, reader_.file_size()); // trailing dense tail (lm_head et al.)
-
-    pio::aligned_free(buf);
-    pio::close_fd(fd);
-    const double s = std::chrono::duration<double>(clock_t_::now() - t0).count();
-    std::fprintf(stderr, "bmoe: dense warm-up — %llu MiB in %.1f s%s\n", (unsigned long long) (warmed >> 20), s,
-                 ok ? "" : " (partial)");
-}
-
-// ── --dense-odirect: read each dense tensor whole into an anon buffer and rebind onto it ──
-bool ExpertStreamSource::read_dense_odirect() {
-    // Chunked so read_slice's per-lane bounce stays bounded (a dense tensor can be hundreds of MiB);
-    // each chunk re-reads at most one partial page at its boundary, which is harmless. Lane 0 only —
-    // this runs before the workers start, so there is no contention on the bounce or fd.
-    const uint64_t chunk = 8ull << 20;
-    uint64_t total = 0;
-    dense_bufs_.reserve(dense_tensors_.size());
-    dense_buf_sz_.reserve(dense_tensors_.size());
-    for (const DenseTensorRef & d : dense_tensors_) {
-        if (!d.tensor || d.size == 0) continue;
-        void * buf = pio::alloc_aligned(align_, (size_t) d.size);
-        if (!buf) {
-            std::fprintf(stderr, "bmoe: dense buffer alloc %llu failed\n", (unsigned long long) d.size);
-            return false;
-        }
-        dense_bufs_.push_back(buf); // tracked for shutdown even if a chunk read below fails
-        dense_buf_sz_.push_back((size_t) d.size); // paired size, for the anon-residency sample
-        for (uint64_t done = 0; done < d.size;) {
-            IoJob j;
-            j.dst = (char *) buf + done;
-            j.off = d.file_off + done;
-            j.nbytes = std::min<uint64_t>(chunk, d.size - done);
-            if (!read_slice(0, j)) return false;
-            done += j.nbytes;
-        }
-        d.tensor->data = buf; // rebind the model weight onto its private anon copy
-        total += d.size;
-    }
-    std::fprintf(stderr, "bmoe: --dense-odirect — %llu MiB of dense weights in %zu anon buffers\n",
-                 (unsigned long long) (total >> 20), dense_bufs_.size());
-
-    // Hand the mmap copies back. The capture warm-up decode faulted these dense pages in mmap-
-    // resident, and we have just read them again into anon buffers and rebound every tensor onto
-    // those — so the file-backed pages are now referenced by nobody. Left alone they sit resident
-    // until reclaim, doubling the dense footprint at the worst moment (right before prefill, when the
-    // governor's entry test reads MemAvailable). Drop them explicitly instead: a clean read-only
-    // mapping, so MADV_DONTNEED loses no data and nothing will refault the range. Best-effort — it
-    // needs /proc/self/maps to turn a file offset into an address; where that is unreadable (or the
-    // host build) the pages simply stay, which only forfeits the saving.
-    std::vector<pio::MappedRegion> vmas;
-    const size_t slash = gguf_path_.find_last_of("/\\");
-    const std::string base = slash == std::string::npos ? gguf_path_ : gguf_path_.substr(slash + 1);
-    if (pio::file_mapped_regions(base.c_str(), vmas) && !vmas.empty()) {
-        const size_t pg = pio::vm_page();
-        auto addr_of = [&](uint64_t off) -> char * {
-            for (const auto & v : vmas) {
-                const uint64_t span = (uint64_t) (v.end - v.start);
-                if (off >= v.file_offset && off < v.file_offset + span) return (char *) v.start + (off - v.file_offset);
-            }
-            return nullptr;
-        };
-        uint64_t dropped = 0;
-        for (const DenseTensorRef & d : dense_tensors_) {
-            if (!d.tensor || d.size == 0) continue;
-            char * a = addr_of(d.file_off);
-            if (!a) continue;
-            // Align INWARD to whole pages (round the start up, the end down), so a page shared with an
-            // adjacent tensor that stays mmap-resident — an expert slice, or the next dense tensor — is
-            // never dropped out from under it. Same clipping the residency sampler applies.
-            uintptr_t a0 = ((uintptr_t) a + pg - 1) & ~(uintptr_t) (pg - 1);
-            uintptr_t a1 = ((uintptr_t) a + d.size) & ~(uintptr_t) (pg - 1);
-            if (a1 > a0) {
-                pio::vm_drop_file_pages((void *) a0, (size_t) (a1 - a0));
-                dropped += a1 - a0;
-            }
-        }
-        if (dropped)
-            std::fprintf(stderr, "bmoe: --dense-odirect — dropped %llu MiB of now-unused mmap pages\n",
-                         (unsigned long long) (dropped >> 20));
-    }
     return true;
 }
 
@@ -616,95 +471,6 @@ void ExpertStreamSource::sample_residency() {
     resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
 }
 
-// The dense weights' residency, the half resident_frac cannot see. The weights are one mmap of the
-// gguf; a dense file offset becomes an address through the VMA that backs it (/proc/self/maps),
-// which — unlike /proc/vmstat — an app may read, being its own. Probe dense_sample_pages points
-// spread evenly across the dense byte ranges; one page each, so the cost is a few hundred mincore
-// calls, and only every residency_probe_every load. Shares probe_tick_ with sample_residency, so it
-// fires on the same throttle without a second counter.
-void ExpertStreamSource::sample_dense_residency() {
-    // Under --dense-odirect the dense weights are our own anon buffers, not the mmap the block below
-    // samples. But anon memory is reclaimed too (to zram), and mincore reports resident anon pages
-    // exactly as it does file pages — so sample the buffers directly and dense_resident_frac keeps its
-    // meaning ("how much of the dense set the kernel still has in RAM") instead of reading unmeasured.
-    if (dense_odirect_) {
-        if (dense_bufs_.empty()) return;
-        // Share sample_residency's throttle: it has just done the ++ this load, so fire on the same
-        // loads and skip the rest, without a second counter.
-        if (probe_tick_ % residency_probe_every != 0) return;
-        uint64_t total = 0;
-        for (size_t sz : dense_buf_sz_)
-            total += sz;
-        if (total == 0) return;
-        size_t sampled = 0, resident = 0;
-        for (int k = 0; k < dense_sample_pages; ++k) {
-            // Stratified: the k-th of dense_sample_pages evenly spaced points across the summed buffer
-            // bytes, one page each — the same shape as the mmap path, so the two modes are comparable.
-            uint64_t target = (total * (uint64_t) k) / (uint64_t) dense_sample_pages;
-            for (size_t i = 0; i < dense_bufs_.size(); ++i) {
-                if (target < dense_buf_sz_[i]) {
-                    const char * a = (const char *) dense_bufs_[i] + target;
-                    const char * pg = (const char *) ((uintptr_t) a & ~(uintptr_t) (page_ - 1));
-                    pio::vm_resident_sample(pg, page_, &sampled, &resident);
-                    break;
-                }
-                target -= dense_buf_sz_[i];
-            }
-        }
-        dense_resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
-        return;
-    }
-    if (dense_ranges_.empty()) return;
-    // Share sample_residency's throttle without a second counter: it has just done the ++, so this
-    // fires exactly on the loads where it did, and skips the rest.
-    if (probe_tick_ % residency_probe_every != 0) return;
-    if (!dense_vmas_tried_) { // resolve the mmap once; llama.cpp has mapped the file by first decode
-        dense_vmas_tried_ = true;
-        const size_t slash = gguf_path_.find_last_of("/\\");
-        const std::string base = slash == std::string::npos ? gguf_path_ : gguf_path_.substr(slash + 1);
-        pio::file_mapped_regions(base.c_str(), dense_vmas_);
-    }
-    if (dense_vmas_.empty()) return; // maps unreadable → leave dense_resident_frac_ at -1
-
-    uint64_t total = 0;
-    for (const auto & r : dense_ranges_)
-        total += r.second - r.first;
-    if (total == 0) return;
-
-    // Map a file offset to a virtual address via the VMA that contains it. A large mmap can be split
-    // into several VMAs, so search rather than assume one.
-    auto addr_of = [&](uint64_t off) -> const char * {
-        for (const auto & v : dense_vmas_) {
-            const uint64_t span = (uint64_t) (v.end - v.start);
-            if (off >= v.file_offset && off < v.file_offset + span)
-                return (const char *) v.start + (off - v.file_offset);
-        }
-        return nullptr;
-    };
-
-    size_t sampled = 0, resident = 0;
-    for (int k = 0; k < dense_sample_pages; ++k) {
-        // Stratified: the k-th of dense_sample_pages evenly spaced points across the dense bytes.
-        uint64_t target = (total * (uint64_t) k) / (uint64_t) dense_sample_pages;
-        uint64_t off = 0;
-        for (const auto & r : dense_ranges_) {
-            const uint64_t len = r.second - r.first;
-            if (target < len) {
-                off = r.first + target;
-                break;
-            }
-            target -= len;
-        }
-        // Align the probe DOWN to its page: vm_resident_sample counts only pages fully inside the
-        // range, so a single page's worth handed in at an arbitrary offset would clip to nothing.
-        if (const char * a = addr_of(off)) {
-            const char * pg = (const char *) ((uintptr_t) a & ~(uintptr_t) (page_ - 1));
-            pio::vm_resident_sample(pg, page_, &sampled, &resident);
-        }
-    }
-    dense_resident_frac_ = sampled ? (double) resident / (double) sampled : -1.0;
-}
-
 // A token's pass over the layer stack is monotonic in il, so a non-increasing layer index means the
 // previous token's pass just ended and the bytes it demanded are known. Prefill measures the
 // batch's union (larger); the first decode token overwrites it with the decode value, which is the
@@ -857,8 +623,8 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
         // loop, where an evicting shrink is safe) and we only sense here; otherwise the legacy
         // free-RAM tracking sizes it in place.
         if (cache_dynamic_) {
-            sample_residency();
-            sample_dense_residency();
+            sample_residency(); // increments probe_tick_ and samples the cache on the throttle tick
+            if (probe_tick_ % residency_probe_every == 0) dense_.sample_residency(page_); // the same tick
         } else {
             adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
         }
@@ -1008,8 +774,8 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
         quiesce_spec();
         // See the serial path: the governor owns the budget when it is on, and only senses here.
         if (cache_dynamic_) {
-            sample_residency();
-            sample_dense_residency();
+            sample_residency(); // increments probe_tick_ and samples the cache on the throttle tick
+            if (probe_tick_ % residency_probe_every == 0) dense_.sample_residency(page_); // the same tick
         } else {
             adapt_cache_budget(); // re-size to free RAM before this layer stages + evicts
         }
@@ -1217,7 +983,7 @@ IExpertSource::Stats ExpertStreamSource::stats() const {
     s.cache_budget_bytes = (uint64_t) cache_max_;
     s.cache_resizes = cache_resizes_;
     s.cache_resident_frac = resident_frac_;
-    s.dense_resident_frac = dense_resident_frac_;
+    s.dense_resident_frac = dense_.resident_frac();
     s.token_demand_bytes = (uint64_t) token_demand_;
     s.layer_demand_bytes = (uint64_t) layer_demand_;
     return s;
@@ -1265,13 +1031,10 @@ void ExpertStreamSource::shutdown() {
         lbuf_[p].clear();
         lbuf_sz_[p].clear();
     }
-    // --dense-odirect anon buffers. Safe here: the context (whose rebound dense tensors point at
-    // these) is torn down after the source, and no decode is in flight — same contract as the slot
-    // and LRU buffers freed above.
-    for (void * b : dense_bufs_)
-        if (b) pio::aligned_free(b);
-    dense_bufs_.clear();
-    dense_buf_sz_.clear();
+    // The dense-weights module frees its own anon buffers here. Safe: the context (whose rebound
+    // dense tensors point at them) is torn down after the source, and no decode is in flight — same
+    // contract as the slot and LRU buffers freed above.
+    dense_.shutdown();
     dense_tensors_.clear();
     reader_.close(); // closes the lane fds and frees the bounces
     jobs_.clear();

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -20,6 +20,7 @@
 #include "bmoe/recipe.h"
 #include "../io/platform_io.h"
 #include "../io/file_reader.h"
+#include "dense_weights.h" // DenseWeights + DenseTensorRef
 
 #include <atomic>
 #include <condition_variable>
@@ -39,15 +40,6 @@ struct ExpertTensorRef {
     ggml_tensor * tensor = nullptr; // persistent weight tensor whose ->data we rebind
     uint64_t file_off = 0;          // absolute file offset of the tensor's data
     uint64_t nb2 = 0;               // bytes per expert (== tensor->nb[2])
-};
-
-// One dense (non-expert) weight tensor to read once via O_DIRECT and rebind onto our own
-// anonymous buffer, for the --dense-odirect experiment. Unlike an expert slice, a dense tensor is
-// read whole and contiguous: `size` bytes from `file_off`, matching its gguf on-disk layout.
-struct DenseTensorRef {
-    ggml_tensor * tensor = nullptr; // persistent weight tensor whose ->data we rebind
-    uint64_t file_off = 0;          // absolute file offset of the tensor's data
-    uint64_t size = 0;              // its data size in bytes (== ggml_nbytes)
 };
 
 // The expert weight tensors of one MoE layer, one per recipe suffix slot. The split
@@ -72,10 +64,9 @@ public:
     bool
     init(const std::string & gguf_path, int n_expert, std::vector<LayerExperts> layers, const MoeStreamConfig & cfg);
 
-    // Supply the dense (non-expert) weight tensors to read via O_DIRECT and rebind, for the
-    // --dense-odirect experiment. Call BEFORE init (which does the read); a no-op unless
-    // cfg.dense_odirect is set. The runtime builds the list from the captured weight leaves and the
-    // gguf offsets. See docs/pressure.md.
+    // Supply the dense (non-expert) weight tensors the DenseWeights policy may need (only the
+    // Anonymous mode reads+rebinds them). Call BEFORE init, which hands them to the dense module.
+    // The runtime builds the list from the captured weight leaves and the gguf offsets.
     void set_dense_tensors(std::vector<DenseTensorRef> dense) { dense_tensors_ = std::move(dense); }
 
     // IExpertSource
@@ -146,15 +137,8 @@ private:
 
     // One sequential buffered sweep over the file's non-expert byte ranges (header, embeddings,
     // attention, norms, lm_head) to populate the kernel page cache at load time, so the mmap'd
-    // dense tensors do not demand-fault 4 KiB at a time inside the first decodes. Best-effort:
-    // a read failure only leaves the corresponding pages cold.
-    void warm_dense_regions(const std::string & gguf_path);
-
-    // Experiment (--dense-odirect): read every dense tensor once via O_DIRECT into an aligned anon
-    // buffer and rebind its ->data onto it, so the dense weights are anonymous (a reclaim swaps
-    // them to zram instead of dropping them to a 4 KiB flash refault). Done once in init, on lane 0,
-    // before the workers start; the buffers are freed in shutdown(). Returns false on any failure.
-    bool read_dense_odirect();
+    // dense tensors do not demand-fault 4 KiB at a time inside the first decodes. The dense-weights
+    // policy (warm sweep, anonymous rebind, and the residency sensor) lives in DenseWeights (dense_).
 
     // Adaptive sizing (cache_auto): re-probe device memory (throttled) and nudge cache_max_ so it
     // tracks free RAM. Eval-thread only, called in the mgmt section of load_layer; the eviction
@@ -164,15 +148,9 @@ private:
     // Pressure sensing (cache_dynamic): sample (throttled) how much of the cache the kernel still
     // has in RAM, walking the LRU cold end — the pages reclaim takes first, so a dip here is the
     // earliest evidence the budget outgrew what the device concedes. Sets resident_frac_ for the
-    // governor; changes no budget itself. Eval-thread only (it walks the LRU list).
+    // governor; changes no budget itself. Eval-thread only (it walks the LRU list). The dense half of
+    // the picture is dense_.sample_residency(), fired on the same throttle from load_layer.
     void sample_residency();
-
-    // Companion sensor for the OTHER half of memory: the dense weights, which are mmap'd file-backed
-    // and reclaimed by being dropped (never swapped), so resident_frac — which watches only our anon
-    // cache — is blind to them. A stratified mincore over the dense file ranges says how much of the
-    // model itself the kernel still has. When this falls while resident_frac holds, the faults are
-    // the weights, not the cache, and shrinking the cache cannot help. Sets dense_resident_frac_.
-    void sample_dense_residency();
 
     // Accumulate one token's routed working set. Eval-thread only, called per layer load.
     void account_demand(int il, int n_unique);
@@ -235,22 +213,14 @@ private:
     // rather than hidden in the compute residual.
     static constexpr unsigned residency_probe_every = 128; // load_layer calls between probes (~2-3 tokens)
     static constexpr int residency_sample_entries = 16;    // coldest entries read per probe
-    static constexpr int dense_sample_pages = 256;         // stratified probe points over the dense weights
     bool cache_dynamic_ = false;
-    bool dense_odirect_ = false; // --dense-odirect: read dense weights via O_DIRECT into our buffers
-    std::vector<DenseTensorRef> dense_tensors_; // set before init; read+rebound when dense_odirect_
-    std::vector<void *> dense_bufs_;            // the anon buffers backing them; freed in shutdown()
-    std::vector<size_t> dense_buf_sz_;          // dense_bufs_[i]'s byte size, for the anon-residency sample
-    double resident_frac_ = -1.0;               // last sampled cache residency; -1 = never measured
-    double dense_resident_frac_ = -1.0; // last sampled dense-weight residency; -1 = never measured
+    double resident_frac_ = -1.0; // last sampled cache residency; -1 = never measured
 
-    // The dense weights' byte ranges in the file (complement of the expert ranges), and the mmap VMAs
-    // that back them — resolved once, lazily, from /proc/self/maps. Empty vma set = maps unreadable,
-    // which keeps dense_resident_frac_ at -1 rather than inventing a number.
-    std::string gguf_path_;
-    std::vector<std::pair<uint64_t, uint64_t>> dense_ranges_;
-    std::vector<pio::MappedRegion> dense_vmas_;
-    bool dense_vmas_tried_ = false;
+    // The dense (non-expert) weights: their residency policy (mmap / warm / anon), the buffers it may
+    // hold, and the sensor for the half resident_frac cannot see. Set before init via
+    // set_dense_tensors, then handed to dense_.init(); dense_.resident_frac() feeds the governor.
+    std::vector<DenseTensorRef> dense_tensors_; // pending, set before init; moved into dense_
+    DenseWeights dense_;
 
     // Two measured demands, and the difference between them decides the whole policy.
     //

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -19,6 +19,7 @@
 #include "bmoe/decode_trace.h"
 #include "bmoe/recipe.h"
 #include "../io/platform_io.h"
+#include "../io/file_reader.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -195,14 +196,17 @@ private:
     std::vector<IoTraceRow> io_trace_rows_;
 
     bool active_ = false;
-    bool o_direct_ = false;
     bool load_all_ = false;
     bool overlap_ = false;
     bool prefetch_sync_ = false; // test only: drain prefetch reads synchronously (serial mode)
     int n_layer_ = 0;
     int n_expert_ = 0;
-    uint64_t fsize_ = 0;
     size_t align_ = 4096;
+
+    // The positioned reader that owns the fd pool, bounces and O_DIRECT decision. Expert slices are
+    // read through it; the dense-weights loader constructs its own, so their O_DIRECT choices are
+    // independent (see docs/architecture.md). file_size() replaces the old fsize_ member.
+    FileReader reader_;
 
     std::vector<LayerExperts> layers_;
 
@@ -294,10 +298,6 @@ private:
 
     // I/O lane pool
     int io_threads_ = 1;
-    std::vector<pio::fd_t> fds_;
-    std::vector<pio::fd_t> fds_buf_;
-    std::vector<void *> bounces_;
-    std::vector<size_t> bounce_sz_;
     std::vector<std::thread> io_pool_;
     std::vector<IoJob> jobs_;
     std::mutex io_mtx_;
@@ -309,9 +309,7 @@ private:
     std::atomic<bool> io_err_{false};
     uint32_t batch_flag_gen_ = 0; // async_gen_ of the batch in flight; snapshot under io_mtx_ at publish
 
-    std::atomic<long long> read_bytes_{0};
     std::atomic<long long> read_ns_{0};
-    std::atomic<long long> io_syscall_ns_{0};
     std::atomic<long long> mgmt_ns_{0}; // staging-section time: vm commit + evict + LRU bookkeeping
 
     // ── overlap mode: one layer in flight at a time (guaranteed by graph order) ──

--- a/docs/pressure.md
+++ b/docs/pressure.md
@@ -123,32 +123,33 @@ near the demand holds about one token of routing history and its hits come from 
 correlation only; a budget far above it is either buying real reuse or buying a war, and
 `cache_cuts` says which.
 
-## `--dense-odirect`: make the dense weights anonymous
+## `--dense-weights anon`: make the dense weights anonymous
 
 The governor above manages the *cache*. The other half of the war is the *dense* (non-expert)
-weights, which are mmap'd file-backed: the kernel reclaims them by simply dropping the pages, and a
-later touch demand-faults them back 4 KiB at a time from flash. `--dense-odirect` is an experiment
-(default off, in-app toggle) that removes that half of the mmap from the picture: at load it reads
-each dense tensor once via O_DIRECT into an aligned anonymous buffer and rebinds the tensor onto it.
-A reclaim of anonymous memory swaps to zram rather than dropping to flash, so a refault is a fast
-zram decompress instead of a scattered 4 KiB flash read.
+weights, whose policy is a single knob `--dense-weights mmap|warm|anon` (`DenseWeightsMode`, owned by
+`core/src/moe/dense_weights.h`). `mmap` leaves them file-backed (the kernel reclaims them by dropping
+the pages, and a later touch demand-faults them 4 KiB at a time — the slow-start baseline); `warm`
+(the default) page-caches them once at load; `anon` reads each dense tensor once via O_DIRECT into an
+aligned anonymous buffer and rebinds the tensor onto it. A reclaim of anonymous memory swaps to zram
+rather than dropping to flash, so a refault is a fast zram decompress instead of a scattered flash
+read. (`--dense-odirect` and `--no-warm-dense` remain as deprecated aliases for `anon` and `mmap`.)
 
-The mechanism reuses the expert-capture path: the router hook already records every weight leaf it
-sees in the warm-up graph, and the runtime pairs the non-expert ones with their gguf offsets
-(`ExpertStreamSource::read_dense_odirect`). It is a strict A/B lever, and the analysis says its
-upside is narrow — Q4 weights are close to incompressible, so on a model whose dense set already fits
-resident, moving it flash→zram frees nothing and is a wash. Where it can pay is a model actively
-losing its dense set to reclaim.
+The `anon` read reuses the expert-capture path: the router hook already records every weight leaf it
+sees in the warm-up graph, and the runtime pairs the non-expert ones with their gguf offsets. It reads
+through the dense module's own `FileReader`, so its O_DIRECT choice is independent of the expert
+stream's — the experts can be streamed buffered while the dense set is pulled cache-bypassing, or the
+reverse. It is a strict A/B lever, and the analysis says its upside is narrow — Q4 weights are close
+to incompressible, so on a model whose dense set already fits resident, moving it flash→zram frees
+nothing and is a wash. Where it can pay is a model actively losing its dense set to reclaim.
 
 Two details keep the A/B honest rather than measuring load-time artefacts. First, the capture warm-up
 decode faults the dense pages in *mmap-resident* before the read copies them into the anon buffers, so
-for a moment the dense set is resident twice; once every tensor is rebound, `read_dense_odirect` drops
-those now-unreferenced mmap pages with `MADV_DONTNEED` (`pio::vm_drop_file_pages`), so prefill starts
-from the true anonymous-only footprint instead of a doubled peak that the governor's entry test would
-misread. Second, the dense-residency sensor does not go blind: it samples the anon buffers directly
-(`mincore` reports resident anon pages too), so `dense_resident_frac` keeps its meaning under the flag
-— whether zram is holding the dense set — rather than reading unmeasured. `warm_dense` is skipped (the
-dense is no longer the mmap it would warm).
+for a moment the dense set is resident twice; once every tensor is rebound, the module drops those
+now-unreferenced mmap pages with `MADV_DONTNEED` (`pio::vm_drop_file_pages`), so prefill starts from
+the true anonymous-only footprint instead of a doubled peak the entry test would misread. Second, the
+dense-residency sensor does not go blind: it samples the anon buffers directly (`mincore` reports
+resident anon pages too), so `dense_resident_frac` keeps its meaning under the flag — whether zram is
+holding the dense set — rather than reading unmeasured.
 
 Byte-identity gates: `G6` proves the rebind changes not a single output byte against the mmap-resident
 reference, and `G7` proves the same with O_DIRECT off (the read may bypass the page cache or not; the

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -170,18 +170,17 @@ int main(int argc, char ** argv) {
     streamall.moe.cache_mb = 0;
     streamall.moe.load_all = true;
 
-    // streaming, cache off, dense weights read via O_DIRECT into anon buffers and rebound. warm_dense
-    // off so the gate exercises the rebind alone: the rebound bytes must equal the mmap reference.
+    // streaming, cache off, dense weights read via O_DIRECT into anon buffers and rebound (the
+    // Anonymous policy, which does not warm — so the gate exercises the rebind alone: the rebound
+    // bytes must equal the mmap reference).
     RunConfig dense_od = base(model);
     dense_od.moe.enabled = true;
     dense_od.moe.cache_mb = 0;
     dense_od.moe.io_threads = 4;
-    dense_od.moe.warm_dense = false;
-    dense_od.moe.dense_odirect = true;
+    dense_od.moe.dense_weights = DenseWeightsMode::Anonymous;
 
-    // Same, but with O_DIRECT off: the dense read then lands buffered through read_slice's shared fd.
-    // The rebound bytes must still equal the mmap reference — proves --dense-odirect does not depend on
-    // the underlying read bypassing the page cache.
+    // Same, but with the expert stream's O_DIRECT off: the dense reader still bypasses the cache on
+    // its own choice, so this proves the rebind is byte-identical regardless of the expert flag.
     RunConfig dense_od_buf = dense_od;
     dense_od_buf.moe.o_direct = false;
 
@@ -220,7 +219,7 @@ int main(int argc, char ** argv) {
     // correctness proof for --dense-odirect (the risk is rebinding the wrong tensor).
     fails += check("G6 dense-odirect(rebind) == resident", s_res, s_dod);
     // G7: the rebind is byte-identical whether or not the dense read bypassed the page cache.
-    fails += check("G7 dense-odirect(no O_DIRECT) == resident", s_res, s_dodb);
+    fails += check("G7 dense=anon + expert O_DIRECT off == resident", s_res, s_dodb);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off


### PR DESCRIPTION
## What

Harmonizes how the dense and expert weights do O_DIRECT I/O, and untangles the dense-weights
handling from the expert streamer — the modularity + "which O_DIRECT, dense or expert or a mix"
question that motivated this. Pure structural refactor: **byte-identity gates G1–G7 + S1–S4 green on
both fixtures at every step.**

Stacked on `feat/dense-odirect` (#39).

## The seam, before → after

Before, `ExpertStreamSource` owned everything: the fd pool + bounces + O_DIRECT verify, `read_slice`,
the dense warm sweep, the `--dense-odirect` anon read+rebind+drop, and the dense residency sensor —
and every read rode one `o_direct_` flag, so `--no-odirect` silently changed the dense read too, and
"which bytes are dense" was computed three separate times.

After, three layers:

- **`FileReader`** (`core/src/io/file_reader.{h,cpp}`) — a pooled positioned reader: fd pool, bounces,
  aligned-window mechanics, and the O_DIRECT open+verify+fallback. **O_DIRECT is a property of the
  reader**, chosen by whoever opens it. Knows nothing about experts or dense.
- **`DenseWeights`** (`core/src/moe/dense_weights.{h,cpp}`) — the non-expert weight policy, its
  buffers, and the residency sensor, with one `byte_ranges()` definition shared by all consumers. It
  opens its **own** `FileReader`, so the dense O_DIRECT choice is independent of the expert stream's —
  the experts can stream buffered while the dense set is pulled cache-bypassing, or the reverse.
- **`ExpertStreamSource`** — back to expert streaming + the LRU/slot cache; it *composes* a reader and
  a `DenseWeights`. ~250 lines of non-expert concern left it.

## Policy consolidation

The two bools `warm_dense` + `dense_odirect` collapse into one enum:

```
DenseWeightsMode { Mmap, Warmed (default), Anonymous }
```

CLI gains `--dense-weights mmap|warm|anon`; `--no-warm-dense` (→`Mmap`) and `--dense-odirect`
(→`Anonymous`) stay as **deprecated aliases**, so scripts and the app keep working. The CSV still
emits `warm_dense`/`dense_odirect`, derived from the resolved policy — telemetry and the Android
reader unchanged.

## Answering the original question

Priority isn't dense-O_DIRECT *or* expert-O_DIRECT — it's the **mix**, and this is what makes it
expressible: experts are always direct-streamed (the hot path), and the dense set picks its own policy
per model, with the two O_DIRECT decisions genuinely independent. `G7` proves it: `dense=anon` with
the expert stream's O_DIRECT *off* still produces byte-identical output.

## Not in scope (a separate follow-up)

The measurements say the adaptive cache / governor doesn't pay for the >RAM case this engine exists
for (cache-off is the ceiling). Removing that machinery is a separate cut, deliberately kept out of
this refactor — this branch stays governor-agnostic and would survive it unchanged.

Host build + full `ctest` green. See `docs/pressure.md`, `docs/architecture.md`.


