### PR TITLE
feat(android): built-in model catalog, and retire the shardllm directory

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -39,20 +39,40 @@ Two build flavors differ only in how a model reaches the device:
 
 ## Getting a model onto the device
 
-Any of these — the picker lists every MoE `.gguf` it finds (dense models are filtered out by
-a gguf-header check):
+The picker lists every MoE `.gguf` it finds (dense models are filtered out by a gguf-header
+check). Nothing below needs a storage permission except the last option.
 
-1. **In-app URL download** (both flavors). Tap **Add → Download** and paste a direct gguf URL
-   (e.g. a Hugging Face `…/resolve/main/model.gguf` link). It downloads in the background to
-   the app's files dir — no permission needed — and appears in the picker when done.
-2. **In-app file picker** (both flavors). Tap **Add → Pick file** and choose a `.gguf` already
-   on the device; it is imported into the app's files dir.
+1. **Built-in catalog** (both flavors) — the "Get a model" card offers the models this engine
+   is measured on, each a single tap: **Qwen3-30B-A3B-Q4_K_M** (~18.5 GB, the reference model)
+   and **Gemma-4-26B-A4B-it-Q4_K_M** (~17 GB). Downloads run in the background, survive the app
+   being killed, and appear in the picker when done.
+2. **Any other model** — under **Other model**, paste a direct gguf URL (e.g. a Hugging Face
+   `…/resolve/main/model.gguf` link), or pick a `.gguf` already on the device to import it.
 3. **adb push** (dev flavor only — needs all-files access, which the dev build requests):
 
    ```bash
    adb push Qwen3-30B-A3B-Q4_K_M.gguf /sdcard/Download/
-   # or the app's own dir, or /data/local/tmp/shardllm for a model too big to duplicate
+   # /data/local/tmp/bmoe avoids duplicating a model too big to copy, and is on a real
+   # filesystem where O_DIRECT works (the emulated dirs fall back to buffered I/O)
+   adb push Qwen3-30B-A3B-Q4_K_M.gguf /data/local/tmp/bmoe/
    ```
+
+   This directory was named `shardllm` before v0.8.0. To keep models already pushed there:
+
+   ```bash
+   adb shell mv /data/local/tmp/shardllm /data/local/tmp/bmoe
+   ```
+
+### gpt-oss-120b
+
+Listed in the catalog but not downloadable in-app: Hugging Face ships the Q4_K_M quant as two
+shards (the 50 GB per-file limit), and expert streaming reads tensors by byte offset from a
+single file. Merge the shards on a PC, then transfer the result:
+
+```bash
+llama-gguf-split --merge gpt-oss-120b-Q4_K_M-00001-of-00002.gguf gpt-oss-120b-Q4_K_M.gguf
+adb push gpt-oss-120b-Q4_K_M.gguf /data/local/tmp/bmoe/   # or import it with the file picker
+```
 
 ## Expected numbers
 

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 9
-        versionName '0.7.0'
+        versionCode 10
+        versionName '0.8.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Fetching a model is the only thing this app does over the network: DownloadManager needs
+         INTERNET both to run a download and to report on one. Inference is entirely on-device —
+         nothing about a prompt or an answer leaves the phone. -->
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- No broad storage permission here: models arrive through the in-app URL downloader or
          the system file picker, both writing to the app-specific external files dir. The dev
          flavor overlay (src/dev/AndroidManifest.xml) adds all-files access to also read

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -12,10 +12,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -25,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -223,7 +226,7 @@ private fun MainScreen(
                     // Bring a model onto the device without adb: the built-in catalog, an arbitrary
                     // URL, or a local file. All land in the app models dir; on completion we
                     // re-scan so the model appears above.
-                    AddModelSection(models = models, onModelReady = onRefresh)
+                    AddModelSection(models = models, scanning = scanning, onModelReady = onRefresh)
 
                     OutlinedTextField(
                         value = prompt,
@@ -372,13 +375,19 @@ private fun configSummary(s: AppSettings): String {
  * [models] is the current scan result: it is what tells a catalog entry it is already on device.
  */
 @Composable
-private fun AddModelSection(models: List<File>, onModelReady: () -> Unit) {
+private fun AddModelSection(models: List<File>, scanning: Boolean, onModelReady: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     var url by rememberSaveable { mutableStateOf("") }
     var expanded by rememberSaveable { mutableStateOf(false) }
     var showInstall by rememberSaveable { mutableStateOf<String?>(null) }
+    // Null until the first scan finishes: on a first run the card opens itself, on a device that
+    // already has a model it stays out of the way. Deciding before the scan lands would flash the
+    // whole catalog open on every launch.
+    var open by rememberSaveable { mutableStateOf<Boolean?>(null) }
+    LaunchedEffect(scanning) { if (!scanning && open == null) open = models.isEmpty() }
+    val isOpen = open == true
     // filename -> DownloadManager id. Seeded from DownloadManager rather than remembered, so a
     // transfer started before the app was killed is picked back up instead of running unseen.
     var downloads by remember { mutableStateOf<Map<String, Long>>(emptyMap()) }
@@ -442,35 +451,51 @@ private fun AddModelSection(models: List<File>, onModelReady: () -> Unit) {
 
     ElevatedCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("Get a model", fontWeight = FontWeight.SemiBold)
-
-            ModelCatalog.entries.forEach { e ->
-                CatalogRow(
-                    entry = e,
-                    status = ModelCatalog.statusOf(e, present, downloads.keys),
-                    progress = progress[e.fileName],
-                    installShown = showInstall == e.fileName,
-                    onToggleInstall = { showInstall = if (showInstall == e.fileName) null else e.fileName },
-                    onDownload = {
-                        error = null
-                        ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
-                            .onSuccess { reseed() }
-                            .onFailure { error = it.message ?: "download failed to start" }
-                    },
-                    onCancel = {
-                        downloads[e.fileName]?.let { ModelDownloader.cancel(context, it, e.fileName) }
-                        reseed()
-                    },
-                )
-            }
-
-            HorizontalDivider()
-
+            // Collapsible: once a model is on the device this card is just in the way, but it has
+            // to stay reachable to add a second one.
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Other model", fontSize = 14.sp, modifier = Modifier.weight(1f))
-                TextButton(onClick = { expanded = !expanded }) { Text(if (expanded) "Hide" else "Show") }
+                Column(Modifier.weight(1f)) {
+                    Text("Get a model", fontWeight = FontWeight.SemiBold)
+                    if (!isOpen && downloads.isNotEmpty()) {
+                        Text(
+                            "${downloads.size} downloading…",
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                TextButton(onClick = { open = !isOpen }) { Text(if (isOpen) "Close" else "Open") }
             }
-            if (expanded) {
+
+            if (isOpen) {
+                ModelCatalog.entries.forEach { e ->
+                    CatalogRow(
+                        entry = e,
+                        status = ModelCatalog.statusOf(e, present, downloads.keys),
+                        progress = progress[e.fileName],
+                        installShown = showInstall == e.fileName,
+                        onToggleInstall = { showInstall = if (showInstall == e.fileName) null else e.fileName },
+                        onDownload = {
+                            error = null
+                            ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
+                                .onSuccess { reseed() }
+                                .onFailure { error = it.message ?: "download failed to start" }
+                        },
+                        onCancel = {
+                            downloads[e.fileName]?.let { ModelDownloader.cancel(context, it, e.fileName) }
+                            reseed()
+                        },
+                    )
+                }
+
+                HorizontalDivider()
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Other model", fontSize = 14.sp, modifier = Modifier.weight(1f))
+                    TextButton(onClick = { expanded = !expanded }) { Text(if (expanded) "Hide" else "Show") }
+                }
+            }
+            if (isOpen && expanded) {
                 Text(
                     "Any MoE gguf works — paste a direct link, or pick a file already on the device.",
                     fontSize = 12.sp,
@@ -502,10 +527,13 @@ private fun AddModelSection(models: List<File>, onModelReady: () -> Unit) {
                 // A pasted URL has no catalog row to show its progress in.
                 progress.filterKeys { k -> ModelCatalog.entries.none { it.fileName == k } }
                     .forEach { (name, p) ->
-                        DownloadProgress(p) {
-                            ModelDownloader.cancel(context, p.id, name)
-                            reseed()
-                        }
+                        DownloadProgress(
+                            p,
+                            onCancel = {
+                                ModelDownloader.cancel(context, p.id, name)
+                                reseed()
+                            },
+                        )
                     }
             }
 
@@ -534,61 +562,96 @@ private fun CatalogRow(
     onDownload: () -> Unit,
     onCancel: () -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        // Name and action share a line; the blurb gets the full card width on its own line. Next
+        // to a button there is not enough room left for a sentence, and it wraps to a stack of
+        // one-word lines.
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Column(Modifier.weight(1f)) {
-                Text(entry.title, fontSize = 14.sp)
-                Text(
-                    "${ModelCatalog.sizeLabel(entry)} · ${entry.blurb}",
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+            Text(
+                entry.title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(8.dp))
             when (status) {
                 ModelCatalog.Status.AVAILABLE ->
-                    Button(onClick = onDownload) { Text("Download") }
+                    Button(onClick = onDownload, contentPadding = PaddingValues(horizontal = 16.dp)) {
+                        Text("Download", maxLines = 1, softWrap = false)
+                    }
                 ModelCatalog.Status.DOWNLOADING ->
-                    TextButton(onClick = onCancel) { Text("Cancel") }
+                    TextButton(onClick = onCancel) { Text("Cancel", maxLines = 1, softWrap = false) }
                 ModelCatalog.Status.ON_DEVICE ->
                     Text(
                         "On device",
-                        fontSize = 12.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 12.dp),
+                        fontSize = 13.sp,
+                        maxLines = 1,
+                        softWrap = false,
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 ModelCatalog.Status.MANUAL_ONLY ->
-                    TextButton(onClick = onToggleInstall) { Text(if (installShown) "Hide" else "How to") }
+                    TextButton(onClick = onToggleInstall) {
+                        Text(if (installShown) "Hide" else "How to", maxLines = 1, softWrap = false)
+                    }
             }
         }
-        if (progress != null) DownloadProgress(progress, onCancel = null)
+        Text(
+            "${entry.quant} · ${ModelCatalog.sizeLabel(entry)} · ${entry.blurb}",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (progress != null) DownloadProgress(progress, onCancel = null, showName = false)
         if (installShown) {
             entry.install?.let {
+                // Commands must stay copy-pasteable, so they scroll sideways rather than wrap:
+                // a wrapped shell line is a broken shell line.
                 SelectionContainer {
-                    Text(it, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                    Text(
+                        it,
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 11.sp,
+                        softWrap = false,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(vertical = 4.dp),
+                    )
                 }
             }
         }
     }
 }
 
-/** Progress line + bar for one download. [onCancel] null when the row already offers Cancel. */
+/**
+ * Progress line + bar for one download. [onCancel] null when the row already offers Cancel;
+ * [showName] false inside a catalog row, where the title is already on the line above.
+ */
 @Composable
-private fun DownloadProgress(p: ModelDownloader.Progress, onCancel: (() -> Unit)?) {
+private fun DownloadProgress(
+    p: ModelDownloader.Progress,
+    onCancel: (() -> Unit)?,
+    showName: Boolean = true,
+) {
     val pct = if (p.totalBytes > 0) {
         (p.downloadedBytes.toFloat() / p.totalBytes).coerceIn(0f, 1f)
     } else {
         null
     }
+    val prefix = if (showName) "${p.name} — " else ""
     Text(
         when {
-            p.state == ModelDownloader.State.PAUSED -> "${p.name} — ${p.reason ?: "paused"}"
-            pct != null -> String.format(
-                Locale.US, "%s — %d%% (%d/%d MiB)",
-                p.name, (pct * 100).toInt(), p.downloadedBytes shr 20, p.totalBytes shr 20,
+            p.state == ModelDownloader.State.PAUSED -> prefix + (p.reason ?: "paused")
+            pct != null -> prefix + String.format(
+                Locale.US, "%d%% (%d/%d MiB)",
+                (pct * 100).toInt(), p.downloadedBytes shr 20, p.totalBytes shr 20,
             )
-            else -> "Downloading ${p.name}…"
+            else -> if (showName) "Downloading ${p.name}…" else "Starting…"
         },
         fontSize = 12.sp,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
     )
     if (pct != null) {
         LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -220,9 +220,10 @@ private fun MainScreen(
                         )
                     }
 
-                    // Bring a model onto the device without adb: download by URL or pick a local file.
-                    // Both land in the app models dir; on completion we re-scan so it appears above.
-                    AddModelSection(onModelReady = onRefresh)
+                    // Bring a model onto the device without adb: the built-in catalog, an arbitrary
+                    // URL, or a local file. All land in the app models dir; on completion we
+                    // re-scan so the model appears above.
+                    AddModelSection(models = models, onModelReady = onRefresh)
 
                     OutlinedTextField(
                         value = prompt,
@@ -363,22 +364,33 @@ private fun configSummary(s: AppSettings): String {
 }
 
 /**
- * "Add a model" card: download a gguf by URL (DownloadManager) or import one the user already
- * has via the system file picker (SAF). Both write to the app models dir with no permission;
- * [onModelReady] triggers a re-scan so the new model shows up in the picker above.
+ * "Get a model" card: one-tap downloads of the models this engine is measured on ([ModelCatalog]),
+ * plus the escape hatches — any gguf URL (DownloadManager) or a file the user already has (SAF
+ * picker). Everything lands in the app models dir with no permission; [onModelReady] triggers a
+ * re-scan so the new model shows up in the picker above.
+ *
+ * [models] is the current scan result: it is what tells a catalog entry it is already on device.
  */
 @Composable
-private fun AddModelSection(onModelReady: () -> Unit) {
+private fun AddModelSection(models: List<File>, onModelReady: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     var url by rememberSaveable { mutableStateOf("") }
     var expanded by rememberSaveable { mutableStateOf(false) }
-    var downloadId by rememberSaveable { mutableStateOf(-1L) }
-    var progress by remember { mutableStateOf<ModelDownloader.Progress?>(null) }
+    var showInstall by rememberSaveable { mutableStateOf<String?>(null) }
+    // filename -> DownloadManager id. Seeded from DownloadManager rather than remembered, so a
+    // transfer started before the app was killed is picked back up instead of running unseen.
+    var downloads by remember { mutableStateOf<Map<String, Long>>(emptyMap()) }
+    var progress by remember { mutableStateOf<Map<String, ModelDownloader.Progress>>(emptyMap()) }
     var importStatus by remember { mutableStateOf<String?>(null) }
     var importFrac by remember { mutableStateOf(-1f) }
     var error by remember { mutableStateOf<String?>(null) }
+
+    val present = remember(models) { models.map { it.name }.toSet() }
+    val reseed = { downloads = ModelDownloader.activeDownloads(context) }
+
+    LaunchedEffect(Unit) { reseed() }
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
@@ -396,20 +408,32 @@ private fun AddModelSection(onModelReady: () -> Unit) {
         }
     }
 
-    // Poll an active download to completion, then finalize (.part → .gguf) and re-scan.
-    LaunchedEffect(downloadId) {
-        if (downloadId < 0) return@LaunchedEffect
+    // Poll the in-flight downloads; finalize each (.part → .gguf) as it lands and re-scan. The
+    // effect restarts whenever the set changes, which is also how it stops.
+    LaunchedEffect(downloads) {
+        if (downloads.isEmpty()) return@LaunchedEffect
         while (true) {
-            val p = ModelDownloader.query(context, downloadId) ?: break
-            progress = p
-            if (p.state == ModelDownloader.State.SUCCESS) {
-                ModelDownloader.finalizeDownload(context, p.name)
-                downloadId = -1L; progress = null; onModelReady()
-                break
+            val finished = mutableSetOf<String>()
+            val live = mutableMapOf<String, ModelDownloader.Progress>()
+            for ((name, id) in downloads) {
+                val p = ModelDownloader.query(context, id)
+                when {
+                    p == null -> finished += name
+                    p.state == ModelDownloader.State.SUCCESS -> {
+                        ModelDownloader.finalizeDownload(context, name)
+                        finished += name
+                    }
+                    p.state == ModelDownloader.State.FAILED -> {
+                        error = "$name: ${p.reason ?: "download failed"}"
+                        finished += name
+                    }
+                    else -> live[name] = p
+                }
             }
-            if (p.state == ModelDownloader.State.FAILED) {
-                error = p.reason ?: "download failed"
-                downloadId = -1L; progress = null
+            progress = live
+            if (finished.isNotEmpty()) {
+                downloads = downloads - finished
+                onModelReady()
                 break
             }
             delay(700)
@@ -418,11 +442,40 @@ private fun AddModelSection(onModelReady: () -> Unit) {
 
     ElevatedCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Get a model", fontWeight = FontWeight.SemiBold)
+
+            ModelCatalog.entries.forEach { e ->
+                CatalogRow(
+                    entry = e,
+                    status = ModelCatalog.statusOf(e, present, downloads.keys),
+                    progress = progress[e.fileName],
+                    installShown = showInstall == e.fileName,
+                    onToggleInstall = { showInstall = if (showInstall == e.fileName) null else e.fileName },
+                    onDownload = {
+                        error = null
+                        ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
+                            .onSuccess { reseed() }
+                            .onFailure { error = it.message ?: "download failed to start" }
+                    },
+                    onCancel = {
+                        downloads[e.fileName]?.let { ModelDownloader.cancel(context, it, e.fileName) }
+                        reseed()
+                    },
+                )
+            }
+
+            HorizontalDivider()
+
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Add a model", fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
-                TextButton(onClick = { expanded = !expanded }) { Text(if (expanded) "Hide" else "Add") }
+                Text("Other model", fontSize = 14.sp, modifier = Modifier.weight(1f))
+                TextButton(onClick = { expanded = !expanded }) { Text(if (expanded) "Hide" else "Show") }
             }
             if (expanded) {
+                Text(
+                    "Any MoE gguf works — paste a direct link, or pick a file already on the device.",
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
                 OutlinedTextField(
                     value = url,
                     onValueChange = { url = it },
@@ -435,10 +488,10 @@ private fun AddModelSection(onModelReady: () -> Unit) {
                         onClick = {
                             error = null
                             ModelDownloader.enqueue(context, url)
-                                .onSuccess { downloadId = it }
+                                .onSuccess { reseed() }
                                 .onFailure { error = it.message ?: "invalid URL" }
                         },
-                        enabled = url.isNotBlank() && downloadId < 0,
+                        enabled = url.isNotBlank(),
                         modifier = Modifier.weight(1f),
                     ) { Text("Download") }
                     OutlinedButton(
@@ -446,34 +499,14 @@ private fun AddModelSection(onModelReady: () -> Unit) {
                         modifier = Modifier.weight(1f),
                     ) { Text("Pick file") }
                 }
-            }
-
-            progress?.let { p ->
-                val pct = if (p.totalBytes > 0) {
-                    (p.downloadedBytes.toFloat() / p.totalBytes).coerceIn(0f, 1f)
-                } else {
-                    null
-                }
-                Text(
-                    if (pct != null) {
-                        String.format(
-                            Locale.US, "Downloading %s — %d%% (%d/%d MiB)",
-                            p.name, (pct * 100).toInt(), p.downloadedBytes shr 20, p.totalBytes shr 20,
-                        )
-                    } else {
-                        "Downloading ${p.name}…"
-                    },
-                    fontSize = 12.sp,
-                )
-                if (pct != null) {
-                    LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
-                } else {
-                    LinearProgressIndicator(Modifier.fillMaxWidth())
-                }
-                TextButton(onClick = {
-                    ModelDownloader.cancel(context, p.id, p.name)
-                    downloadId = -1L; progress = null
-                }) { Text("Cancel") }
+                // A pasted URL has no catalog row to show its progress in.
+                progress.filterKeys { k -> ModelCatalog.entries.none { it.fileName == k } }
+                    .forEach { (name, p) ->
+                        DownloadProgress(p) {
+                            ModelDownloader.cancel(context, p.id, name)
+                            reseed()
+                        }
+                    }
             }
 
             importStatus?.let { st ->
@@ -488,6 +521,81 @@ private fun AddModelSection(onModelReady: () -> Unit) {
             error?.let { Text(it, color = MaterialTheme.colorScheme.error, fontSize = 12.sp) }
         }
     }
+}
+
+/** One catalog model: what it is, how big, and the single action its current state allows. */
+@Composable
+private fun CatalogRow(
+    entry: ModelCatalog.Entry,
+    status: ModelCatalog.Status,
+    progress: ModelDownloader.Progress?,
+    installShown: Boolean,
+    onToggleInstall: () -> Unit,
+    onDownload: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(entry.title, fontSize = 14.sp)
+                Text(
+                    "${ModelCatalog.sizeLabel(entry)} · ${entry.blurb}",
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            when (status) {
+                ModelCatalog.Status.AVAILABLE ->
+                    Button(onClick = onDownload) { Text("Download") }
+                ModelCatalog.Status.DOWNLOADING ->
+                    TextButton(onClick = onCancel) { Text("Cancel") }
+                ModelCatalog.Status.ON_DEVICE ->
+                    Text(
+                        "On device",
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                ModelCatalog.Status.MANUAL_ONLY ->
+                    TextButton(onClick = onToggleInstall) { Text(if (installShown) "Hide" else "How to") }
+            }
+        }
+        if (progress != null) DownloadProgress(progress, onCancel = null)
+        if (installShown) {
+            entry.install?.let {
+                SelectionContainer {
+                    Text(it, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                }
+            }
+        }
+    }
+}
+
+/** Progress line + bar for one download. [onCancel] null when the row already offers Cancel. */
+@Composable
+private fun DownloadProgress(p: ModelDownloader.Progress, onCancel: (() -> Unit)?) {
+    val pct = if (p.totalBytes > 0) {
+        (p.downloadedBytes.toFloat() / p.totalBytes).coerceIn(0f, 1f)
+    } else {
+        null
+    }
+    Text(
+        when {
+            p.state == ModelDownloader.State.PAUSED -> "${p.name} — ${p.reason ?: "paused"}"
+            pct != null -> String.format(
+                Locale.US, "%s — %d%% (%d/%d MiB)",
+                p.name, (pct * 100).toInt(), p.downloadedBytes shr 20, p.totalBytes shr 20,
+            )
+            else -> "Downloading ${p.name}…"
+        },
+        fontSize = 12.sp,
+    )
+    if (pct != null) {
+        LinearProgressIndicator(progress = { pct }, modifier = Modifier.fillMaxWidth())
+    } else {
+        LinearProgressIndicator(Modifier.fillMaxWidth())
+    }
+    onCancel?.let { TextButton(onClick = it) { Text("Cancel") } }
 }
 
 @Composable

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -395,6 +395,9 @@ private fun AddModelSection(models: List<File>, scanning: Boolean, onModelReady:
     var importStatus by remember { mutableStateOf<String?>(null) }
     var importFrac by remember { mutableStateOf(-1f) }
     var error by remember { mutableStateOf<String?>(null) }
+    // A catalog failure belongs to the row whose button was tapped: filename -> message. Reported
+    // at the bottom of the card it would surface under a different heading entirely.
+    var rowError by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     val present = remember(models) { models.map { it.name }.toSet() }
     val reseed = { downloads = ModelDownloader.activeDownloads(context) }
@@ -474,12 +477,16 @@ private fun AddModelSection(models: List<File>, scanning: Boolean, onModelReady:
                         status = ModelCatalog.statusOf(e, present, downloads.keys),
                         progress = progress[e.fileName],
                         installShown = showInstall == e.fileName,
+                        error = rowError?.takeIf { it.first == e.fileName }?.second,
                         onToggleInstall = { showInstall = if (showInstall == e.fileName) null else e.fileName },
                         onDownload = {
                             error = null
+                            rowError = null
                             ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
                                 .onSuccess { reseed() }
-                                .onFailure { error = it.message ?: "download failed to start" }
+                                .onFailure {
+                                    rowError = e.fileName to (it.message ?: "download failed to start")
+                                }
                         },
                         onCancel = {
                             downloads[e.fileName]?.let { ModelDownloader.cancel(context, it, e.fileName) }
@@ -558,6 +565,7 @@ private fun CatalogRow(
     status: ModelCatalog.Status,
     progress: ModelDownloader.Progress?,
     installShown: Boolean,
+    error: String?,
     onToggleInstall: () -> Unit,
     onDownload: () -> Unit,
     onCancel: () -> Unit,
@@ -602,6 +610,9 @@ private fun CatalogRow(
             fontSize = 12.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        if (error != null) {
+            Text(error, fontSize = 12.sp, color = MaterialTheme.colorScheme.error)
+        }
         if (progress != null) DownloadProgress(progress, onCancel = null, showName = false)
         if (installShown) {
             entry.install?.let {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -20,10 +20,11 @@ object ModelCatalog {
      */
     data class Entry(
         val title: String,
+        val quant: String,
         val fileName: String,
         val approxBytes: Long,
         val url: String?,
-        /** One line under the title. */
+        /** Why you would pick this one. Kept short enough to sit on one line. */
         val blurb: String,
         /** Manual install steps, shown on demand. Non-null exactly when [url] is null. */
         val install: String? = null,
@@ -47,30 +48,33 @@ object ModelCatalog {
 
     val entries: List<Entry> = listOf(
         Entry(
-            title = "Qwen3-30B-A3B (Q4_K_M)",
+            title = "Qwen3-30B-A3B",
+            quant = "Q4_K_M",
             fileName = "Qwen3-30B-A3B-Q4_K_M.gguf",
             approxBytes = 18_556_686_912L,
             url = "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/" +
                 "Qwen3-30B-A3B-Q4_K_M.gguf?download=true",
-            blurb = "The reference model for this engine's published numbers. 3B active of 30B.",
+            blurb = "3B active of 30B. The published numbers use this one.",
         ),
         Entry(
-            title = "Gemma-4-26B-A4B-it (Q4_K_M)",
+            title = "Gemma-4-26B-A4B-it",
+            quant = "Q4_K_M",
             fileName = "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
             approxBytes = 17_035_038_112L,
             url = "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF/resolve/main/" +
                 "google_gemma-4-26B-A4B-it-Q4_K_M.gguf?download=true",
-            blurb = "Smaller expert working set — the gentler first model to try. 4B active of 26B.",
+            blurb = "4B active of 26B. Smaller experts — the gentlest start.",
         ),
         Entry(
-            title = "gpt-oss-120b (Q4_K_M)",
+            title = "gpt-oss-120b",
+            quant = "Q4_K_M",
             fileName = "gpt-oss-120b-Q4_K_M.gguf",
             approxBytes = 62_768_723_552L,
             // Not downloadable in-app: Hugging Face ships this quant as two shards (the 50 GB
             // per-file limit), and expert streaming reads tensors by byte offset from one file.
             // Merging on the phone would need ~120 GB of free space, so it is a PC step.
             url = null,
-            blurb = "The >RAM case: 117B total, 5B active. Needs a merge on a PC first.",
+            blurb = "5B active of 117B. The >RAM case — merge it on a PC.",
             install = "Hugging Face ships this quant as two shards, and expert streaming needs a\n" +
                 "single file. Merging on the phone would need ~120 GB free, so merge on a PC:\n" +
                 "\n" +

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -92,8 +92,15 @@ object ModelCatalog {
         ),
     )
 
-    /** Human-readable size for the row label. Decimal GB, matching how the models are listed. */
-    fun sizeLabel(e: Entry): String = String.format(java.util.Locale.US, "~%.1f GB", e.approxBytes.toDouble() / GB)
+    /**
+     * How this app writes a size: decimal GB, one decimal, the same unit the model repositories
+     * quote. Everything user-facing goes through here — quoting a model as 17.0 GB and then
+     * refusing it for "15 GiB" reads as a bug even though both are true.
+     */
+    fun gbLabel(bytes: Long): String = String.format(java.util.Locale.US, "%.1f GB", bytes.toDouble() / GB)
+
+    /** Size for the row label. */
+    fun sizeLabel(e: Entry): String = "~" + gbLabel(e.approxBytes)
 
     /**
      * Status of one entry. [present] is the scanned model list (any scan dir counts, so a merged

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -1,0 +1,105 @@
+package io.bigmoeonedge.example
+
+/**
+ * The MoE models this app offers as a one-tap download, so a first run needs no adb and no
+ * hunting on Hugging Face. The list is deliberately short: these are the models the engine is
+ * measured on (see docs/benchmarks.md), not a catalog of everything that happens to load.
+ *
+ * Any other MoE gguf still works — the URL field and the file picker below the catalog take
+ * arbitrary models. Nothing here is baked into the engine: architectures are discovered at
+ * runtime, this is only a convenience shortcut in the demo UI.
+ */
+object ModelCatalog {
+
+    /**
+     * One offered model.
+     *
+     * [url] null means "listed but not downloadable in-app" — [install] then carries the manual
+     * recipe. [fileName] is authoritative: it is what lands on disk and what [statusOf] matches
+     * against, so a redirect or a query string in the URL cannot rename the model.
+     */
+    data class Entry(
+        val title: String,
+        val fileName: String,
+        val approxBytes: Long,
+        val url: String?,
+        /** One line under the title. */
+        val blurb: String,
+        /** Manual install steps, shown on demand. Non-null exactly when [url] is null. */
+        val install: String? = null,
+    )
+
+    enum class Status {
+        /** Already on the device — nothing to do. */
+        ON_DEVICE,
+
+        /** A DownloadManager job for this file is in flight. */
+        DOWNLOADING,
+
+        /** Downloadable, not present yet. */
+        AVAILABLE,
+
+        /** Listed for reference; [Entry.notes] carries the manual install recipe. */
+        MANUAL_ONLY,
+    }
+
+    private const val GB = 1_000_000_000L
+
+    val entries: List<Entry> = listOf(
+        Entry(
+            title = "Qwen3-30B-A3B (Q4_K_M)",
+            fileName = "Qwen3-30B-A3B-Q4_K_M.gguf",
+            approxBytes = 18_556_686_912L,
+            url = "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/" +
+                "Qwen3-30B-A3B-Q4_K_M.gguf?download=true",
+            blurb = "The reference model for this engine's published numbers. 3B active of 30B.",
+        ),
+        Entry(
+            title = "Gemma-4-26B-A4B-it (Q4_K_M)",
+            fileName = "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",
+            approxBytes = 17_035_038_112L,
+            url = "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF/resolve/main/" +
+                "google_gemma-4-26B-A4B-it-Q4_K_M.gguf?download=true",
+            blurb = "Smaller expert working set — the gentler first model to try. 4B active of 26B.",
+        ),
+        Entry(
+            title = "gpt-oss-120b (Q4_K_M)",
+            fileName = "gpt-oss-120b-Q4_K_M.gguf",
+            approxBytes = 62_768_723_552L,
+            // Not downloadable in-app: Hugging Face ships this quant as two shards (the 50 GB
+            // per-file limit), and expert streaming reads tensors by byte offset from one file.
+            // Merging on the phone would need ~120 GB of free space, so it is a PC step.
+            url = null,
+            blurb = "The >RAM case: 117B total, 5B active. Needs a merge on a PC first.",
+            install = "Hugging Face ships this quant as two shards, and expert streaming needs a\n" +
+                "single file. Merging on the phone would need ~120 GB free, so merge on a PC:\n" +
+                "\n" +
+                "1. Download both shards from\n" +
+                "   huggingface.co/unsloth/gpt-oss-120b-GGUF (folder Q4_K_M/)\n" +
+                "2. llama-gguf-split --merge \\\n" +
+                "     gpt-oss-120b-Q4_K_M-00001-of-00002.gguf \\\n" +
+                "     gpt-oss-120b-Q4_K_M.gguf\n" +
+                "3. Move the merged file to the phone" +
+                if (BuildConfig.SHARED_STORAGE) {
+                    ":\n   adb push gpt-oss-120b-Q4_K_M.gguf /data/local/tmp/bmoe/"
+                } else {
+                    ", then pick it with\n   \"Other model\" below."
+                },
+        ),
+    )
+
+    /** Human-readable size for the row label. Decimal GB, matching how the models are listed. */
+    fun sizeLabel(e: Entry): String = String.format(java.util.Locale.US, "~%.1f GB", e.approxBytes.toDouble() / GB)
+
+    /**
+     * Status of one entry. [present] is the scanned model list (any scan dir counts, so a merged
+     * gpt-oss pushed to /data/local/tmp/bmoe reads as ON_DEVICE), [downloading] the filenames of
+     * in-flight downloads.
+     */
+    fun statusOf(e: Entry, present: Set<String>, downloading: Set<String>): Status = when {
+        e.fileName in present -> Status.ON_DEVICE
+        e.fileName in downloading -> Status.DOWNLOADING
+        e.url == null -> Status.MANUAL_ONLY
+        else -> Status.AVAILABLE
+    }
+}

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -71,11 +71,11 @@ object ModelDownloader {
         dm.enqueue(req)
     }
 
-    /** Current status of a download, or null if the id is unknown. */
-    fun query(ctx: Context, id: Long): Progress? {
+    /** Current status of a download, or null if the id is unknown or the provider refused. */
+    fun query(ctx: Context, id: Long): Progress? = runCatching {
         val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         dm.query(DownloadManager.Query().setFilterById(id)).use { c ->
-            if (c == null || !c.moveToFirst()) return null
+            if (c == null || !c.moveToFirst()) return@runCatching null
             val status = c.getInt(c.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
             val soFar = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
             val total = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
@@ -93,9 +93,9 @@ object ModelDownloader {
                 State.PAUSED -> pauseReason(reasonCode)
                 else -> null
             }
-            return Progress(id, title, soFar, total, state, reason)
+            Progress(id, title, soFar, total, state, reason)
         }
-    }
+    }.getOrNull()
 
     /**
      * Model downloads this app still has in flight, as filename -> DownloadManager id.
@@ -103,8 +103,12 @@ object ModelDownloader {
      * DownloadManager outlives the app process, so a download started before the app was killed
      * is still running when the user comes back. The UI seeds itself from this instead of losing
      * track of a multi-GB transfer. Only our own downloads are visible to this query.
+     *
+     * Never throws: this only restores convenience state, and the download provider is a system
+     * component that can refuse the query. An empty map costs the user a progress bar; letting
+     * the exception out would cost them the whole screen.
      */
-    fun activeDownloads(ctx: Context): Map<String, Long> {
+    fun activeDownloads(ctx: Context): Map<String, Long> = runCatching {
         val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val q = DownloadManager.Query().setFilterByStatus(
             DownloadManager.STATUS_PENDING or DownloadManager.STATUS_RUNNING or DownloadManager.STATUS_PAUSED
@@ -117,8 +121,8 @@ object ModelDownloader {
                 if (title.endsWith(".gguf")) out.putIfAbsent(title, id)
             }
         }
-        return out
-    }
+        out as Map<String, Long>
+    }.getOrDefault(emptyMap())
 
     /**
      * Finish a successful download: rename `<name>.gguf.part` to `<name>.gguf` in the app models

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -53,8 +53,8 @@ object ModelDownloader {
         val dir = ModelManager.appModelsDir(ctx) ?: error("no writable app storage")
         if (expectedBytes > 0 && expectedBytes > dir.usableSpace) {
             error(
-                "not enough free space: needs ${expectedBytes shr 30} GiB, " +
-                    "${dir.usableSpace shr 30} GiB free"
+                "needs ${ModelCatalog.gbLabel(expectedBytes)}, " +
+                    "only ${ModelCatalog.gbLabel(dir.usableSpace)} free"
             )
         }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -29,15 +29,34 @@ object ModelDownloader {
 
     /**
      * Start a download. Returns the DownloadManager id, or an error if the URL doesn't name a
-     * .gguf file. No model names or hosts are assumed — the filename comes from the URL.
+     * .gguf file or the model cannot fit. No model names or hosts are assumed — for a pasted URL
+     * the filename comes from the URL itself.
+     *
+     * [fileName] overrides that for catalog downloads, where the on-disk name is known upfront
+     * and must not depend on redirects or query strings. [expectedBytes] (when > 0) is checked
+     * against free space before enqueuing: DownloadManager would fail with
+     * ERROR_INSUFFICIENT_SPACE anyway, but only after the user waited for it to try.
      */
-    fun enqueue(ctx: Context, rawUrl: String): Result<Long> = runCatching {
+    fun enqueue(
+        ctx: Context,
+        rawUrl: String,
+        fileName: String? = null,
+        expectedBytes: Long = -1L,
+    ): Result<Long> = runCatching {
         val url = rawUrl.trim()
         val uri = Uri.parse(url)
         require(uri.scheme == "http" || uri.scheme == "https") { "URL must be http(s)" }
 
-        val name = fileNameFromUrl(uri)
+        val name = fileName ?: fileNameFromUrl(uri)
         require(name.endsWith(".gguf")) { "URL must point to a .gguf file" }
+
+        val dir = ModelManager.appModelsDir(ctx) ?: error("no writable app storage")
+        if (expectedBytes > 0 && expectedBytes > dir.usableSpace) {
+            error(
+                "not enough free space: needs ${expectedBytes shr 30} GiB, " +
+                    "${dir.usableSpace shr 30} GiB free"
+            )
+        }
 
         val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val req = DownloadManager.Request(uri)
@@ -76,6 +95,29 @@ object ModelDownloader {
             }
             return Progress(id, title, soFar, total, state, reason)
         }
+    }
+
+    /**
+     * Model downloads this app still has in flight, as filename -> DownloadManager id.
+     *
+     * DownloadManager outlives the app process, so a download started before the app was killed
+     * is still running when the user comes back. The UI seeds itself from this instead of losing
+     * track of a multi-GB transfer. Only our own downloads are visible to this query.
+     */
+    fun activeDownloads(ctx: Context): Map<String, Long> {
+        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+        val q = DownloadManager.Query().setFilterByStatus(
+            DownloadManager.STATUS_PENDING or DownloadManager.STATUS_RUNNING or DownloadManager.STATUS_PAUSED
+        )
+        val out = mutableMapOf<String, Long>()
+        dm.query(q)?.use { c ->
+            while (c.moveToNext()) {
+                val title = c.getString(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TITLE)) ?: continue
+                val id = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_ID))
+                if (title.endsWith(".gguf")) out.putIfAbsent(title, id)
+            }
+        }
+        return out
     }
 
     /**

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -45,10 +45,14 @@ object ModelManager {
         }
     }
 
+    // Deduped by filename, not by path: the same gguf often exists in two scanned dirs (imported
+    // and adb-pushed). The first hit wins, so scanDirs order is a precedence list — the internal
+    // dir (O_DIRECT works) before the emulated external dirs. It also lets the model catalog
+    // recognize its own entries by name, wherever they landed.
     private fun allGguf(ctx: Context): List<File> =
         scanDirs(ctx)
             .flatMap { it.listFiles { f -> f.isFile && f.name.endsWith(".gguf") }?.toList() ?: emptyList() }
-            .distinctBy { it.absolutePath }
+            .distinctBy { it.name }
             .sortedBy { it.name }
 
     /** List MoE models only. Blocking header reads — call off the main thread. */
@@ -61,11 +65,11 @@ object ModelManager {
     /** Empty-state guidance, phrased for the current flavor's model-acquisition paths. */
     fun pushHint(): String =
         if (BuildConfig.SHARED_STORAGE) {
-            "No MoE .gguf found. Add one below (download by URL or pick a file), or adb-push a\n" +
-                "model to shared storage:\n" +
-                "adb push model.gguf /sdcard/Download/"
+            "No MoE .gguf found. Download one below, or adb-push a model to shared storage:\n" +
+                "adb push model.gguf /sdcard/Download/\n" +
+                "adb push model.gguf /data/local/tmp/bmoe/   (no duplicate, O_DIRECT works)"
         } else {
-            "No MoE .gguf found. Add one below: download by URL, or pick a .gguf you already\n" +
-                "have on the device."
+            "No MoE .gguf found. Download one below, or pick a .gguf you already have on the\n" +
+                "device."
         }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -36,19 +36,23 @@ object ModelManager {
      */
     fun internalModelsDir(ctx: Context): File = File(ctx.filesDir, "models").apply { mkdirs() }
 
+    // Order is precedence, not taste: allGguf keeps the first file of a given name, and the same
+    // gguf really does sit in two places at once (adb-pushed to /data/local/tmp *and* downloaded
+    // to /sdcard/Download). Real filesystems come first, because O_DIRECT works there and the
+    // emulated dirs force the engine back onto buffered I/O. Reading the slow copy of a model
+    // that is also present on the fast one is a silent, unexplained loss of throughput.
     private fun scanDirs(ctx: Context): List<File> = buildList {
         add(internalModelsDir(ctx))
+        if (BuildConfig.SHARED_STORAGE && TMP_MODEL_DIR.isDirectory) add(TMP_MODEL_DIR)
         appModelsDir(ctx)?.let { add(it) }
         if (BuildConfig.SHARED_STORAGE) {
             Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.let { add(it) }
-            if (TMP_MODEL_DIR.isDirectory) add(TMP_MODEL_DIR)
         }
     }
 
     // Deduped by filename, not by path: the same gguf often exists in two scanned dirs (imported
-    // and adb-pushed). The first hit wins, so scanDirs order is a precedence list — the internal
-    // dir (O_DIRECT works) before the emulated external dirs. It also lets the model catalog
-    // recognize its own entries by name, wherever they landed.
+    // and adb-pushed). The first hit wins — see scanDirs for the precedence. It also lets the
+    // model catalog recognize its own entries by name, wherever they landed.
     private fun allGguf(ctx: Context): List<File> =
         scanDirs(ctx)
             .flatMap { it.listFiles { f -> f.isFile && f.name.endsWith(".gguf") }?.toList() ?: emptyList() }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -12,7 +12,7 @@ import java.io.File
  *
  *   always      the app-specific external files dir — no permission needed. The in-app URL
  *               downloader and the file picker both land models here.
- *   dev only    the public Downloads folder and /data/local/tmp/shardllm, for models adb-pushed
+ *   dev only    the public Downloads folder and /data/local/tmp/bmoe, for models adb-pushed
  *               to the device. These need all-files access, which only the dev flavor requests.
  *
  * Only MoE models are listed: this engine streams experts, so dense models are filtered out by
@@ -23,7 +23,7 @@ object ModelManager {
     // still be adb-pushed to /data/local/tmp (same physical partition, no duplicate needed) and
     // read in place: the path is world-traversable and the file world-readable, so the app's
     // untrusted_app domain can open it.
-    private val TMP_MODEL_DIR = File("/data/local/tmp/shardllm")
+    private val TMP_MODEL_DIR = File("/data/local/tmp/bmoe")
 
     /** The app-specific external files dir — the download target, readable with no permission. */
     fun appModelsDir(ctx: Context): File? = ctx.getExternalFilesDir(null)

--- a/scripts/bench-warmonly.sh
+++ b/scripts/bench-warmonly.sh
@@ -6,7 +6,7 @@
 # Model paths default to where they sit on the test device; override any of them from the
 # environment to bench a different copy, e.g.
 #   GPTOSS=/sdcard/Download/other.gguf sh bench-warmonly.sh
-GPTOSS=${GPTOSS:-/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf}
+GPTOSS=${GPTOSS:-/data/local/tmp/bmoe/gpt-oss-120b-Q4_K_M.gguf}
 QWEN=${QWEN:-/sdcard/Download/Qwen3-30B-A3B-Q4_K_M.gguf}
 GEMMA=${GEMMA:-/sdcard/Download/google_gemma-4-26B-A4B-it-Q4_K_M.gguf}
 PSHORT="What is 17 times 23? Then name the capital of Australia."

--- a/scripts/gptoss-matrix.sh
+++ b/scripts/gptoss-matrix.sh
@@ -6,7 +6,7 @@
 #
 # Model path, output log and cooldown default to the test device's setup; override from the
 # environment, e.g.  M=/sdcard/Download/other.gguf COOLDOWN=60 sh gptoss-matrix.sh
-M=${M:-/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf}
+M=${M:-/data/local/tmp/bmoe/gpt-oss-120b-Q4_K_M.gguf}
 P="What is 17 times 23? Then name the capital of Australia."
 OUT=${OUT:-/data/local/tmp/gptoss-matrix.out}
 COOLDOWN=${COOLDOWN:-20}

--- a/scripts/gptoss-mmap.sh
+++ b/scripts/gptoss-mmap.sh
@@ -7,7 +7,7 @@
 #
 # Overridable from the environment, and M/OUT must match the streaming matrix run this is the
 # baseline for: OUT is appended to, not replaced.
-M=${M:-/data/local/tmp/shardllm/gpt-oss-120b-Q4_K_M.gguf}
+M=${M:-/data/local/tmp/bmoe/gpt-oss-120b-Q4_K_M.gguf}
 P="What is 17 times 23? Then name the capital of Australia."
 OUT=${OUT:-/data/local/tmp/gptoss-matrix.out}
 COOLDOWN=${COOLDOWN:-20}


### PR DESCRIPTION
Makes a first run possible without knowing which MoE gguf to hunt for, and drops a directory name inherited from an earlier project.

## What changes

**A model catalog in the app.** The "Get a model" card lists the models this engine is measured on, each one tap:

| model | size | in-app download |
|---|---|---|
| Qwen3-30B-A3B-Q4_K_M | ~18.6 GB | yes |
| Gemma-4-26B-A4B-it-Q4_K_M | ~17.0 GB | yes |
| gpt-oss-120b-Q4_K_M | ~62.8 GB | no — shows the merge recipe |

Each row shows size, a one-line blurb, and the single action its state allows: Download / progress + Cancel / "On device". Free space is checked before enqueuing rather than after DownloadManager fails on it.

`gpt-oss-120b` is listed but deliberately not downloadable: Hugging Face ships that quant as two shards (the 50 GB per-file limit) and expert streaming reads tensors by byte offset from a single file, so it needs `llama-gguf-split --merge` on a PC first. Merging on the phone would want ~120 GB free. The row carries the recipe; once the merged file reaches the device it is recognized like any other model.

Arbitrary Hugging Face URLs and the file picker stay, under "Other model".

**Downloads survive the app.** Tracked by filename and seeded from `DownloadManager.activeDownloads` instead of a remembered id, so an 18 GB transfer started before the process died is picked back up in the UI rather than running unseen.

**Model scan dedupes by filename**, first hit wins — `scanDirs` order becomes a precedence list (internal dir, where O_DIRECT works, before the emulated ones). The same gguf imported *and* adb-pushed used to show twice.

**`/data/local/tmp/shardllm` → `/data/local/tmp/bmoe`.** Plain rename: the constant, the three benchmark script defaults (all already `${VAR:-default}`), the comments and the README. `docs/bench-data/**` keeps the old path — those headers record where the runs actually read their model from; rewriting them would falsify the measurement record.

Existing devices keep their models: `adb shell mv /data/local/tmp/shardllm /data/local/tmp/bmoe`.

## Notes

- No new permissions. The catalog uses the same app-specific external dir the URL downloader already used.
- Nothing model-specific reaches the engine — the catalog is UI convenience; architectures are still discovered at runtime.
- Both HF URLs verified against the HF API: single-file, sizes as listed above.
- Version bumped to 0.8.0 (versionCode 10).

## Test

`assembleDevDebug` + `assemblePlayDebug` both compile. On-device verification of the catalog rows, a real download surviving a process kill, and the free-space guard still owed before the release is promoted.