### PR TITLE
chore(scripts): consolidate the bench drivers, prune the retired framing

### DIFF
--- a/scripts/bench-analyze.py
+++ b/scripts/bench-analyze.py
@@ -8,13 +8,16 @@
 #   mean = aggregate n_tokens / total_seconds ; min/max = slowest/fastest single token.
 import os, sys, statistics
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from trace_io import percentile as pct, read_kv_file as read_metrics
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BENCH = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, ".bench")
 ORDER = ["mmap", "stream", "c2000_l2", "c2000_l4", "c4000_l2", "c4000_l4",
          "stream_ov", "c2000_l4_ov", "c4000_l4_ov",
          "c4000_l4_pf1", "c4000_l4_pf2", "c4000_l4_pf4",
-         # 2026-07-13 rework matrix: fixed reference, adaptive cache (± cap), speculative gating.
-         "base_ov", "auto_ov", "autocap_ov", "sg_ov"]
+         # Fixed reference vs the engine sizing the cache itself (± a cap).
+         "base_ov", "auto_ov", "autocap_ov"]
 LABEL = {
     "mmap": "solo mmap (no streaming)",
     "stream": "streaming O_DIRECT, cache 0, lane 4",
@@ -29,25 +32,9 @@ LABEL = {
     "c4000_l4_pf2": "streaming + cache 4000 MiB, lane 4, prefetch 2",
     "c4000_l4_pf4": "streaming + cache 4000 MiB, lane 4, prefetch 4",
     "base_ov": "fixed cache + overlap (reference)",
-    "auto_ov": "adaptive cache (--cache-mb auto) + overlap",
-    "autocap_ov": "adaptive cache, capped + overlap",
-    "sg_ov": "fixed cache + overlap + speculative gating",
+    "auto_ov": "auto-sized cache (--cache-mb auto) + overlap",
+    "autocap_ov": "auto-sized cache, capped + overlap",
 }
-
-def pct(v, q):
-    if not v:
-        return 0.0
-    i = q * (len(v) - 1); lo = int(i); hi = min(lo + 1, len(v) - 1)
-    return v[lo] + (v[hi] - v[lo]) * (i - lo)
-
-def read_metrics(path):
-    d = {}
-    if os.path.exists(path):
-        for line in open(path):
-            if "=" in line:
-                k, v = line.strip().split("=", 1)
-                d[k] = v
-    return d
 
 def num(d, k):
     try:
@@ -105,8 +92,8 @@ def analyze(csv_path):
         "mgmt_ms_tok": (statistics.mean(mgmts) if mgmts else None),
         "prefill_tps": g("prefill_tps"), "load_s": g("load_s"),
         "prefill_s": g("prefill_s"), "ttft": g("load_s") + g("prefill_s"),
-        # 2026-07-13 rework metrics (0 / absent on older CSVs that predate them).
-        "cache_budget_MiB": g("cache_budget_MiB"), "cache_resizes": g("cache_resizes"),
+        # 0 / absent on older CSVs that predate these columns.
+        "cache_budget_MiB": g("cache_budget_MiB"),
         "cache_resident_MiB": g("cache_resident_MiB"),
         "spec_read_MiB_tok": (g("spec_read_MiB") / n) if n else 0.0,
         "spec_useful_pct": (100.0 * g("spec_useful") / g("spec_experts")) if g("spec_experts") else 0.0,
@@ -149,22 +136,25 @@ for model, pretty in (("qwen", "Qwen3-30B-A3B-Q4_K_M (18.5 GB, 128 experts, top-
         print(f"{LABEL[key]:36s} {r['peak_rss_gb']:6.2f}GB {r['mem_floor_gb']:7.2f}GB {r['cpu0']:5.1f}C {r['cpu_max']:6.1f}C {r['batt_max']:7.1f}C")
         md.append(f"| {LABEL[key]} | {r['peak_rss_gb']:.2f} GB | {r['mem_floor_gb']:.2f} GB | {r['cpu0']:.1f} °C | {r['cpu_max']:.1f} °C | {r['batt_max']:.1f} °C |")
 
-    # Third table: adaptive-cache and temporal-prefetch specifics — only for configs that exercise
+    # Third table: cache sizing and temporal-prefetch specifics — only for configs that exercise
     # them (a fixed non-prefetch run has cache_budget==resident and no speculative reads, so it is
     # uninformative).
-    adaptive = [(k, r) for k, r in rows if r and (r["cache_budget_MiB"] > 0 or r["spec_read_MiB_tok"] > 0)]
-    if adaptive:
-        print(f"\n===== {model.upper()} — adaptive cache / temporal prefetch =====")
-        md.append(f"\n**Adaptive cache & temporal prefetch** (budget & resizes under `--cache-mb auto`; "
-                  f"speculative read volume and useful-hit rate under `--prefetch`):\n")
-        md.append("| Config | cache budget | resizes | resident | prefetch useful | prefetch read/token |")
-        md.append("|---|---:|---:|---:|---:|---:|")
-        for key, r in adaptive:
+    #
+    # No `resizes` column: it once tracked a governor moving the budget mid-run, and that governor is
+    # gone — `--cache-mb auto` sizes the budget once at init and holds it, so the count is 0 for every
+    # run bmoe-cli produces. A column that is structurally always 0 reads as a finding, not a blank.
+    sized = [(k, r) for k, r in rows if r and (r["cache_budget_MiB"] > 0 or r["spec_read_MiB_tok"] > 0)]
+    if sized:
+        print(f"\n===== {model.upper()} — cache sizing / temporal prefetch =====")
+        md.append(f"\n**Cache sizing & temporal prefetch** (the budget `--cache-mb auto` chose at init and what "
+                  f"stayed resident under it; speculative read volume and useful-hit rate under `--prefetch`):\n")
+        md.append("| Config | cache budget | resident | prefetch useful | prefetch read/token |")
+        md.append("|---|---:|---:|---:|---:|")
+        for key, r in sized:
             budget = f"{r['cache_budget_MiB']:.0f} MiB" if r["cache_budget_MiB"] > 0 else "—"
-            resiz = f"{r['cache_resizes']:.0f}" if r["cache_budget_MiB"] > 0 else "—"
             useful = f"{r['spec_useful_pct']:.0f}%" if r["spec_read_MiB_tok"] > 0 else "—"
             sread = f"{r['spec_read_MiB_tok']:.0f} MiB" if r["spec_read_MiB_tok"] > 0 else "—"
-            md.append(f"| {LABEL[key]} | {budget} | {resiz} | {r['cache_resident_MiB']:.0f} MiB | {useful} | {sread} |")
+            md.append(f"| {LABEL[key]} | {budget} | {r['cache_resident_MiB']:.0f} MiB | {useful} | {sread} |")
 
 out = os.path.join(BENCH, "summary.md")
 open(out, "w", encoding="utf-8").write("\n".join(md) + "\n")

--- a/scripts/bench-lib.ps1
+++ b/scripts/bench-lib.ps1
@@ -1,0 +1,60 @@
+# Shared plumbing for the on-device benchmark drivers. Dot-source it:
+#
+#     . "$PSScriptRoot\bench-lib.ps1"
+#
+# Every driver does the same thing: cool the SoC, run one config through the device-side
+# bench-run.sh, echo the lines worth watching, pull the CSV + metrics back. What differs between
+# drivers is the config matrix and which perf lines matter — that IS the driver. This is everything
+# else, and it used to be copied verbatim into each of them.
+
+# Where bench-run.sh and the per-run artifacts live on the device.
+$script:DEV_DIR = "/data/local/tmp"
+
+# Model paths on the test device. Defaults, not constants: pass -Model whatever you are benching.
+$script:BENCH_QWEN  = "/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf"
+$script:BENCH_GEMMA = "/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf"
+
+# The perf lines worth echoing for any run. A driver exercising a specific feature appends its own
+# (e.g. "|moe-prefetch:") via -Match rather than re-stating the whole pattern.
+$script:BENCH_MATCH_DEFAULT =
+  "generation:|prefill:|moe-stream:|moe-cache:|peak_rss|mem_avail_floor|batt_temp_max|cpu_temp_max|charge_"
+
+<#
+.SYNOPSIS
+Run one benchmark config on the device and pull its artifacts.
+
+.DESCRIPTION
+One cell of a matrix: cooldown, run, echo, pull. The tag names the run and its files.
+
+KNOWN LIMITATION — the cooldown is a timer, and a timer is the wrong instrument. A fixed wait does
+not reliably reach a thermal baseline, so a long matrix can drift and tok/s starts tracking run
+order rather than the config under test. Read a suspicious matrix with that in mind: check the
+temperature columns before believing a trend. Making this a condition (wait until the SoC is
+actually cool) is the fix, and it needs device time to calibrate.
+#>
+function Invoke-BenchCfg {
+    param(
+        [Parameter(Mandatory)][string]$Tag,
+        [Parameter(Mandatory)][string]$Model,
+        [Parameter(Mandatory)][string]$OutDir,
+        [string]$Flags = "",
+        [int]$NPred = 256,
+        [int]$CooldownSec = 45,
+        [string]$Match = $script:BENCH_MATCH_DEFAULT
+    )
+    Write-Host "==================== $Tag ===================="
+    Start-Sleep -Seconds $CooldownSec   # see the note above: this is a timer, not a guarantee
+    $t0 = Get-Date
+    $log = & adb shell "sh $script:DEV_DIR/bench-run.sh $NPred $Model $script:DEV_DIR/$Tag.csv $script:DEV_DIR/$Tag.metrics $Flags" 2>&1
+    $dt = [math]::Round(((Get-Date) - $t0).TotalSeconds, 1)
+    $log | Where-Object { $_ -match $Match } | ForEach-Object { Write-Host "  $_" }
+    Write-Host "  wall(incl load)=${dt}s"
+    $log | Out-File -FilePath "$OutDir\$Tag.log" -Encoding utf8
+    & adb pull "$script:DEV_DIR/$Tag.csv" "$OutDir\$Tag.csv" 2>&1 | Out-Null
+    & adb pull "$script:DEV_DIR/$Tag.metrics" "$OutDir\$Tag.metrics" 2>&1 | Out-Null
+    if (Test-Path "$OutDir\$Tag.csv") {
+        Write-Host "  -> $Tag.csv + .metrics pulled"
+    } else {
+        Write-Host "  !! no CSV for $Tag"
+    }
+}

--- a/scripts/bench-matrix-rework.ps1
+++ b/scripts/bench-matrix-rework.ps1
@@ -1,8 +1,16 @@
-# On-device benchmark matrix for the 2026-07-13 rework: adaptive cache (--cache-mb auto, ± ceiling)
-# and the reworked speculative gating, against a fixed-cache overlap reference. Mirrors
-# bench-matrix.ps1 (same bench-run.sh, same .csv/.metrics/.log outputs, same tag naming so
-# bench-analyze.py picks them up) but with today's four configs per model. Qwen uses a 4000 MiB
-# reference/ceiling, Gemma a 2000 MiB one (4000 OOMs on this device).
+# ARCHIVED — kept for the provenance of docs/bench-data/2026-07-13, not for reuse.
+#
+# This drove the 2026-07-13 matrix: auto-sized cache (--cache-mb auto, ± ceiling) and the reworked
+# speculative gating, against a fixed-cache overlap reference. Both of those features are gone from
+# the engine as shipped — spec-gating was removed, and the adaptive governor that made `auto` a live
+# control loop was retired (`auto` now sizes once at init). Its `--spec-gate` cells will not run.
+#
+# It stays because the tables it produced are published; deleting it would leave those numbers with
+# no visible derivation. For a live matrix use bench-matrix.ps1, which shares bench-lib.ps1.
+#
+# Mirrors bench-matrix.ps1's outputs (same bench-run.sh, same .csv/.metrics/.log, same tag naming so
+# bench-analyze.py picks them up). Qwen used a 4000 MiB reference/ceiling, Gemma a 2000 MiB one
+# (4000 OOMs on this device).
 param(
   [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench"),
   [int]$NPred = 256,

--- a/scripts/bench-matrix.ps1
+++ b/scripts/bench-matrix.ps1
@@ -1,31 +1,24 @@
-# On-device benchmark matrix driver. Invokes the instrumented device-side bench-run.sh.
+# On-device benchmark matrix driver: the cache-size × read-lane grid, plus the overlap pair, per
+# model. Invokes the instrumented device-side bench-run.sh via bench-lib.ps1.
 param(
   [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench"),
   [int]$NPred = 256,
-  [int]$CooldownSec = 45   # let the SoC cool to a similar baseline before each run
+  [int]$CooldownSec = 45,   # let the SoC cool toward a similar baseline before each run
+  [string]$Qwen,
+  [string]$Gemma
 )
 $ErrorActionPreference = "Continue"
+. "$PSScriptRoot\bench-lib.ps1"
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
-$DEV = "/data/local/tmp"
 
-$QWEN  = "/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf"
-$GEMMA = "/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf"
+if (-not $Qwen)  { $Qwen  = $BENCH_QWEN }
+if (-not $Gemma) { $Gemma = $BENCH_GEMMA }
 
 function Run-Cfg($tag, $model, $flags) {
-  Write-Host "==================== $tag ===================="
-  Start-Sleep -Seconds $CooldownSec   # thermal cooldown so runs start from a similar baseline
-  $t0 = Get-Date
-  $log = & adb shell "sh $DEV/bench-run.sh $NPred $model $DEV/$tag.csv $DEV/$tag.metrics $flags" 2>&1
-  $dt = [math]::Round(((Get-Date) - $t0).TotalSeconds, 1)
-  $log | Where-Object { $_ -match "generation:|prefill:|moe-stream:|moe-cache:|peak_rss|mem_avail_floor|batt_temp_max|cpu_temp_max|charge_" } | ForEach-Object { Write-Host "  $_" }
-  Write-Host "  wall(incl load)=${dt}s"
-  $log | Out-File -FilePath "$OutDir\$tag.log" -Encoding utf8
-  & adb pull "$DEV/$tag.csv" "$OutDir\$tag.csv" 2>&1 | Out-Null
-  & adb pull "$DEV/$tag.metrics" "$OutDir\$tag.metrics" 2>&1 | Out-Null
-  if (Test-Path "$OutDir\$tag.csv") { Write-Host "  -> $tag.csv + .metrics pulled" } else { Write-Host "  !! no CSV for $tag" }
+  Invoke-BenchCfg -Tag $tag -Model $model -Flags $flags -OutDir $OutDir -NPred $NPred -CooldownSec $CooldownSec
 }
 
-$models = @{ qwen = $QWEN; gemma = $GEMMA }
+$models = @{ qwen = $Qwen; gemma = $Gemma }
 foreach ($name in @("qwen","gemma")) {
   $m = $models[$name]
   Run-Cfg "${name}_mmap"     $m ""

--- a/scripts/bench-pr23-c2000.ps1
+++ b/scripts/bench-pr23-c2000.ps1
@@ -1,31 +1,26 @@
 # Max-throughput follow-up for Qwen: push the cache lever (5000 MiB — fewer misses, closer to the
-# ~7 tok/s compute ceiling) and test the one new feature with a real shot here — shallow prefetch
-# (depth 1, low speculative volume, unlike spec-gate). Baseline vs +prefetch 1, at lane 4 overlap.
+# ~7 tok/s compute ceiling) and test shallow prefetch (depth 1, low speculative volume) on top of it.
+# Baseline vs +prefetch 1, at lane 4 overlap.
 param(
   [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench-pr23"),
   [int]$NPred = 256,
-  [int]$CooldownSec = 45
+  [int]$CooldownSec = 45,
+  [string]$Qwen
 )
 $ErrorActionPreference = "Continue"
+. "$PSScriptRoot\bench-lib.ps1"
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
-$DEV = "/data/local/tmp"
-$QWEN = "/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf"
+
+if (-not $Qwen) { $Qwen = $BENCH_QWEN }
+
+$match = $BENCH_MATCH_DEFAULT + "|moe-overlap:|moe-prefetch:"
 
 function Run-Cfg($tag, $model, $flags) {
-  Write-Host "==================== $tag ===================="
-  Start-Sleep -Seconds $CooldownSec
-  $t0 = Get-Date
-  $log = & adb shell "sh $DEV/bench-run.sh $NPred $model $DEV/$tag.csv $DEV/$tag.metrics $flags" 2>&1
-  $dt = [math]::Round(((Get-Date) - $t0).TotalSeconds, 1)
-  $log | Where-Object { $_ -match "generation:|prefill:|moe-stream:|moe-cache:|moe-overlap:|moe-prefetch:|moe-spec-gate:|peak_rss|mem_avail_floor|batt_temp_max|cpu_temp_max" } | ForEach-Object { Write-Host "  $_" }
-  Write-Host "  wall(incl load)=${dt}s"
-  $log | Out-File -FilePath "$OutDir\$tag.log" -Encoding utf8
-  & adb pull "$DEV/$tag.csv" "$OutDir\$tag.csv" 2>&1 | Out-Null
-  & adb pull "$DEV/$tag.metrics" "$OutDir\$tag.metrics" 2>&1 | Out-Null
-  if (Test-Path "$OutDir\$tag.csv") { Write-Host "  -> $tag.csv pulled" } else { Write-Host "  !! no CSV for $tag" }
+  Invoke-BenchCfg -Tag $tag -Model $model -Flags $flags -OutDir $OutDir -NPred $NPred `
+                  -CooldownSec $CooldownSec -Match $match
 }
 
 $B = "--moe-stream --cache-mb 5000 --io-threads 4 --overlap"
-Run-Cfg "qwen5k_base" $QWEN $B
-Run-Cfg "qwen5k_pf1"  $QWEN "$B --prefetch 1"
+Run-Cfg "qwen5k_base" $Qwen $B
+Run-Cfg "qwen5k_pf1"  $Qwen "$B --prefetch 1"
 Write-Host "ALL DONE -> $OutDir"

--- a/scripts/bench-pr23-summary.py
+++ b/scripts/bench-pr23-summary.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
-# Summarise the PR2/PR3 device A/B: parse each run's .log (throughput + cache + the new
-# prefetch/spec-gate lines) and .metrics (device pressure) into one markdown table per model.
+# ARCHIVED — kept for the provenance of the published PR2/PR3 A/B tables, not for reuse.
+#
+# Summarises that A/B: each run's .log (throughput + cache + prefetch/spec-gate lines) and .metrics
+# (device pressure) into one markdown table per model. Its `sg` / `sg_pf2` configs and the
+# `moe-spec-gate:` recall line no longer exist — the CLI does not accept the flag and the engine does
+# not emit the metric — so those rows can only come out empty against a current build.
+#
+# It stays because the tables it produced are published; deleting it would leave those numbers with
+# no visible derivation. For live analysis use bench-analyze.py.
 import os, re, sys, statistics
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/scripts/bench-prefetch.ps1
+++ b/scripts/bench-prefetch.ps1
@@ -1,39 +1,36 @@
 # On-device A/B for temporal prefetch, on top of each model's best measured config from
 # docs/bench-data/2026-07-12 (Qwen: cache 4000, lane 4, overlap; Gemma: cache 2000, lane 4,
-# overlap). One matrix per model: base / +prefetch.
+# overlap). One pair per model: base / +prefetch.
 param(
   [string]$OutDir = (Join-Path (Split-Path $PSScriptRoot -Parent) ".bench-pr23"),
   [int]$NPred = 256,
-  [int]$CooldownSec = 45
+  [int]$CooldownSec = 45,
+  [string]$Qwen,
+  [string]$Gemma
 )
 $ErrorActionPreference = "Continue"
+. "$PSScriptRoot\bench-lib.ps1"
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
-$DEV = "/data/local/tmp"
-$QWEN  = "/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf"
-$GEMMA = "/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf"
+
+if (-not $Qwen)  { $Qwen  = $BENCH_QWEN }
+if (-not $Gemma) { $Gemma = $BENCH_GEMMA }
+
+# This A/B is about overlap and prefetch, so watch their lines too.
+$match = $BENCH_MATCH_DEFAULT + "|moe-overlap:|moe-prefetch:"
 
 function Run-Cfg($tag, $model, $flags) {
-  Write-Host "==================== $tag ===================="
-  Start-Sleep -Seconds $CooldownSec
-  $t0 = Get-Date
-  $log = & adb shell "sh $DEV/bench-run.sh $NPred $model $DEV/$tag.csv $DEV/$tag.metrics $flags" 2>&1
-  $dt = [math]::Round(((Get-Date) - $t0).TotalSeconds, 1)
-  $log | Where-Object { $_ -match "generation:|prefill:|moe-stream:|moe-cache:|moe-overlap:|moe-prefetch:|peak_rss|mem_avail_floor|batt_temp_max|cpu_temp_max" } | ForEach-Object { Write-Host "  $_" }
-  Write-Host "  wall(incl load)=${dt}s"
-  $log | Out-File -FilePath "$OutDir\$tag.log" -Encoding utf8
-  & adb pull "$DEV/$tag.csv" "$OutDir\$tag.csv" 2>&1 | Out-Null
-  & adb pull "$DEV/$tag.metrics" "$OutDir\$tag.metrics" 2>&1 | Out-Null
-  if (Test-Path "$OutDir\$tag.csv") { Write-Host "  -> $tag.csv pulled" } else { Write-Host "  !! no CSV for $tag" }
+  Invoke-BenchCfg -Tag $tag -Model $model -Flags $flags -OutDir $OutDir -NPred $NPred `
+                  -CooldownSec $CooldownSec -Match $match
 }
 
 # Qwen — best baseline: cache 4000 MiB, lane 4, overlap
 $QB = "--moe-stream --cache-mb 4000 --io-threads 4 --overlap"
-Run-Cfg "qwen_base"     $QWEN  $QB
-Run-Cfg "qwen_pf2"      $QWEN  "$QB --prefetch 2"
+Run-Cfg "qwen_base"     $Qwen  $QB
+Run-Cfg "qwen_pf2"      $Qwen  "$QB --prefetch 2"
 
 # Gemma — best baseline: cache 2000 MiB, lane 4, overlap
 $GB = "--moe-stream --cache-mb 2000 --io-threads 4 --overlap"
-Run-Cfg "gemma_base"    $GEMMA $GB
-Run-Cfg "gemma_pf2"     $GEMMA "$GB --prefetch 2"
+Run-Cfg "gemma_base"    $Gemma $GB
+Run-Cfg "gemma_pf2"     $Gemma "$GB --prefetch 2"
 
 Write-Host "ALL DONE -> $OutDir"

--- a/scripts/bench-warmonly.sh
+++ b/scripts/bench-warmonly.sh
@@ -2,9 +2,13 @@
 # Warm-up-only validation: dense warm-up ON, dense reservation OFF (default binary now).
 # One run per model at the higher k tested before, same recipes as the full battery.
 # Confirms the gpt-oss startup win survives and gemma/qwen show no budget-driven regression.
-GPTOSS=/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf
-QWEN=/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf
-GEMMA=/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf
+#
+# Model paths default to where they sit on the test device; override any of them from the
+# environment to bench a different copy, e.g.
+#   GPTOSS=/sdcard/Download/other.gguf sh bench-warmonly.sh
+GPTOSS=${GPTOSS:-/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf}
+QWEN=${QWEN:-/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf}
+GEMMA=${GEMMA:-/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf}
 PSHORT="What is 17 times 23? Then name the capital of Australia."
 PLONG="Write a long detailed essay about the history of computing including its origins its key milestones the people involved and the future directions of the field"
 cd /data/local/tmp || exit 1

--- a/scripts/decode-analyze.py
+++ b/scripts/decode-analyze.py
@@ -12,27 +12,12 @@ A traced run is not a benchmark run: isolating every node forbids ggml the opera
 would normally do, and the I/O rows take a lock per read. Read the proportions, not the absolutes.
 """
 import argparse
-import csv
+import os
 import sys
 from collections import defaultdict
 
-
-def read_trace(path):
-    """Split the `#` preamble from the rows. Mirrors scripts/route-analyze.py's reader."""
-    meta, rows = {}, []
-    with open(path, newline="", encoding="utf-8") as f:
-        lines = f.readlines()
-    body = []
-    for ln in lines:
-        if ln.startswith("#"):
-            for tok in ln.lstrip("# ").rstrip().split():
-                if "=" in tok:
-                    k, v = tok.split("=", 1)
-                    meta[k] = v
-        else:
-            body.append(ln)
-    rows = list(csv.DictReader(body))
-    return meta, rows
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from trace_io import read_preamble_csv as read_trace
 
 
 def fmt_ms(ns):

--- a/scripts/gptoss-matrix.sh
+++ b/scripts/gptoss-matrix.sh
@@ -3,10 +3,13 @@
 # Sweep io-threads {4,8} x prefetch {0,4} x top-k {2,3,4} = 12 cells.
 # Per cell: full bmoe-cli stdout (the direct answer + perf lines). Deterministic greedy,
 # so the answer depends only on k -> quality read once per k, perf per cell.
-M=/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf
+#
+# Model path, output log and cooldown default to the test device's setup; override from the
+# environment, e.g.  M=/sdcard/Download/other.gguf COOLDOWN=60 sh gptoss-matrix.sh
+M=${M:-/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf}
 P="What is 17 times 23? Then name the capital of Australia."
-OUT=/data/local/tmp/gptoss-matrix.out
-COOLDOWN=20
+OUT=${OUT:-/data/local/tmp/gptoss-matrix.out}
+COOLDOWN=${COOLDOWN:-20}
 cd /data/local/tmp || exit 1
 : > "$OUT"
 for K in 2 3 4; do

--- a/scripts/gptoss-mmap.sh
+++ b/scripts/gptoss-mmap.sh
@@ -4,10 +4,13 @@
 # in/out of the page cache on demand. This is the >RAM baseline the streaming modes beat.
 # top-k override still applies (it is a load-time kv_override, valid without streaming).
 # Appends to the same log as the streaming matrix. k=4 then k=2, per request.
-M=/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf
+#
+# Overridable from the environment, and M/OUT must match the streaming matrix run this is the
+# baseline for: OUT is appended to, not replaced.
+M=${M:-/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf}
 P="What is 17 times 23? Then name the capital of Australia."
-OUT=/data/local/tmp/gptoss-matrix.out
-COOLDOWN=20
+OUT=${OUT:-/data/local/tmp/gptoss-matrix.out}
+COOLDOWN=${COOLDOWN:-20}
 cd /data/local/tmp || exit 1
 for K in 4 2; do
   TAG="mmap_k${K}"

--- a/scripts/route-analyze.py
+++ b/scripts/route-analyze.py
@@ -18,8 +18,12 @@
 #   python scripts/route-analyze.py trace.csv --view hot --top 12
 import argparse
 import math
+import os
 import sys
 from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from trace_io import kv_tokens
 
 PHASES = {"prefill": 0, "decode": 1}
 RESIDENCY = {0: "miss", 1: "hit", 2: "prefetch"}
@@ -70,7 +74,7 @@ class Trace:
                 self.rows.append((int(p[2]), int(p[3]), int(p[4]), int(p[5]), w, int(p[7]), int(p[8])))
 
     def _preamble(self, line):
-        kv = dict(tok.split("=", 1) for tok in line[1:].split() if "=" in tok)
+        kv = kv_tokens(line)
         if "model" in kv:
             self.model = kv["model"]
             self.arch = kv.get("arch", "?")

--- a/scripts/trace_io.py
+++ b/scripts/trace_io.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Shared reading for the analysis scripts. Stdlib only, like everything else here.
+
+Every artifact the engine writes — the per-token CSV, the route trace, the decode/IO traces, the
+device .metrics file — carries its context as `key=value` tokens on `#` lines, with the rows below.
+That contract is one thing, and it was being re-implemented per script (decode-analyze.py's reader
+said as much: "Mirrors scripts/route-analyze.py's reader"). It lives here now.
+
+The contract is deliberately forgiving in one direction: unknown keys are kept and missing keys are
+absent rather than an error, so a file from an older or newer engine still reads.
+"""
+import csv
+import os
+
+
+def kv_tokens(line):
+    """`# a=1 b=2` -> {"a": "1", "b": "2"}. Non-`key=value` tokens are skipped."""
+    return dict(tok.split("=", 1) for tok in line.lstrip("#").split() if "=" in tok)
+
+
+def read_preamble_csv(path):
+    """Split a `#`-preamble CSV into (meta, rows): meta merges every `#` line's key=value tokens,
+    rows are dicts keyed by the header. Use when the rows are wanted by column NAME."""
+    meta, body = {}, []
+    with open(path, newline="", encoding="utf-8") as f:
+        for ln in f:
+            if ln.startswith("#"):
+                meta.update(kv_tokens(ln.rstrip()))
+            else:
+                body.append(ln)
+    return meta, list(csv.DictReader(body))
+
+
+def read_kv_file(path):
+    """A flat `key=value` per line file (the device .metrics sidecar). {} when absent."""
+    d = {}
+    if os.path.exists(path):
+        with open(path) as f:
+            for line in f:
+                if "=" in line:
+                    k, v = line.strip().split("=", 1)
+                    d[k] = v
+    return d
+
+
+def percentile(values, q):
+    """Linear-interpolated percentile of an ALREADY SORTED list; 0.0 when empty."""
+    if not values:
+        return 0.0
+    i = q * (len(values) - 1)
+    lo = int(i)
+    hi = min(lo + 1, len(values) - 1)
+    return values[lo] + (values[hi] - values[lo]) * (i - lo)


### PR DESCRIPTION
> Independent of the others (scripts only) — mergeable in any order.

`scripts/` had drifted into a pile of near-duplicate one-off drivers: four PS1 files each carrying a **byte-identical `Run-Cfg`**, three Python tools each re-deriving the same readers — one saying so out loud (*"Mirrors scripts/route-analyze.py's reader"*).

### Two shared pieces

- **`bench-lib.ps1`** — the driver plumbing (cooldown, `adb` into `bench-run.sh`, filter the perf lines, pull the artifacts). A driver is now its config matrix and nothing else.
- **`trace_io.py`** — the reading contract every artifact shares: `key=value` tokens on `#` lines, rows below, unknown keys kept.

Device model paths were hardcoded in scripts that were otherwise parameterised → now defaults behind `-Qwen`/`-Gemma` params (PS1) and `${VAR:-default}` (sh).

### Retired framing, pruned from the tools that still run

- `bench-analyze.py` listed **`sg_ov`** (speculative gating — removed in #15) and labelled `--cache-mb auto` "adaptive cache" with a **`resizes`** column. The governor that resized is gone, so that count is `0` for every run `bmoe-cli` can produce — and a column that is structurally always 0 reads as a *finding*, not a blank. Dropped; auto is now "auto-sized".
- `bench-pr23-c2000.ps1` grepped for `moe-spec-gate:`, a line the engine no longer emits. Its `--prefetch` A/B is still valid → moved onto the lib.

### Deliberately NOT retrofitted

`bench-matrix-rework.ps1` and `bench-pr23-summary.py` only re-derive tables already published under `docs/bench-data`, and their spec-gate cells cannot run against a current build. Marked **ARCHIVED with the reason** rather than rebuilt or deleted — deleting them would leave published numbers with no visible derivation.

### One thing the copies were hiding

`bench-lib.ps1` documents it: the cooldown is a **timer**, and a timer doesn't guarantee a thermal baseline — hence the matrices where tok/s tracked run order rather than the config. Fixing it needs device calibration; saying so beats leaving the next reader to rediscover it.

### Verification — against committed data, not by inspection

| check | result |
|---|---|
| `route-analyze --view hot/reuse/overlap/cache`, `decode-analyze` | output **byte-identical** before/after (`2026-07-15-route-trace`) |
| `bench-analyze` on `docs/bench-data/2026-07-13` | **every figure matches the committed `summary.md` digit for digit**; only labels changed, `sg_ov` gone |
| all five PS1 files | parse clean |
| dot-sourced `Invoke-BenchCfg` | builds the **exact same** adb command string the copies did |