### PR TITLE
feat(core): opt-in sampling (temperature, top-p, top-k, seed) (#51)

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -326,6 +326,13 @@ static void print_usage(const char * argv0) {
         "      --n-expert-used N   override active MoE experts per token (top-k); lower = faster\n"
         "                          but changes the output (quality). 0 = model default\n"
         "\n"
+        "  Sampling (default: greedy/argmax, deterministic):\n"
+        "      --temp F            sampling temperature; <= 0 keeps greedy (default 0). > 0 enables\n"
+        "                          the chain top-k -> top-p -> temp -> dist\n"
+        "      --top-k N           top-k cutoff when sampling (0 disables the stage; default 40)\n"
+        "      --top-p F           nucleus cutoff in (0,1] when sampling (default 0.95)\n"
+        "      --seed N            RNG seed for sampling (default: random per run)\n"
+        "\n"
         "  MoE expert streaming:\n"
         "      --moe-stream        stream only the routed experts per token (MoE models)\n"
         "      --cache-mb N|auto   LRU expert cache budget in MiB (0=off, or >=%d); auto=size to device\n"
@@ -377,6 +384,14 @@ int main(int argc, char ** argv) {
             cfg.n_ctx = std::atoi(next("-c"));
         else if (a == "--n-expert-used")
             cfg.n_expert_used = std::atoi(next("--n-expert-used"));
+        else if (a == "--temp")
+            cfg.sampling.temp = (float) std::atof(next("--temp"));
+        else if (a == "--top-k")
+            cfg.sampling.top_k = std::atoi(next("--top-k"));
+        else if (a == "--top-p")
+            cfg.sampling.top_p = (float) std::atof(next("--top-p"));
+        else if (a == "--seed")
+            cfg.sampling.seed = (uint32_t) std::strtoul(next("--seed"), nullptr, 10);
         else if (a == "--chatml")
             cfg.chatml = true;
         else if (a == "--no-think")

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -9,9 +9,21 @@
 // without the native backend.
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace bmoe {
+
+// Token sampling. temp <= 0 (the default) selects greedy argmax — the deterministic path the
+// byte-identity gates depend on, and today's behaviour for any caller that sets nothing. temp > 0
+// builds the standard chain top_k -> top_p -> temp -> dist. Opt-in by construction: sampling never
+// perturbs a run that did not ask for it, so the gates stay meaningful.
+struct SamplingConfig {
+    float temp = 0.0f;           // <= 0: greedy (argmax). > 0: stochastic sampling.
+    int top_k = 40;              // 0 disables the top-k stage (llama.cpp convention)
+    float top_p = 0.95f;         // nucleus cutoff, in (0, 1]
+    uint32_t seed = 0xFFFFFFFFu; // == LLAMA_DEFAULT_SEED (random per run); static_assert'd in session.cpp
+};
 
 // How the dense (non-expert) model weights are kept resident. See MoeStreamConfig::dense_weights and
 // core/src/moe/dense_weights.h. Ordered cheapest-effort first.
@@ -115,6 +127,7 @@ struct RunConfig {
     // expert_used_count metadata key; must stay in [1, n_expert]. Independent of streaming.
     int n_expert_used = 0;
 
+    SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
 };
 

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -40,6 +40,7 @@ struct SessionConfig {
     // Active-expert (top-k) override applied at load via a kv_override on the arch-prefixed
     // expert_used_count key. 0 = use the model's own count. See RunConfig::n_expert_used.
     int n_expert_used = 0;
+    SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
 };
 

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -31,6 +31,18 @@ ValidationResult validate(const RunConfig & cfg) {
         return fail("n_expert_used must be >= 0 (0 = model default)");
     }
 
+    // Sampling ranges are enforced only when sampling is actually on (temp > 0). With temp <= 0
+    // the engine takes the argmax path and the other knobs are inert, so a caller that leaves them
+    // at any value still describes a valid greedy run — today's default stays valid untouched.
+    if (cfg.sampling.temp > 0.0f) {
+        if (cfg.sampling.top_k < 0) {
+            return fail("sampling.top_k must be >= 0 (0 disables the top-k stage)");
+        }
+        if (cfg.sampling.top_p <= 0.0f || cfg.sampling.top_p > 1.0f) {
+            return fail("sampling.top_p must be in (0, 1]");
+        }
+    }
+
     // overlap is meaningless without streaming (it gates the streamer's own reads). The
     // hook-availability check is deferred to run(): validate() stays pure (no native).
     if (cfg.moe.overlap && !cfg.moe.enabled) {

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -14,6 +14,7 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
     sc.chatml = cfg.chatml;
     sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
+    sc.sampling = cfg.sampling;           // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
     return sc;
 }

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -103,6 +103,10 @@ struct Session::Impl {
     common_chat_templates_ptr chat_tmpls;
     bool backend_inited = false;
 
+    // Sampling chain, built once at open() only when sampling is requested (temp > 0); null on the
+    // greedy default, where the decode loop stays on the argmax fast path. See open()/generate().
+    llama_sampler * smpl = nullptr;
+
     // Multi-turn chat state (chat mode only). chat_history is the running conversation the
     // template is re-rendered over each turn; kv_tokens mirrors the tokens currently decoded
     // into the context's KV (seq 0), in order, so the next turn can reuse the common prefix
@@ -139,6 +143,7 @@ struct Session::Impl {
         // buffers back the rebound expert tensors), then the context (its eval callback points
         // at the hook), then the hook, then unmap the model, then release the backend.
         source.shutdown();
+        if (smpl) llama_sampler_free(smpl); // independent of ctx/model; free before them
         ctx.reset();
         hook.reset();
         model.reset();
@@ -283,6 +288,19 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     if (!ctx) return fail("failed to create context");
     im.ctx.reset(ctx);
     llama_set_n_threads(ctx, cfg.n_threads, cfg.n_threads);
+
+    // Opt-in sampling. temp <= 0 leaves smpl null and the decode loop on argmax — the deterministic
+    // default the byte-identity gates rely on. temp > 0 builds the standard chain, using only the
+    // public llama_sampler_* API (hard rule 1): common_sampler lives in the non-stable common layer.
+    static_assert(SamplingConfig{}.seed == LLAMA_DEFAULT_SEED,
+                  "SamplingConfig::seed default must mirror LLAMA_DEFAULT_SEED");
+    if (cfg.sampling.temp > 0.0f) {
+        im.smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
+        llama_sampler_chain_add(im.smpl, llama_sampler_init_top_k(cfg.sampling.top_k));
+        llama_sampler_chain_add(im.smpl, llama_sampler_init_top_p(cfg.sampling.top_p, /*min_keep*/ 1));
+        llama_sampler_chain_add(im.smpl, llama_sampler_init_temp(cfg.sampling.temp));
+        llama_sampler_chain_add(im.smpl, llama_sampler_init_dist(cfg.sampling.seed));
+    }
 
     // One abort callback for the session's whole life, checking two independent predicates:
     // an explicit cancel() request (any mode) and a fatal streaming I/O error (overlap only).
@@ -499,6 +517,10 @@ RunResult Session::generate(const GenerateRequest & req,
         llama_memory_clear(llama_get_memory(ctx), true);
         im.chat_history.clear();
         im.kv_tokens.clear();
+        // A new chat resets the sampler RNG, so a fixed seed reproduces the same transcript from a
+        // fresh conversation. A continued turn (clear_kv=false) keeps the stream going, matching the
+        // KV it decodes against.
+        if (im.smpl) llama_sampler_reset(im.smpl);
     }
 
     // Format the prompt. With chat on, render the model's OWN chat template (real Jinja) over the
@@ -709,7 +731,10 @@ RunResult Session::generate(const GenerateRequest & req,
     double gen_cpu_seconds = 0.0;
 
     for (int t = 0; t < req.n_predict; ++t) {
-        llama_token tok = argmax(logits, im.n_vocab);
+        // Greedy stays argmax (byte-identical to the resident reference the gates check); with a
+        // sampling chain, draw from the context's last-position logits, which llama_sampler_sample
+        // reads at index -1 — the same logits argmax would have read.
+        llama_token tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, -1) : argmax(logits, im.n_vocab);
         if (llama_vocab_is_eog(im.vocab, tok)) break;
 
         char piece[256];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@
 add_executable(bmoe_moe_gates moe_gates.cpp)
 target_link_libraries(bmoe_moe_gates PRIVATE bmoe_core)
 
+# validate() unit tests (issue #51 + the pre-existing rules). Pure config, no model — runs
+# unconditionally, and makes good on config.h's "unit-tested" claim.
+add_executable(bmoe_config_test config_test.cpp)
+target_link_libraries(bmoe_config_test PRIVATE bmoe_core)
+add_test(NAME config_validate COMMAND bmoe_config_test)
+
 find_program(PYTHON3 NAMES python3 python)
 
 if(PYTHON3)

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -1,0 +1,152 @@
+// Unit tests for validate() (core/src/config.cpp) — the pure config-consistency gate.
+//
+// config.h has long advertised validate() as "unit-tested without the native backend"; this is
+// that test. It needs no model and no llama.cpp, so it runs unconditionally in ctest. It covers the
+// pre-existing rules and the opt-in sampling ranges added in #51.
+//
+// Checks are explicit (not <cassert>): the Release build defines NDEBUG, which compiles assert out.
+
+#include "bmoe/config.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace bmoe;
+
+static int failures = 0;
+
+// A config that passes validate(): the minimum is a model path. Streaming off, greedy sampling.
+static RunConfig ok_base() {
+    RunConfig c;
+    c.model_path = "model.gguf";
+    return c;
+}
+
+// A config with MoE streaming on, otherwise valid — the base for the streaming-rule cases.
+static RunConfig ok_moe() {
+    RunConfig c = ok_base();
+    c.moe.enabled = true;
+    return c;
+}
+
+static void expect_ok(const char * name, const RunConfig & c) {
+    ValidationResult r = validate(c);
+    if (r.ok) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n  expected ok, got error: %s\n", name, r.error.c_str());
+        ++failures;
+    }
+}
+
+static void expect_fail(const char * name, const RunConfig & c) {
+    ValidationResult r = validate(c);
+    if (!r.ok) {
+        std::printf("[PASS] %s (rejected: %s)\n", name, r.error.c_str());
+    } else {
+        std::printf("[FAIL] %s\n  expected rejection, got ok\n", name);
+        ++failures;
+    }
+}
+
+int main() {
+    // Baseline and the pre-existing scalar rules.
+    expect_ok("valid minimal config", ok_base());
+    {
+        RunConfig c = ok_base();
+        c.model_path.clear();
+        expect_fail("empty model_path", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.n_predict = 0;
+        expect_fail("n_predict must be positive", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.n_threads = 0;
+        expect_fail("n_threads must be positive", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.n_ctx = -1;
+        expect_fail("n_ctx must be positive", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.n_expert_used = -1;
+        expect_fail("n_expert_used must be >= 0", c);
+    }
+
+    // Streaming rules.
+    {
+        RunConfig c = ok_base();
+        c.moe.overlap = true; // enabled stays false
+        expect_fail("overlap requires streaming", c);
+    }
+    expect_ok("streaming, cache off", ok_moe());
+    {
+        RunConfig c = ok_moe();
+        c.moe.io_threads = MoeStreamConfig::io_threads_max + 1;
+        expect_fail("io_threads out of range", c);
+    }
+    {
+        RunConfig c = ok_moe();
+        c.moe.cache_mb = MoeStreamConfig::cache_min_mb - 1; // pathological band
+        expect_fail("cache_mb in pathological band", c);
+        c.moe.force_cache = true;
+        expect_ok("cache_mb in band allowed with force_cache", c);
+    }
+    {
+        RunConfig c = ok_moe();
+        c.moe.cache_auto = true;
+        c.moe.cache_mb = 2048; // both set
+        expect_fail("cache_auto and explicit cache_mb are mutually exclusive", c);
+    }
+    {
+        RunConfig c = ok_moe();
+        c.moe.prefetch_layers = 2; // cache off
+        expect_fail("prefetch requires the cache", c);
+        c.moe.cache_mb = MoeStreamConfig::cache_min_mb;
+        expect_ok("prefetch allowed with the cache on", c);
+    }
+
+    // Sampling ranges — enforced only when temp > 0.
+    {
+        RunConfig c = ok_base();
+        c.sampling.temp = 0.8f;
+        c.sampling.top_k = 40;
+        c.sampling.top_p = 0.95f;
+        expect_ok("valid sampling config", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.sampling.temp = 0.8f;
+        c.sampling.top_p = 0.0f;
+        expect_fail("top_p must be > 0 when sampling", c);
+        c.sampling.top_p = 1.5f;
+        expect_fail("top_p must be <= 1 when sampling", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.sampling.temp = 0.8f;
+        c.sampling.top_k = -1;
+        expect_fail("top_k must be >= 0 when sampling", c);
+    }
+    {
+        // With greedy (temp <= 0) the other knobs are inert, so out-of-range values are still a
+        // valid greedy run — the default path must never be rejected on account of sampling fields.
+        RunConfig c = ok_base();
+        c.sampling.temp = 0.0f;
+        c.sampling.top_p = 5.0f;
+        c.sampling.top_k = -3;
+        expect_ok("out-of-range sampling knobs are inert under greedy", c);
+    }
+
+    if (failures == 0) {
+        std::printf("all config checks passed\n");
+        return 0;
+    }
+    std::printf("%d config check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Fixes #51.

## What

Generation was greedy-only: `argmax()` always took the highest-logit token and `RunConfig` carried no sampling knobs. This exposes the standard llama.cpp sampling parameters through the existing config seam, **opt-in**, with greedy staying the default.

## Why greedy stays the default

Greedy decoding is what makes a run reproducible, and `bmoe_moe_gates` depends on it (streamed output must be byte-identical to resident). So `temp <= 0` selects the current `argmax` path verbatim and is the default — a caller that passes nothing sees today's behaviour, and the gates keep passing untouched.

## How

- `SamplingConfig` (`temp`, `top_k`, `top_p`, `seed`) added to `RunConfig` and `SessionConfig`; `config.h` stays llama-free.
- `temp > 0` builds a per-session chain `top_k → top_p → temp → dist` using **only the public `llama_sampler_*` API** — `common_sampler` lives in the non-stable `common` layer, avoided per hard rule 1. Built at `open()`, freed in `~Impl`, RNG reset on `clear_kv` so a fixed seed reproduces a fresh chat.
- The `seed` default is pinned to `LLAMA_DEFAULT_SEED` via a `static_assert`, so the llama-free header can't drift from the backend constant.
- `validate()` enforces sampling ranges only when `temp > 0` (the knobs are inert under greedy, so old configs stay valid).
- CLI flags `--temp`, `--top-k`, `--top-p`, `--seed` in `main.cpp` (the only place env overrides are read). Android app knobs are left to a separate change, as the issue asks.

## Test

`tests/config_test.cpp` — pure `validate()` unit tests (no model, runs unconditionally in ctest), covering the pre-existing rules **and** the new sampling ranges. This also makes good on the long-standing "validate() is unit-tested" claim in `config.h`, which previously had no test.

## Verification (local — CI Actions is billing-blocked)

- `clang-format` 18.1.8 clean on all changed C++ files.
- Full `ctest -C Release`: **5/5 pass** — `config_validate` + the byte-identity gates for both archs (`moe_gates_qwen3moe`, `moe_gates_gemma4`). The default greedy path is byte-identical, so the gates are the regression proof.
- CLI smoke test on the tiny model: greedy reproducible; `--temp 0.8 --seed 42` reproducible and different from greedy; `--temp 1.2` (no seed) differs across runs.

