### PR TITLE
refactor(moe): share the cache accounting between the two load paths

### DIFF
--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -564,6 +564,46 @@ uint64_t ExpertStreamSource::expert_bytes(int il) const {
     return (uint64_t) entry_bytes(il);
 }
 
+// The cache accounting both load paths share. See the header for why this is the part that is shared
+// and the job emission is not. Eval-thread only, like every other LRU mutation.
+bool ExpertStreamSource::touch_entry(int il, int e, bool & hit) {
+    const int32_t id = il * n_expert_ + e;
+    clookups_++;
+    cstamp_[id] = cgen_;
+    if (cvalid_[id]) {
+        chits_++;
+        if (cspec_[id]) { // this hit was served by a speculative prefetch — count it useful once
+            spec_useful_.fetch_add(1);
+            cspec_[id] = 0;
+        }
+        lru_unlink(id);
+        lru_push_front(id);
+        hit = true;
+        return true;
+    }
+    // Miss: commit the pages the caller's reads will fill, then enter the expert as resident. The
+    // entry is valid from here on because the caller is contracted to schedule those reads before
+    // anything can consume the slices — the barrier that makes this safe is the eval-callback's.
+    const LayerExperts & L = layers_[il];
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+        const uint64_t slice = L.proj[p].nb2;
+        if (slice == 0) continue; // absent slot in a fused layout
+        char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
+        uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
+        uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
+        if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) {
+            std::fprintf(stderr, "bmoe: commit failed\n");
+            return false;
+        }
+    }
+    cvalid_[id] = 1;
+    cspec_[id] = 0; // a real read, not speculative
+    cresident_ += entry_bytes(il);
+    lru_push_front(id);
+    hit = false;
+    return true;
+}
+
 // ── load: stage routed experts, read the batch, evict cold entries to budget ────────
 bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     if (!active_ || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0) return false;
@@ -591,36 +631,18 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
             }
             return true;
         }
-        const int32_t id = il * n_expert_ + e;
-        clookups_++;
-        cstamp_[id] = cgen_;
-        if (cvalid_[id]) {
-            chits_++;
-            if (cspec_[id]) { // this hit was served by a speculative prefetch — count it useful once
-                spec_useful_.fetch_add(1);
-                cspec_[id] = 0;
-            }
-            lru_unlink(id);
-            lru_push_front(id);
-            return true;
-        }
+        bool hit = false;
+        if (!touch_entry(il, e, hit)) return false;
+        if (hit) return true;
+        // A miss: emit this expert's reads, expert-major. The drain below waits on them all, so the
+        // order only has to be complete, not clever — unlike the overlap path, where it feeds a
+        // kernel that is already blocking.
         for (int p = 0; p < MoeRecipe::max_exps; ++p) {
             const uint64_t slice = L.proj[p].nb2;
             if (slice == 0) continue; // absent slot in a fused layout
-            char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
-            uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
-            uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
-            if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) {
-                std::fprintf(stderr, "bmoe: commit failed\n");
-                return false;
-            }
-            jobs_.push_back(
-                {dst, L.proj[p].file_off + (uint64_t) e * slice, slice, -1, e, (int16_t) il, (int8_t) p, 0});
+            jobs_.push_back({(char *) lbuf_[p][il] + (uint64_t) e * slice, L.proj[p].file_off + (uint64_t) e * slice,
+                             slice, -1, e, (int16_t) il, (int8_t) p, 0});
         }
-        cvalid_[id] = 1;
-        cspec_[id] = 0; // a real read, not speculative
-        cresident_ += entry_bytes(il);
-        lru_push_front(id);
         return true;
     };
 
@@ -772,37 +794,17 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
         // commit the pages and remember it). Then emit the misses' jobs projection-major.
         seen_.assign(seen_.size(), 0); // reuse as a per-staged miss marker keyed by expert
         for (int e : staged_) {
-            const int32_t id = il * n_expert_ + e;
-            clookups_++;
-            cstamp_[id] = cgen_;
-            if (cvalid_[id]) {
-                chits_++;
-                if (cspec_[id]) {
-                    spec_useful_.fetch_add(1);
-                    cspec_[id] = 0;
-                }
-                lru_unlink(id);
-                lru_push_front(id);
+            bool hit = false;
+            if (!touch_entry(il, e, hit)) {
+                // Nothing waits on a flag we will never publish: abort the graph instead.
+                fatal_.store(true, std::memory_order_release);
+                return false;
+            }
+            if (hit) { // resolved without a read — release every projection's waiter now
                 for (int p = 0; p < MoeRecipe::max_exps; ++p)
                     if (L.proj[p].nb2) mark_ready(p, e);
                 continue;
             }
-            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
-                const uint64_t slice = L.proj[p].nb2;
-                if (slice == 0) continue;
-                char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
-                uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
-                uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
-                if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) {
-                    std::fprintf(stderr, "bmoe: commit failed\n");
-                    fatal_.store(true, std::memory_order_release);
-                    return false;
-                }
-            }
-            cvalid_[id] = 1;
-            cspec_[id] = 0; // a real read, not speculative
-            cresident_ += entry_bytes(il);
-            lru_push_front(id);
             seen_[e] = 1; // this expert missed → its projections need reads
         }
         for (int p = 0; p < MoeRecipe::max_exps; ++p) {

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -152,6 +152,16 @@ private:
     static void c_expert_ready(const ggml_tensor * src0, int expert, void * user_data);
     void on_expert_ready(const ggml_tensor * src0, int expert);
 
+    // One expert's cache accounting for the layer being staged: the lookup, the hit/miss decision,
+    // and the residency bookkeeping that follows. Both load paths need exactly this and used to spell
+    // it out separately — what a hit means, what a miss commits, how the LRU order is kept — so a fix
+    // to any of it had to be made twice or not at all. What they do NOT share is how they schedule the
+    // reads (serial emits expert-major and blocks; overlap emits projection-major and publishes), so
+    // that stays with each caller. `hit` tells the caller whether this expert still needs reads.
+    // Returns false only if committing the pages failed; the caller decides how fatal that is.
+    // LRU mode only (cache_max_ > 0) — the shared-slot path has no entries to account for.
+    bool touch_entry(int il, int e, bool & hit);
+
     // LRU helpers (active only when cache_max_ > 0)
     void lru_unlink(int32_t id);
     void lru_push_front(int32_t id);


### PR DESCRIPTION
> Stacked on #43 (which is stacked on #42). Merge in order 42 → 43 → 44; GitHub retargets each as its base merges.

`load_layer` and `load_layer_async` each spelled out what a cache lookup means: the hit, the speculative-hit credit, the miss's page commit, the residency add, the LRU link. Two copies of the most correctness-critical bookkeeping in the engine — where a fix to one is silently not a fix to the other.

`touch_entry()` now owns that, and both paths call it.

### What is deliberately NOT unified

The review that prompted this called the two functions "near-identical, differing mainly in serial-drain vs publish-and-return." Reading them closely, that undersells it — each difference is load-bearing:

| | serial | overlap |
|---|---|---|
| read order | expert-major | **projection-major** — `mul_mat_id` consumes projections in that order, so reads feed a kernel already blocking on them |
| readiness | no reader to release | publishes a flag per (projection, expert) |
| eviction | after the drain | concurrent with its own batch — safe only via its steps 1 and 5 |
| commit failure | returns false | also sets `fatal_` — a flag nobody will publish would hang a compute thread |

Collapsing those into one function behind mode flags would trade duplication for something worse. **The shared part is now shared; the different part stays apart.** Net −53/+65 lines, but the win is one place to fix LRU logic, not the line count.

### Verification

**17/17 gates**, and they reach every branch of `touch_entry` from *both* callers — this is the point, not the pass count:

```
[PASS] G4a overlap(cache off) == streaming(cache off)
[PASS] G4b overlap(LRU cache) == streaming(cache off)      <- async caller, miss+evict
[PASS] G4c overlap(io_threads=1) == streaming(cache off)
[PASS] G2  streaming(cache off) == streaming(LRU cache)     <- forced evictions
[PASS] G5a/b/c prefetch                                     <- cspec_ / spec_useful_ credit
[PASS] S3a/S3b session generate (after budget shrink)
[PASS] G3  streaming(selective) == streaming(load-all)
```

Android arm64 cross-compile clean. No behavior change intended or observed.