### PR TITLE
fix(core): strip reasoning from chat answers (#49)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ if(BMOE_HAVE_LLAMA)
         src/moe/expert_stream_source.cpp
         src/moe/router_hook.cpp
         src/engine/session.cpp
+        src/engine/chat_parse.cpp
         src/engine/runtime.cpp
         src/metrics/csv_metrics_sink.cpp
         src/metrics/route_trace_sink.cpp

--- a/core/src/engine/chat_parse.cpp
+++ b/core/src/engine/chat_parse.cpp
@@ -1,0 +1,23 @@
+#include "chat_parse.h"
+
+#include <cstdio>
+#include <mutex>
+
+namespace bmoe::detail {
+
+common_chat_parser_params build_parse_params(const common_chat_params & cp) {
+    common_chat_parser_params pp(cp);
+    // The converting constructor drops the grammar; load it so the parser can actually match.
+    pp.parser.load(cp.parser);
+    pp.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    return pp;
+}
+
+void warn_parse_failed_once(const char * what) {
+    static std::once_flag flag;
+    std::call_once(flag, [what] {
+        std::fprintf(stderr, "bmoe: reasoning parse failed (%s); showing raw model output\n", what ? what : "unknown");
+    });
+}
+
+} // namespace bmoe::detail

--- a/core/src/engine/chat_parse.h
+++ b/core/src/engine/chat_parse.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Wiring for llama.cpp's reasoning parser. Kept separate from session.cpp so the seam that
+// was silently broken (issue #49) is unit-testable without a model or a live session.
+//
+// Internal header: includes llama.cpp's `common` (not the stable public API), so it must not
+// be pulled into core/include/bmoe/. See docs/seam.md.
+
+#include "chat.h"
+
+#include <string>
+
+namespace bmoe::detail {
+
+// Build reasoning-parser params from an applied chat template.
+//
+// The `common_chat_parser_params(const common_chat_params &)` convenience constructor copies
+// only `format` and `generation_prompt` (chat.h) — it leaves the PEG `parser` arena empty, so
+// `common_chat_parse` throws on the first token and reasoning markers leak into the answer.
+// The serialized grammar has to be loaded explicitly (this is what the upstream server does).
+common_chat_parser_params build_parse_params(const common_chat_params & cp);
+
+// Warn exactly once that reasoning parsing failed and the raw stream is being shown instead.
+// Returning the raw text is the right degradation, but doing it silently is how #49 stayed
+// invisible; the next wiring regression should be noticed.
+void warn_parse_failed_once(const char * what);
+
+} // namespace bmoe::detail

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -2,6 +2,7 @@
 #include "bmoe/recipe.h"
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
+#include "chat_parse.h"
 #include "../moe/router_hook.h"
 #include "../moe/expert_stream_source.h"
 #include "../moe/gguf_offsets.h"
@@ -522,10 +523,13 @@ RunResult Session::generate(const GenerateRequest & req,
             inputs.add_generation_prompt = true;
             inputs.use_jinja = true;
             inputs.enable_thinking = req.think;
+            // AUTO is what bakes reasoning-stripping into the generated parser grammar. It is set
+            // here, before apply — the field defaults to NONE, which produces a content-only
+            // grammar that leaves <think> markers in the answer no matter how the parse is wired.
+            inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
             common_chat_params cp = common_chat_templates_apply(im.chat_tmpls.get(), inputs);
             prompt = cp.prompt;
-            parse_params = common_chat_parser_params(cp);
-            parse_params.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+            parse_params = detail::build_parse_params(cp);
 
             // gpt-oss / harmony ignores enable_thinking: its template always opens an
             // <|channel|>analysis turn (only the "Reasoning:" effort level is tunable), so a
@@ -577,7 +581,8 @@ RunResult Session::generate(const GenerateRequest & req,
         if (forced_final) return raw;
         try {
             return common_chat_parse(raw, partial, parse_params).content;
-        } catch (const std::exception &) {
+        } catch (const std::exception & e) {
+            detail::warn_parse_failed_once(e.what());
             return raw;
         }
     };
@@ -858,7 +863,8 @@ RunResult Session::generate(const GenerateRequest & req,
         } else {
             try {
                 assistant = common_chat_parse(gen, /*is_partial*/ false, parse_params);
-            } catch (const std::exception &) {
+            } catch (const std::exception & e) {
+                detail::warn_parse_failed_once(e.what());
                 assistant.content = gen;
             }
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,15 @@
 add_executable(bmoe_moe_gates moe_gates.cpp)
 target_link_libraries(bmoe_moe_gates PRIVATE bmoe_core)
 
+# Reasoning-parser wiring regression (issue #49). Needs no model — it drives the extracted
+# bmoe::detail::build_parse_params directly — so it runs unconditionally, unlike the gates below.
+add_executable(bmoe_chat_parse_test chat_parse_test.cpp)
+target_link_libraries(bmoe_chat_parse_test PRIVATE bmoe_core)
+target_include_directories(bmoe_chat_parse_test PRIVATE ${CMAKE_SOURCE_DIR}/core/src/engine)
+target_compile_definitions(bmoe_chat_parse_test PRIVATE
+    BMOE_QWEN3_TEMPLATE_PATH="${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates/Qwen3.5-4B.jinja")
+add_test(NAME chat_parse COMMAND bmoe_chat_parse_test)
+
 find_program(PYTHON3 NAMES python3 python)
 
 if(PYTHON3)

--- a/tests/chat_parse_test.cpp
+++ b/tests/chat_parse_test.cpp
@@ -1,0 +1,157 @@
+// Regression test for the reasoning-parser wiring (issue #49).
+//
+// The bug: session.cpp built parse params with `common_chat_parser_params(cp)`, whose
+// convenience constructor copies only format/generation_prompt and leaves the PEG grammar
+// arena empty. `common_chat_parse` then throws on the first token, a catch swallows it, and
+// the raw stream — reasoning markers and all — is shown verbatim. The fix loads the grammar
+// (`parser.load(cp.parser)`), extracted into bmoe::detail::build_parse_params.
+//
+// This exercises that exact function against a Qwen3-style template, with no model: the whole
+// point is that the wiring is testable without a gguf. Assertions are explicit (not <cassert>)
+// because the Release gates build with NDEBUG, which would compile assert() out.
+
+#include "chat_parse.h"
+
+#include "chat.h"
+#include "common.h"
+
+#include <cstdio>
+#include <exception>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// A real Qwen3 chat template, read from the vendored submodule at test time (the path is injected
+// by CMake). It is detected as a tag-based reasoning format — the exact template upstream's own
+// reasoning tests exercise (tests/test-chat.cpp, message_assist_thoughts). A hand-rolled stub does
+// not reliably trip the differential analyzer, so the test uses the genuine file; if a submodule
+// bump removes or moves it, the test fails loudly rather than rotting.
+//
+// This template PREFILLS "<think>\n" into the thinking-enabled generation prompt, so a model's
+// stream begins with the reasoning text and closes it with "</think>" — hence the input below has
+// no leading "<think>". common_chat_parse prepends the generation prompt before matching, so the
+// prefilled opener is accounted for and the reasoning span is stripped from the shown content.
+#ifndef BMOE_QWEN3_TEMPLATE_PATH
+#error "BMOE_QWEN3_TEMPLATE_PATH must be defined by the build (path to the vendored Qwen3 .jinja)"
+#endif
+
+static int failures = 0;
+
+static std::string read_file(const char * path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        std::printf("[FAIL] cannot open template: %s\n", path);
+        ++failures;
+        return {};
+    }
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+static void expect_eq(const char * name, const std::string & got, const std::string & want) {
+    if (got == want) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n  got:  \"%s\"\n  want: \"%s\"\n", name, got.c_str(), want.c_str());
+        ++failures;
+    }
+}
+
+static std::string rstrip(std::string s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' ' || s.back() == '\t')) {
+        s.pop_back();
+    }
+    return s;
+}
+
+static void expect_true(const char * name, bool cond) {
+    if (cond) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+// Render a one-turn conversation and return the applied chat params (prompt + serialized grammar).
+static common_chat_params apply_template(bool enable_thinking) {
+    static const std::string tmpl = read_file(BMOE_QWEN3_TEMPLATE_PATH);
+    auto tmpls = common_chat_templates_init(/*model=*/nullptr, tmpl);
+
+    common_chat_msg user;
+    user.role = "user";
+    user.content = "hi";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = {user};
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
+    inputs.enable_thinking = enable_thinking;
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+
+    return common_chat_templates_apply(tmpls.get(), inputs);
+}
+
+int main() {
+    // The reasoning stream: the template prefills the opening "<think>\n", so the model emits the
+    // reasoning text, closes it with "</think>", then the answer. Mirrors message_assist_thoughts
+    // in tests/test-chat.cpp.
+    const std::string raw = "I'm\nthinking\n</think>\n\nHello, world!\nWhat's up?";
+    const std::string want_content = "Hello, world!\nWhat's up?";
+    const std::string want_reasoning = "I'm\nthinking";
+
+    common_chat_params cp = apply_template(/*enable_thinking=*/true);
+
+    // The template must be detected as a tag-based reasoning format, or the test proves nothing.
+    expect_true("template yields a non-empty parser grammar", !cp.parser.empty());
+
+    // Positive: the production wiring loads the grammar and strips the reasoning block.
+    common_chat_parser_params good = bmoe::detail::build_parse_params(cp);
+    common_chat_msg parsed;
+    bool threw = false;
+    try {
+        parsed = common_chat_parse(raw, /*is_partial=*/false, good);
+    } catch (const std::exception & e) {
+        threw = true;
+        std::printf("  build_parse_params path threw: %s\n", e.what());
+    }
+    expect_true("build_parse_params: parse does not throw", !threw);
+    expect_eq("build_parse_params: reasoning stripped from content", parsed.content, want_content);
+    // The parser preserves the reasoning span verbatim (a trailing newline before </think> may
+    // survive); the answer being clean is the contract, so compare the reasoning trimmed.
+    expect_eq("build_parse_params: reasoning captured", rstrip(parsed.reasoning_content), want_reasoning);
+
+    // Negative control: the pre-fix wiring (convenience ctor, no parser.load) must NOT correctly
+    // strip — whether it throws or returns the raw stream, it must not yield the clean answer.
+    // This pins bug #49 so a future submodule bump that silently changes the behaviour is noticed.
+    common_chat_parser_params unloaded(cp);
+    unloaded.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    bool unloaded_stripped = false;
+    try {
+        unloaded_stripped = common_chat_parse(raw, /*is_partial=*/false, unloaded).content == want_content;
+    } catch (const std::exception &) {
+        unloaded_stripped = false;
+    }
+    expect_true("empty-arena ctor does not strip reasoning (the #49 bug)", !unloaded_stripped);
+
+    // Partial parse (the streaming path): mid-reasoning, before "</think>", the answer is not yet
+    // available and no reasoning must leak into the shown content.
+    bool partial_threw = false;
+    std::string partial_content;
+    try {
+        partial_content = common_chat_parse("I'm\nthink", /*is_partial=*/true, good).content;
+    } catch (const std::exception &) {
+        partial_threw = true;
+    }
+    expect_true("partial parse mid-reasoning does not throw", !partial_threw);
+    expect_true("partial parse leaks no reasoning into content", partial_content.empty());
+
+    if (failures == 0) {
+        std::printf("all chat-parse checks passed\n");
+        return 0;
+    }
+    std::printf("%d chat-parse check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Fixes #49.

## Problem

In the Android app the assistant answer showed raw reasoning markers (`<think>`…`</think>` on Qwen, the thought block on Gemma). gpt-oss looked clean only by accident — `--no-think` primes the harmony final channel and returns the raw stream by design, so its parser is never exercised.

## Root cause — two independent gaps

The issue identified one; verifying end-to-end on host surfaced a second, which is why the raw stream leaked rather than a parse simply throwing.

1. **`reasoning_format` was never set to AUTO before `common_chat_templates_apply`.** The field on `common_chat_templates_inputs` defaults to `NONE`, which bakes a *content-only* parser grammar that never strips a reasoning span. Stripping is decided at grammar-build time (apply), not at parse time — so `parse_params.reasoning_format = AUTO` alone (what the code did) was a no-op.
2. **The parser arena was never loaded.** Params were built with the `common_chat_parser_params(cp)` convenience constructor, which copies only `format`/`generation_prompt` and leaves the PEG grammar arena empty. `common_chat_parse` threw on the first token; a bare `catch` returned the raw stream verbatim.

Both are needed: (1) makes the grammar strip, (2) lets `common_chat_parse` actually run it.

## Fix

- Set `inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO` before apply (`session.cpp`).
- Load the serialized grammar into the arena, extracted into `bmoe::detail::build_parse_params` (`core/src/engine/chat_parse.{h,cpp}`) so the seam is unit-testable without a model.
- The two swallowing catches (`shown_text` and the history-commit path) now warn **once** to stderr instead of silently passing the raw stream through — a silent passthrough is how this stayed invisible.

## Test

`tests/chat_parse_test.cpp` — a model-free host gate registered in ctest (no gguf, runs unconditionally). It drives `build_parse_params` against the vendored Qwen3.5 template, asserts the reasoning is stripped from the shown content and captured separately, and pins the pre-fix wiring (empty arena) as a **negative control** so a future submodule bump that changes the behaviour is noticed.

## Verification (local — CI Actions is billing-blocked)

- `clang-format` 18.1.8 clean on all changed C++ files.
- Full `ctest -C Release`: **5/5 pass** — `chat_parse` + the byte-identity gates (`moe_gates_qwen3moe`, `moe_gates_gemma4`) for both archs. Streamed == resident unchanged.
- Owed: on-device spot-check with Qwen3 (thinking on → no `<think>` in the answer) and gpt-oss thinking-on (exercises the parser, unlike the `--no-think` default).

