### PR TITLE
chore: sweep the retired governor's residue from core and CLI

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,3 +1,2 @@
 add_executable(bmoe-cli main.cpp)
 target_link_libraries(bmoe-cli PRIVATE bmoe_core)
-set_target_properties(bmoe-cli PROPERTIES OUTPUT_NAME "bmoe-cli")

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -299,8 +299,7 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
-                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib,
-                    json_escape(r.generated_text).c_str());
+                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
 
@@ -576,9 +575,11 @@ int main(int argc, char ** argv) {
                     s.moe_compute_s_per_token, s.moe_mgmt_s_per_token, s.moe_io_s_per_token,
                     s.moe_io_seconds > 0 ? s.moe_read_mib / s.moe_io_seconds : 0.0);
         if (s.cache_hit_pct >= 0.0) {
+            // The budget is worth printing only when the engine chose it: with an explicit --cache-mb
+            // the reader already knows the number they passed.
             if (cfg.moe.cache_auto)
-                std::printf("moe-cache: %.1f%% hit, resident %.1f MiB, budget %.0f MiB (auto, resized %lld×)\n",
-                            s.cache_hit_pct, s.cache_resident_mib, s.cache_budget_mib, s.cache_resizes);
+                std::printf("moe-cache: %.1f%% hit, resident %.1f MiB, budget %.0f MiB (auto)\n", s.cache_hit_pct,
+                            s.cache_resident_mib, s.cache_budget_mib);
             else
                 std::printf("moe-cache: %.1f%% hit, resident %.1f MiB\n", s.cache_hit_pct, s.cache_resident_mib);
         }

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -31,10 +31,10 @@ struct MoeStreamConfig {
     // so validate() rejects the 1..cache_min_mb-1 band unless force_cache is set.
     int cache_mb = 0;
 
-    // Size the cache from the device instead of a fixed cache_mb: at init the budget is set to
-    // (available RAM − cache_floor_mb), clamped to [cache_min_mb, total expert bytes], and it is
-    // re-checked during generation so it shrinks if free memory falls under the floor (and grows
-    // back within the floor's headroom). Keeps the phone responsive without a hand-tuned number.
+    // Size the cache from the device instead of a fixed cache_mb: once at init the budget is set to
+    // (available RAM − cache_floor_mb), clamped to [cache_min_mb, total expert bytes], and then held
+    // for the whole run. One shot, not a control loop — it spares the caller a hand-tuned number on a
+    // device whose free RAM it cannot know in advance; it does not chase memory pressure afterwards.
     // Mutually exclusive with an explicit cache_mb > 0. See docs/adaptive-cache.md.
     bool cache_auto = false;
     int cache_floor_mb = 1536; // RAM to leave free for the rest of the system when auto-sizing

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -67,8 +67,8 @@ public:
         uint64_t spec_read_bytes = 0;      // bytes read speculatively by prefetch (subset of read_bytes)
         long long spec_experts = 0;        // experts fully prefetched
         long long spec_useful = 0;         // prefetched experts that a later lookup actually hit
-        uint64_t cache_budget_bytes = 0;   // current cache budget (moves under --cache-mb auto)
-        long long cache_resizes = 0;       // times the budget changed at runtime (auto + explicit)
+        uint64_t cache_budget_bytes = 0;   // cache budget in force; fixed for the run once init sizes it
+        long long cache_resizes = 0;       // explicit set_cache_budget_mb() calls that moved the budget
 
         // ── residency telemetry (diagnostic) ──
         // Sampled fraction of the DENSE weights still in RAM, or -1 when not measured yet. Under the

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -92,7 +92,7 @@ public:
 
     // Set the expert-cache budget in MiB and evict down to it now. PRECONDITION: no generate() in
     // flight — call it between generations (e.g. from an app's memory-pressure callback). A no-op
-    // when the cache is off. Complements --cache-mb auto's automatic tracking with explicit control.
+    // when the cache is off. The only way the budget moves after init sizes it.
     void set_cache_budget_mb(int mib);
 
 private:

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -299,14 +299,13 @@ bool scan_kb_file(const char * path, const char * const * keys, uint64_t * out, 
 } // namespace
 
 bool process_memory(ProcessMemory * out) {
-    static const char * const keys[] = {"VmRSS", "RssAnon", "RssFile", "VmSwap", "VmHWM"};
-    uint64_t v[5] = {0, 0, 0, 0, 0};
-    if (!scan_kb_file("/proc/self/status", keys, v, 5)) return false;
+    static const char * const keys[] = {"VmRSS", "RssAnon", "RssFile", "VmSwap"};
+    uint64_t v[4] = {0, 0, 0, 0};
+    if (!scan_kb_file("/proc/self/status", keys, v, 4)) return false;
     out->rss_bytes = v[0];
     out->rss_anon_bytes = v[1];
     out->rss_file_bytes = v[2];
     out->swap_bytes = v[3];
-    out->rss_peak_bytes = v[4];
     return true;
 }
 

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -87,8 +87,8 @@ struct MappedRegion {
 // or if the file cannot be read — the caller reports that as unmeasured, never as "nothing resident".
 bool file_mapped_regions(const char * basename, std::vector<MappedRegion> & out);
 
-// Physical memory currently allocatable without paging, in bytes. 0 = unknown. Used to size the
-// expert cache to the device (--cache-mb auto) and to shrink it under memory pressure at runtime.
+// Physical memory currently allocatable without paging, in bytes. 0 = unknown. Read once at init to
+// size the expert cache to the device (--cache-mb auto); the budget is fixed for the run thereafter.
 uint64_t mem_available_bytes();
 
 // Process-wide compute-decomposition counters, cumulative since process start; the caller deltas
@@ -121,7 +121,6 @@ struct ProcessMemory {
     uint64_t rss_anon_bytes = 0; // RssAnon: our cache lives here
     uint64_t rss_file_bytes = 0; // RssFile: the mmap'd model
     uint64_t swap_bytes = 0;     // VmSwap: anon we have already lost to zram
-    uint64_t rss_peak_bytes = 0; // VmHWM
 };
 // False when the platform cannot report (Windows host), leaving `out` untouched.
 bool process_memory(ProcessMemory * out);

--- a/core/src/moe/dense_weights.cpp
+++ b/core/src/moe/dense_weights.cpp
@@ -148,10 +148,6 @@ void DenseWeights::warm() {
                  ok ? "" : " (partial)");
 }
 
-void DenseWeights::rewarm() {
-    if (mode_ == DenseWeightsMode::Warmed) warm();
-}
-
 // ── residency sensor ─────────────────────────────────────────────────────────────────
 void DenseWeights::sample_residency(size_t page) {
     if (mode_ == DenseWeightsMode::Anonymous)
@@ -203,7 +199,8 @@ void DenseWeights::sample_mmap(size_t page) {
     auto addr_of = [&](uint64_t off) -> const char * {
         for (const auto & v : vmas_) {
             const uint64_t span = (uint64_t) (v.end - v.start);
-            if (off >= v.file_offset && off < v.file_offset + span) return (const char *) v.start + (off - v.file_offset);
+            if (off >= v.file_offset && off < v.file_offset + span)
+                return (const char *) v.start + (off - v.file_offset);
         }
         return nullptr;
     };

--- a/core/src/moe/dense_weights.h
+++ b/core/src/moe/dense_weights.h
@@ -64,10 +64,6 @@ public:
     void sample_residency(size_t page);
     double resident_frac() const { return resident_frac_; }
 
-    // Re-run the warm sweep (a best-effort response to the dense set being reclaimed). A no-op unless
-    // the mode is Warmed — Mmap never warmed, Anonymous has no mmap left to warm.
-    void rewarm();
-
     void shutdown();
 
     static constexpr int sample_pages = 256; // stratified probe points across the dense bytes

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -61,34 +61,33 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
         return false;
     }
 
-    // Adaptive budget: size the cache to the device now that the full expert-set size is known.
+    // Auto budget: size the cache to the device once, now that the full expert-set size is known.
     // (validate() guarantees cache_mb == 0 here, so this is the sole source of cache_max_ when auto.)
+    // One shot — the floor and the cap decide the budget here and are not kept: nothing re-sizes it
+    // afterwards except an explicit set_cache_budget().
     if (cfg.cache_auto) {
-        cache_auto_ = true;
-        cache_floor_ = (size_t) std::max(0, cfg.cache_floor_mb) * 1024ull * 1024ull;
-        // Hard cap: the whole expert set, further capped by the user's ceiling when set. Every auto
-        // budget (init and runtime grow-back) stays at or below this.
+        const size_t floor = (size_t) std::max(0, cfg.cache_floor_mb) * 1024ull * 1024ull; // RAM to leave free
+        // Hard cap: the whole expert set, further capped by the user's ceiling when set.
         const size_t ceil = (size_t) std::max(0, cfg.cache_ceil_mb) * 1024ull * 1024ull;
-        cache_hard_cap_ = ceil > 0 ? std::min(ceil, total_expert_bytes_) : total_expert_bytes_;
+        const size_t hard_cap = ceil > 0 ? std::min(ceil, total_expert_bytes_) : total_expert_bytes_;
         const size_t min_budget =
-            std::min<size_t>((size_t) MoeStreamConfig::cache_min_mb * 1024ull * 1024ull, cache_hard_cap_);
+            std::min<size_t>((size_t) MoeStreamConfig::cache_min_mb * 1024ull * 1024ull, hard_cap);
         const uint64_t avail = pio::mem_available_bytes();
         if (avail == 0) {
             cache_max_ = min_budget;
             std::fprintf(stderr, "bmoe: cache auto — available memory unknown, using the %zu MiB floor\n",
                          min_budget / (1024 * 1024));
         } else {
-            size_t budget = avail > cache_floor_ ? (size_t) (avail - cache_floor_) : 0;
+            size_t budget = avail > floor ? (size_t) (avail - floor) : 0;
             budget = std::max(budget, min_budget);
-            budget = std::min(budget, cache_hard_cap_);
+            budget = std::min(budget, hard_cap);
             cache_max_ = budget;
             std::fprintf(stderr,
                          "bmoe: cache auto — %llu MiB available, leaving %zu MiB free → %zu MiB budget"
                          " (cap %zu MiB)\n",
-                         (unsigned long long) (avail / (1024 * 1024)), cache_floor_ / (1024 * 1024),
-                         cache_max_ / (1024 * 1024), cache_hard_cap_ / (1024 * 1024));
+                         (unsigned long long) (avail / (1024 * 1024)), floor / (1024 * 1024),
+                         cache_max_ / (1024 * 1024), hard_cap / (1024 * 1024));
         }
-        cache_target_ = cache_max_;
     }
 
     if (cache_max_ == 0) {
@@ -102,7 +101,6 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
                 std::fprintf(stderr, "bmoe: slot alloc %zu failed\n", max_full[p]);
                 return false;
             }
-            slot_sz_[p] = max_full[p];
         }
         for (LayerExperts & L : layers_) {
             if (!L.bound) continue;
@@ -452,15 +450,14 @@ void ExpertStreamSource::maybe_sample_dense() {
     mgmt_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
 }
 
-// Explicit budget change from outside a decode (memory-pressure callback, the governor, or the
-// shrink gate).
+// Explicit budget change from outside a decode (an app's memory-pressure callback, or the shrink
+// gate). The only thing that moves the budget after init.
 void ExpertStreamSource::set_cache_budget(size_t bytes) {
     if (cache_max_ == 0) return; // initialised off (shared-slot mode); the LRU buffers do not exist
     if (bytes > cache_max_) {
         // Growing evicts nothing, so it needs no quiesce — and must not do one: cancelling the
         // speculative reads in flight on every grow would quietly defeat --prefetch.
         cache_max_ = std::min(bytes, total_expert_bytes_);
-        cache_target_ = std::max(cache_target_, cache_max_); // an explicit raise lifts the grow ceiling
         ++cache_resizes_;
         return;
     }

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -90,7 +90,7 @@ public:
     // Explicitly set the cache budget in bytes and evict down to it immediately (clamped to the
     // full expert-set size). PRECONDITION: no decode in flight — the caller must not be inside a
     // load_layer/generate. Intended for an app's memory-pressure callback (Android onTrimMemory)
-    // and exercised by the shrink gate. Clamped up: an explicit raise also lifts the grow ceiling.
+    // and exercised by the shrink gate. This is the only thing that moves the budget after init.
     void set_cache_budget(size_t bytes);
 
     // ── I/O trace (diagnostics; see bmoe/decode_trace.h) ────────────────────────────
@@ -182,21 +182,15 @@ private:
 
     // shared-slot mode (cache off): one full-size slot per projection, reused by layers
     void * slot_[MoeRecipe::max_exps] = {nullptr, nullptr, nullptr};
-    size_t slot_sz_[MoeRecipe::max_exps] = {0, 0, 0};
 
     // LRU mode (cache on): per-(layer, projection) reserved buffers
-    size_t cache_max_ = 0; // live budget in bytes; mutated at runtime when cache_auto_
+    size_t cache_max_ = 0; // live budget in bytes; only an explicit set_cache_budget() moves it
     size_t page_ = 4096;
 
-    // Auto sizing (cache_auto): the budget is derived once from device memory at init and then fixed
-    // for the run. cache_floor_ is the RAM to leave free; total_expert_bytes_ caps it; cache_target_
-    // is the ceiling an explicit set_cache_budget() raise may climb back to (e.g. an app relaxing an
-    // onTrimMemory shrink).
-    bool cache_auto_ = false;
-    size_t cache_floor_ = 0;
-    size_t cache_target_ = 0;
+    // Every expert of every bound layer resident: the ceiling any budget is clamped to, and (under
+    // cache_auto) the cap the init-time sizing starts from. Auto sizing derives cache_max_ once at
+    // init and keeps nothing else: its floor and ceiling are locals there, not state.
     size_t total_expert_bytes_ = 0;
-    size_t cache_hard_cap_ = 0; // upper bound on the auto budget (ceiling ∧ full expert-set size)
     long long cache_resizes_ = 0;
 
     // The dense (non-expert) weights: their residency policy (mmap / warm / anon) and the buffers it
@@ -207,16 +201,18 @@ private:
     std::vector<DenseTensorRef> dense_tensors_; // pending, set before init; moved into dense_
     DenseWeights dense_;
 
-    // Two measured demands, and the difference between them decides the whole policy.
+    // Two measured demands. Both are pure telemetry now that the governor is gone — nothing here
+    // sizes the cache — but they are what any future sizing policy would have to reason about, and
+    // they explain a run's hit rate after the fact.
     //
     // token_demand_: the bytes routed between two visits to the same layer — one token's working
     // set. Below it the cache stops holding anything BETWEEN tokens, so its hit rate collapses to
-    // inter-token correlation only. Informative (it says where hits start), never a floor: measured
-    // on gpt-oss it is 1815 MiB, more than the device concedes — which is why cache-off is the
-    // ceiling there. Reported as telemetry.
+    // inter-token correlation only. It says where hits start, and it is not something a device has
+    // to concede: measured on gpt-oss it is 1815 MiB, more than the phone gives up — which is why
+    // cache-off is the ceiling there.
     //
-    // layer_demand_: the largest single layer's routed bytes. THIS is the floor, because it is
-    // mechanical — the cache has to hold the layer it is staging right now.
+    // layer_demand_: the largest single layer's routed bytes — the mechanical minimum, since the
+    // cache has to hold the layer it is staging right now.
     size_t demand_accum_ = 0;
     size_t token_demand_ = 0;
     size_t layer_demand_accum_ = 0;

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -21,12 +21,14 @@
 // G4 is compiled only when the fork's expert-ready hook is present (BMOE_HAVE_EXPERT_READY_HOOK).
 //
 //   S1  two sequential Session generates (warm cache) == one-shot resident, per prompt
-//   S2  same, under overlap
+//   S3  same, with an explicit budget shrink between the two generates (full eviction pass)
+//   S2  same as S1, under overlap
 //   G5  streaming + temporal prefetch == streaming (prefetch changes latency, not bytes)
 //         a) serial + cache + prefetch   b) overlap + cache + prefetch
 //
 // S1/S2 guard the session refactor: the expert LRU cache now survives across generate() calls,
 // so a second prompt starts warm. That must change only latency, never the produced bytes.
+// S3 guards set_cache_budget_mb: evicting a warm cache mid-session must cost only re-reads.
 // G5 guards temporal prefetch: speculatively reading the next layers' experts must only warm the
 // cache — the routed slices a token actually consumes, and thus its output, are unchanged.
 #include "bmoe/config.h"
@@ -281,9 +283,10 @@ int main(int argc, char ** argv) {
     fails += check("S1a session generate #1 == resident", s_res, s_g1);
     fails += check("S1b session generate #2 (warm cache) == resident", s_res, s_g2);
 
-    // S3: shrinking the cache budget at runtime (adaptive sizing / memory-pressure callback) evicts
-    // warm entries mid-session; the next generation must rebuild them from flash byte-for-byte. Reuse
-    // the small forced cache, then drop it to ~0 MiB between generates to force a full eviction pass.
+    // S3: an explicit runtime budget change (set_cache_budget_mb, as an app's memory-pressure callback
+    // makes it) evicts warm entries mid-session; the next generation must rebuild them from flash
+    // byte-for-byte. Reuse the small forced cache, then drop it to ~0 MiB between generates to force a
+    // full eviction pass.
     std::string s_sh1, s_sh2;
     if (!session_shrink_gen(sess, /*shrink_mib=*/0, s_sh1, s_sh2, err)) {
         std::fprintf(stderr, "session shrink run failed: %s\n", err.c_str());


### PR DESCRIPTION
Retiring the adaptive cache governor (75b5a63) left behind state nothing reads and comments describing a control loop the engine no longer has. The budget is sized once at init and fixed for the run — this makes the code say only that.

### Dead state (all write-only since the governor went)

- `cache_auto_`, `cache_target_`, `slot_sz_[]` — deleted. `cache_target_`'s "grow ceiling" was never enforced anywhere: `set_cache_budget()` clamps to `total_expert_bytes_`, not to it.
- `cache_floor_` / `cache_hard_cap_` — demoted to locals in the auto-sizing block, the only place they ever meant anything.
- `DenseWeights::rewarm()` — no caller in core, cli or tests. It was the governor's "reclaim happened, warm the dense set again" hook.
- `ProcessMemory::rss_peak_bytes` (VmHWM) — populated, never read. `scripts/bench-run.sh` samples VmHWM straight from `/proc`, so no telemetry is lost.

### Comments that had started to lie

| file | claimed |
|---|---|
| `core/include/bmoe/config.h` | budget "re-checked during generation … grows back" |
| `core/include/bmoe/session.h` | "complements `--cache-mb auto`'s automatic tracking" |
| `core/include/bmoe/expert_source.h` | budget "moves under `--cache-mb auto`" |
| `core/src/io/platform_io.h` | MemAvailable used "to shrink it under memory pressure at runtime" |
| `expert_stream_source.cpp` | `set_cache_budget` lists "the governor" as a caller |

Also: `expert_stream_source.h` asserted `layer_demand_` "is the floor" — nothing enforces a floor now; both demands are telemetry. And the CLI printed `(auto, resized N×)` where N is structurally always 0.

`cache_resizes` **stays** — it still counts an app's explicit `set_cache_budget_mb` calls (Android `onTrimMemory`), which the S3 shrink gate exercises.

### Housekeeping

- `tests/moe_gates.cpp` — S3's comment said "adaptive sizing"; the gate index omitted S3 entirely.
- `cli/CMakeLists.txt` — `OUTPUT_NAME "bmoe-cli"` on a target already named `bmoe-cli` is a no-op.

### Verification

Host build clean; `ctest` byte-identity gates pass (4/4, qwen3moe + gemma4) before and after clang-format 18. No behavior change — pure removal of unread state and untrue comments.