### PR TITLE
refactor(engine): dedupe the session plumbing

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -66,6 +66,23 @@ static std::string json_escape(const std::string & s) {
     return o;
 }
 
+// One token's line-protocol output: the optional BMOE_LOAD, then BMOE_PROGRESS (docs/telemetry.md).
+// Both emitters — the one-shot --progress run and the interactive session, which is a superset of it
+// — must produce a byte-identical line, since the Android app parses one parser's worth of protocol.
+// Keeping the format string in one place is what makes that true rather than merely intended.
+static void emit_progress_line(const TokenMetrics & m) {
+    if (m.read_bytes || m.io_ms > 0.0)
+        std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
+    std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
+                "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
+                "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"dense_resident_frac\":%.3f,"
+                "\"text\":\"%s\"}\n",
+                m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
+                m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
+                m.dense_resident_frac, json_escape(m.text).c_str());
+    std::fflush(stdout);
+}
+
 // ── minimal flat-JSON reading for the --session request protocol ──
 // The session request objects are flat (string/int/bool fields only), so a tiny hand-rolled
 // extractor keeps the CLI dependency-free, mirroring the hand-written JSON it already emits.
@@ -177,14 +194,7 @@ struct SessionCmd {
 // one JSON request per line from stdin and emitting the BMOE_* line protocol on stdout. See
 // docs/telemetry.md. Returns the process exit code.
 static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTraceSink * route_trace) {
-    SessionConfig sc;
-    sc.model_path = cfg.model_path;
-    sc.n_threads = cfg.n_threads;
-    sc.n_ctx = cfg.n_ctx;
-    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
-    sc.chatml = cfg.chatml;
-    sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
-    sc.moe = cfg.moe;
+    const SessionConfig sc = session_config_from(cfg);
 
     std::string error;
     std::unique_ptr<Session> session = Session::open(sc, error, route_trace);
@@ -255,26 +265,13 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
         std::printf("BMOE_BEGIN {\"id\":%d}\n", cmd.id);
         std::fflush(stdout);
 
-        auto on_token = [&](const TokenMetrics & m) {
-            if (m.read_bytes || m.io_ms > 0.0)
-                std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
-            std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
-                        "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
-                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"dense_resident_frac\":%.3f,"
-                        "\"text\":\"%s\"}\n",
-                        m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
-                        m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
-                        m.dense_resident_frac, json_escape(m.text).c_str());
-            std::fflush(stdout);
-        };
-
         GenerateRequest req;
         req.prompt = cmd.prompt;
         req.n_predict = cmd.n_predict;
         req.think = cmd.think;
         req.clear_kv = cmd.clear_kv;
 
-        RunResult r = session->generate(req, on_token, sink);
+        RunResult r = session->generate(req, emit_progress_line, sink);
         if (!r) {
             // A bad request (empty prompt, context overflow) leaves the session usable; a decode
             // failure means the context is compromised, so end the loop.
@@ -524,16 +521,7 @@ int main(int argc, char ** argv) {
 
     auto on_token = [&](const TokenMetrics & m) {
         if (cfg.progress) {
-            if (m.read_bytes || m.io_ms > 0.0)
-                std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
-            std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
-                        "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
-                        "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"dense_resident_frac\":%.3f,"
-                        "\"text\":\"%s\"}\n",
-                        m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
-                        m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
-                        m.dense_resident_frac, json_escape(m.text).c_str());
-            std::fflush(stdout);
+            emit_progress_line(m);
         } else {
             std::fwrite(m.piece.data(), 1, m.piece.size(), stdout);
             std::fflush(stdout);

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -43,6 +43,12 @@ struct SessionConfig {
     MoeStreamConfig moe;
 };
 
+// The RunConfig → SessionConfig mapping, in one place. Both entry points that open a session from a
+// RunConfig — run() and the CLI's interactive loop — need it, and they used to spell it out field by
+// field. Two copies of a mapping is one copy too many: adding a field to RunConfig must not depend on
+// remembering to touch both. n_batch = n_ctx so any prompt that fits the context prefills in one batch.
+SessionConfig session_config_from(const RunConfig & cfg);
+
 // Per-prompt request. clear_kv=true (the default) makes each prompt independent while the
 // expert cache stays warm; clear_kv=false continues the KV cache for multi-turn chat.
 struct GenerateRequest {

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -5,11 +5,23 @@
 
 namespace bmoe {
 
+// n_ctx is passed through untouched so the gates run at exactly the context they specify.
+SessionConfig session_config_from(const RunConfig & cfg) {
+    SessionConfig sc;
+    sc.model_path = cfg.model_path;
+    sc.n_threads = cfg.n_threads;
+    sc.n_ctx = cfg.n_ctx;
+    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
+    sc.chatml = cfg.chatml;
+    sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
+    sc.moe = cfg.moe;
+    return sc;
+}
+
 // run() is the one-shot convenience: open a Session, generate once, close. The engine's real
 // state (model, context, warm expert cache) lives in Session (session.cpp); keeping run() as a
 // thin wrapper means the byte-identity gates exercise the exact same open/generate machinery an
-// interactive session uses. n_batch = n_ctx so the whole prompt still prefills in one batch, and
-// n_ctx is passed through untouched so the gates run at exactly the context they specify.
+// interactive session uses.
 RunResult run(const RunConfig & cfg,
               const std::function<void(const TokenMetrics &)> & on_token,
               IMetricsSink * sink,
@@ -23,14 +35,7 @@ RunResult run(const RunConfig & cfg,
         return r;
     }
 
-    SessionConfig sc;
-    sc.model_path = cfg.model_path;
-    sc.n_threads = cfg.n_threads;
-    sc.n_ctx = cfg.n_ctx;
-    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
-    sc.chatml = cfg.chatml;
-    sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
-    sc.moe = cfg.moe;
+    const SessionConfig sc = session_config_from(cfg);
 
     std::string error;
     std::unique_ptr<Session> session = Session::open(sc, error, route_trace, compute_trace, io_trace);

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -179,6 +179,21 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
 
     const auto t_load0 = clock_t_::now();
 
+    // The gguf header answers three separate questions below — the arch-prefixed key for a top-k
+    // override, the route trace's effective top-k, and the run info's top-k/expert count — and each
+    // used to reopen and reparse the file for its own answer. Read it at most once, lazily: the
+    // callers are conditional (a run with no override and no trace asks nothing), so an eager read
+    // would be work the common path never needs.
+    GgufModelInfo gguf_info;
+    bool gguf_info_read = false;
+    auto gguf = [&]() -> const GgufModelInfo & {
+        if (!gguf_info_read) {
+            gguf_info = read_gguf_model_info(cfg.model_path.c_str());
+            gguf_info_read = true;
+        }
+        return gguf_info;
+    };
+
     // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
     // q4_K buffer would break the rebind), experts on CPU.
     llama_model_params mparams = llama_model_default_params();
@@ -195,7 +210,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     llama_model_kv_override kv_overrides[2];
     std::memset(kv_overrides, 0, sizeof(kv_overrides)); // second entry stays the key[0]==0 terminator
     if (cfg.n_expert_used > 0) {
-        GgufModelInfo info = read_gguf_model_info(cfg.model_path.c_str());
+        const GgufModelInfo & info = gguf();
         if (!info.ok) return fail("cannot read gguf metadata: " + cfg.model_path);
         if (info.arch.empty()) return fail("gguf has no general.architecture; cannot set n_expert_used");
         if (info.n_expert <= 0)
@@ -360,7 +375,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             // The effective top-k: an override IS the applied width, otherwise the model's own.
             st.n_expert_used = cfg.n_expert_used;
             if (st.n_expert_used <= 0) {
-                GgufModelInfo info = read_gguf_model_info(cfg.model_path.c_str());
+                const GgufModelInfo & info = gguf();
                 st.n_expert_used = info.ok ? info.n_expert_used : 0;
             }
             st.dense_bytes_per_layer = std::move(dense_bytes);
@@ -427,7 +442,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
         // The CSV keeps the two familiar flags, derived from the resolved dense-weights policy.
-        ri.dense_weights = cfg.moe.dense_weights == DenseWeightsMode::Mmap      ? "mmap"
+        ri.dense_weights = cfg.moe.dense_weights == DenseWeightsMode::Mmap        ? "mmap"
                            : cfg.moe.dense_weights == DenseWeightsMode::Anonymous ? "anon"
                                                                                   : "warm";
         if (cfg.moe.enabled) {
@@ -439,7 +454,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // cannot be compared against one whose top-k differs, which is most of the point.
         ri.n_expert_used = cfg.n_expert_used;
         if (ri.n_expert_used <= 0 || ri.n_expert == 0) {
-            const GgufModelInfo mi = read_gguf_model_info(cfg.model_path.c_str());
+            const GgufModelInfo & mi = gguf();
             if (mi.ok) {
                 ri.n_expert = mi.n_expert;
                 if (ri.n_expert_used <= 0) ri.n_expert_used = mi.n_expert_used;


### PR DESCRIPTION
> Stacked on #42 — base is `chore/sweep-governor-residue`. Merge #42 first; GitHub will retarget this to `main`.

Three copies of the same knowledge, each free to drift from the others.

### `RunConfig` → `SessionConfig`

Spelled out field by field in **both** `core/src/engine/runtime.cpp` and `cli/main.cpp`. Adding a field to `RunConfig` depended on remembering to touch both. Now one `session_config_from()` in `session.h`.

### The line protocol

`BMOE_LOAD`/`BMOE_PROGRESS` emission was copy-pasted between the one-shot `--progress` path and the interactive session loop. The Android app parses *one* parser's worth of protocol, so the two must be byte-identical — a shared `emit_progress_line()` makes that structurally true rather than merely intended.

### The gguf header

`Session::open()` reopened and reparsed the gguf for each question it asked of it: the arch-prefixed key for a top-k override (:198), the route trace's effective top-k (:363), the run info's top-k/expert count (:442). Now read **at most once, lazily**.

Lazy rather than eager on purpose: the call sites are conditional and partly mutually exclusive (:198 needs `n_expert_used > 0`, :363 needs `<= 0` — they never both run). A run with no override and no trace asks nothing, and an eager read would be work the common path never needs. The memoized lambda preserves each site's condition exactly.

### Deliberately not done

**Splitting `generate()`.** The review flagged its per-token metric block as "self-contained" — it isn't. It mutates eight loop-carried accumulators (`prev_bytes`, `prev_io_s`, `prev_mgmt_s`, `prev_stall_s`, `gen_read_bytes`, `gen_io_seconds`, `gen_mgmt_seconds`, `gen_stall_seconds`), so extracting it means inventing a struct to thread them through: more code than it removes, on the hot decode loop, for a legibility gain alone. Not worth the risk.

### Verification

- Host build clean; `ctest` byte-identity gates 4/4 (S1/S2/S3 exercise `Session` directly).
- The gates don't cover the CLI protocol, so `--progress` was run against the tiny model: `BMOE_LOAD` + `BMOE_PROGRESS` emit every field, exit 0.
- `--cache-mb auto` verified: `budget 6 MiB (auto)`, auto-sizing unchanged with floor/cap as locals.