### PR TITLE
fix(app): correct the metrics glossary and three telemetry miscounts (#50)

### DIFF
--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -9,7 +9,7 @@ import android.content.Context
  */
 enum class DenseWeights(val flag: String, val label: String, val blurb: String) {
     MMAP("mmap", "Mmap (baseline)", "Leave the dense weights mmap'd; the kernel faults them in. Slow first tokens on a >RAM model — the A/B baseline."),
-    WARM("warm", "Warm at load", "Page-cache the dense weights once at load, so the first tokens don't fault them in 4 KiB at a time. Best when the model fits in RAM."),
+    WARM("warm", "Warm at load", "Page-cache the dense weights once at load, so the first tokens don't fault them in a page at a time. Best when the model fits in RAM."),
     ANON("anon", "Anon (O_DIRECT)", "Read the dense weights via O_DIRECT into our own buffers so a reclaim swaps to zram (fast) instead of a slow flash refault. Costs a private copy. The default — it wins on >RAM models."),
 }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -303,7 +303,7 @@ private fun MainScreen(
                         }
                     }
 
-                    TelemetryCard(ui, settings.threads)
+                    TelemetryCard(ui, settings.threads, settings.overlap, settings.ioThreads)
                 }
             }
 
@@ -673,7 +673,7 @@ private fun DownloadProgress(
 }
 
 @Composable
-private fun TelemetryCard(ui: UiState, threads: Int) {
+private fun TelemetryCard(ui: UiState, threads: Int, overlap: Boolean, ioThreads: Int) {
     ElevatedCard(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             if (ui.error != null) {
@@ -707,17 +707,26 @@ private fun TelemetryCard(ui: UiState, threads: Int) {
                 // Once done, show the per-token AVERAGE split; while generating, the live last token.
                 val useAvg = done && t.avgComputeMs >= 0
                 val suffix = if (useAvg) " avg" else ""
-                // The wall-additive breakdown: by the engine's own definition compute = wall − flash-wait
-                // − mgmt, so these three SUM to the token's wall time. That makes tok/s = 1000 / wall
-                // directly readable off the bars, instead of asking the user to reconcile a compute
-                // residual with a parallel (overlapped) flash-I/O figure that isn't a wall component.
-                val compute = if (useAvg) t.avgComputeMs else t.computeMs
+                // The wall-additive breakdown: compute + flash-wait + mgmt SUM to the token's wall time,
+                // so tok/s = 1000 / wall is readable straight off the bars.
                 val mgmt = if (useAvg) t.avgMgmtMs.coerceAtLeast(0.0) else t.mgmtMs
                 val wall = if (useAvg) (if (t.avgTokensPerSecond > 0) 1000.0 / t.avgTokensPerSecond else 0.0)
                            else t.wallMs
-                // Flash wait = wall not spent computing or bookkeeping: the read time overlap couldn't
-                // hide (a stall under --overlap, the whole blocking read in serial mode).
-                val flashWait = (wall - compute - mgmt).coerceAtLeast(0.0)
+                // Flash wait is the MEASURED wall-additive read term — stall_ms under overlap (the wall
+                // time compute sat idle), io_ms in serial (the blocking read) — and compute is the
+                // leftover. Deriving it this way keeps the clamp on compute (a near-0 compute is honest)
+                // instead of the old wall−compute−mgmt, which silently dumped a clamped-to-0 compute into
+                // "flash wait". The end-of-run average has no per-mode io/stall to read, so it keeps the
+                // residual form.
+                val flashWait: Double
+                val compute: Double
+                if (useAvg) {
+                    compute = t.avgComputeMs
+                    flashWait = (wall - compute - mgmt).coerceAtLeast(0.0)
+                } else {
+                    flashWait = if (overlap) t.stallMs else t.ioMs
+                    compute = (wall - flashWait - mgmt).coerceAtLeast(0.0)
+                }
                 val total = if (wall > 0.0) wall else (compute + flashWait + mgmt)
 
                 // Headline: token time and its inverse, so no mental arithmetic to get tok/s.
@@ -730,16 +739,19 @@ private fun TelemetryCard(ui: UiState, threads: Int) {
                 MeterRow("cache mgmt$suffix", mgmt, total, MaterialTheme.colorScheme.secondary)
 
                 // Diagnostic line: WHY compute is what it is, plus cache hit. CPU occupancy = CPU-time ÷
-                // (wall × threads); near 100% is genuinely compute-bound, well below means a throttled/
-                // preempted core (a frequency cap, a co-resident process). Major faults/token > 0 means
-                // dense weights re-faulted from flash inside the decode. Both 0 ⇒ engine couldn't measure.
+                // (wall × busy threads); near 100% is genuinely compute-bound, well below means a
+                // throttled/preempted core (a frequency cap, a co-resident process). The CPU numerator is
+                // whole-process, so under overlap the I/O lanes count too — the denominator must include
+                // them, or occupancy reads above 100%. Major faults/token > 0 means dense weights
+                // re-faulted from flash inside the decode. Both 0 ⇒ engine couldn't measure.
+                val busyThreads = threads + if (overlap) ioThreads else 0
                 val useAvgCpu = useAvg && t.avgCpuSPerTok >= 0
                 val cpuSTok = if (useAvgCpu) t.avgCpuSPerTok else t.cpuMs / 1000.0
                 val faults = if (useAvgCpu) t.avgMajfltPerTok else t.majflt
                 val hit = if (t.cacheHitPct >= 0) String.format(Locale.US, "hit %.0f%%", t.cacheHitPct) else "hit —"
                 val diag = buildString {
-                    if (cpuSTok > 0.0 && wall > 0.0 && threads > 0) {
-                        append(String.format(Locale.US, "CPU %.0f%% busy", cpuSTok / (wall / 1000.0 * threads) * 100.0))
+                    if (cpuSTok > 0.0 && wall > 0.0 && busyThreads > 0) {
+                        append(String.format(Locale.US, "CPU %.0f%% busy", cpuSTok / (wall / 1000.0 * busyThreads) * 100.0))
                         if (faults >= 0.0) append(String.format(Locale.US, "  ·  %.0f faults/tok", faults))
                         append("  ·  ")
                     }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -22,23 +22,23 @@ object MetricFields {
         MetricField("steps", "tokens requested", "the n_predict target for the turn", Better.NEUTRAL),
 
         MetricField("wall_ms", "token time", "the whole time this token took — the one number measured directly; tok/s = 1000/wall_ms", Better.LOWER),
-        MetricField("compute_ms", "compute (a residual!)", "what is left after io/stall and mgmt are subtracted — NOT measured, so it also absorbs faults and scheduler stalls", Better.LOWER),
+        MetricField("compute_ms", "compute (a residual!)", "with streaming on, what is left after io/stall and mgmt are subtracted — NOT measured, so it also absorbs faults and scheduler stalls, and is clamped at 0. With streaming off it is just wall_ms", Better.LOWER),
         MetricField("io_ms", "flash read time", "time reading experts from flash. In serial it is part of wall_ms; under overlap it is per-lane busy time summed, so it can exceed wall_ms", Better.LOWER),
         MetricField("stall_ms", "wait on flash", "overlap only: the wall time compute actually sat idle waiting for a read (already divided per thread)", Better.LOWER),
-        MetricField("mgmt_ms", "cache bookkeeping", "time spent committing, evicting and reordering the LRU cache this token", Better.LOWER),
+        MetricField("mgmt_ms", "cache bookkeeping", "time committing, evicting and reordering the LRU cache this token — plus the periodic dense-residency probe, which the engine folds in here", Better.LOWER),
 
         MetricField("read_bytes", "flash read", "bytes of experts pulled from flash THIS token (not cumulative)", Better.LOWER),
-        MetricField("cache_hit_pct", "hit rate (cumulative!)", "share of expert lookups served from cache — averaged from the start of the session, so it moves slowly and is not a per-token value", Better.HIGHER),
+        MetricField("cache_hit_pct", "hit rate (cumulative!)", "share of expert lookups served from cache — averaged from the start of the session and INCLUDING prefill (which dominates early), so it moves slowly and is not a per-token value", Better.HIGHER),
 
         MetricField("majflt", "hard faults", "pages the kernel reclaimed and the decode had to re-read from flash mid-compute this token", Better.LOWER),
-        MetricField("majflt_mib", "faulted MiB", "the same faults as memory: majflt x 4 KiB. Compare directly to read_bytes — reads we chose vs reads the kernel forced", Better.LOWER),
+        MetricField("majflt_mib", "faulted MiB", "the same faults as memory: majflt × the kernel page size (4 KiB, or 16 KiB on large-page devices — resolved at runtime, not assumed). Compare directly to read_bytes — reads we chose vs reads the kernel forced", Better.LOWER),
         MetricField("cpu_ms", "CPU used", "CPU time across all threads. Compare to wall_ms x threads: near 100% is compute-bound, far below means throttled or stalled cores", Better.NEUTRAL),
 
         MetricField("cache_budget_mib", "cache budget", "the expert-cache size this run used. Fixed for the run (an explicit --cache-mb, or what auto sized to at load). Bigger buys hits but costs RAM", Better.NEUTRAL),
-        MetricField("dense_resident_frac", "dense weights still in RAM", "fraction of the DENSE (non-expert) weights still resident (mincore). Under 'anon' it samples our own buffers — is zram holding them? Under mmap/warm the mmap — is the kernel dropping the model? Read with majflt. -1 = not sampled", Better.HIGHER),
+        MetricField("dense_resident_frac", "dense weights still in RAM", "estimated fraction of the DENSE (non-expert) weights still resident — a 256-page mincore SAMPLE, not the exact fraction, refreshed every few tokens so most rows carry the last sample. Under 'anon' it samples our own buffers (is zram holding them?); under mmap/warm the mmap (is the kernel dropping the model?). Read with majflt. -1 only before the first sample, with streaming off, or when /proc is unreadable", Better.HIGHER),
 
-        MetricField("rss_anon_mib", "anon resident = the cache", "resident anonymous memory — where the expert cache lives. Falling while cache_budget holds = the kernel taking it", Better.NEUTRAL),
-        MetricField("rss_file_mib", "file resident = the model", "resident file-backed memory: the mmap'd weights. Dropped (not swapped) under pressure, so it never shows in swap", Better.NEUTRAL),
+        MetricField("rss_anon_mib", "anon resident", "resident anonymous memory: the expert cache and the KV/activation buffers — and, under the default 'anon' dense policy, the dense weights too. Falling while cache_budget holds = the kernel taking it", Better.NEUTRAL),
+        MetricField("rss_file_mib", "file resident", "resident file-backed memory: the mmap'd weights, dropped (not swapped) under pressure so it never shows in swap. But under the default 'anon' dense policy the dense weights are anonymous, not file-backed — then this is only what is left mmap'd, and rss_anon carries the model", Better.NEUTRAL),
         MetricField("swap_mib", "our memory in zram", "anonymous memory already compressed into swap — cache we have effectively lost", Better.LOWER),
         MetricField("rss_mib", "total resident", "everything resident (VmRSS)", Better.NEUTRAL),
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
@@ -45,10 +45,19 @@ internal class Csv(
         ).joinToString(" · ")
     }
 
-    /** This column's values, or null where the column is absent or the cell is not a number. */
+    /**
+     * This column's values, or null where the column is absent, the cell is not a number, or the
+     * cell is a documented "not sampled" sentinel. `cache_hit_pct` and `dense_resident_frac` write
+     * -1 when the engine had nothing to report (before the first sample, streaming off, /proc
+     * unreadable); that is missing data, not a measurement. Mapping it to null — rather than
+     * dropping the row — keeps every column index-aligned, so the compare view's min/mean/max and
+     * pearson() (which pairs by position) stop counting -1 as a real value. Genuine -1s in other
+     * columns are left untouched.
+     */
     fun column(name: String): List<Float?>? {
         val i = header.indexOf(name).takeIf { it >= 0 } ?: return null
-        return rows.map { it.getOrNull(i)?.toFloatOrNull() }
+        val sentinel = name in NOT_SAMPLED_MINUS_ONE
+        return rows.map { row -> row.getOrNull(i)?.toFloatOrNull()?.takeUnless { sentinel && it == -1f } }
     }
 
     /** Columns worth plotting: numeric, and not an axis or a label. */
@@ -56,6 +65,9 @@ internal class Csv(
         header.filter { it !in setOf("step", "steps", "turn") && column(it)?.any { v -> v != null } == true }
 
     companion object {
+        // Columns where -1 means "not sampled", not a value. See column().
+        private val NOT_SAMPLED_MINUS_ONE = setOf("cache_hit_pct", "dense_resident_frac")
+
         fun read(f: File): Csv {
             val lines = runCatching { f.readLines() }.getOrElse { emptyList() }
             val header = lines.firstOrNull { !it.startsWith("#") }?.split(",") ?: emptyList()

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -8,6 +8,12 @@ data class Telemetry(
     var steps: Int = 0,
     var wallMs: Double = 0.0,
     var computeMs: Double = 0.0,
+    // The measured, wall-additive flash term: io_ms in serial (the blocking read), stall_ms under
+    // overlap (the wall time compute sat idle on a read). The panel shows the one that matches the
+    // run's mode as "flash wait" instead of inverting the clamped compute residual, which mislabels
+    // the token when compute_ms was clamped to 0.
+    var ioMs: Double = 0.0,
+    var stallMs: Double = 0.0,
     // Cache-management time this token — the third wall-additive term. wall = compute + flash-wait +
     // mgmt exactly (the engine defines compute as that residual), so the panel can show a breakdown
     // that sums to the token time and makes tok/s = 1000/wall self-evident.
@@ -69,6 +75,8 @@ class TelemetryParser {
             current.steps = o.optInt("steps")
             current.wallMs = o.optDouble("wall_ms")
             current.computeMs = o.optDouble("compute_ms")
+            current.ioMs = o.optDouble("io_ms", 0.0)
+            current.stallMs = o.optDouble("stall_ms", 0.0)
             current.mgmtMs = o.optDouble("mgmt_ms", 0.0)
             current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
             current.majflt = o.optDouble("majflt", 0.0)


### PR DESCRIPTION
Fixes #50.

The glossary (`MetricFields.kt`) and the live panel described several quantities the engine does not compute. Each was checked against the computing site.

## Text corrections
- **`majflt_mib`** — `majflt × the runtime page size`, resolved via `sysconf(_SC_PAGESIZE)`, not a hardcoded 4 KiB (off by 4× on 16 KB-page devices). Same text in `AppSettings.kt`.
- **`dense_resident_frac`** — a 256-page mincore **sample** refreshed every few tokens, not the exact fraction; `-1` means "not sampled" only before the first sample / with streaming off / when `/proc` is unreadable, not on most rows (they carry the last sample).
- **`mgmt_ms`** — also folds in the dense-residency probe.
- **`compute_ms`** — is `wall_ms` with streaming off, and is clamped at 0.
- **`cache_hit_pct`** — includes prefill lookups, which dominate early.
- **`rss_anon_mib` / `rss_file_mib`** — under the default `anon` dense policy the dense weights are anonymous, not file-backed, so "anon = the cache / file = the model" inverts.

## Code fixes
1. **Flash wait** (`MainActivity`) — show the **measured** wall-additive read term (`stall_ms` under overlap, `io_ms` in serial) and derive compute as the leftover, so the clamp lands on compute (a near-0 compute is honest) instead of `wall − compute − mgmt` silently dumping a clamped-to-0 compute into "flash wait". Adds `io_ms`/`stall_ms` to the parsed telemetry (they were already in the `BMOE_PROGRESS` line). The end-of-run average has no per-mode io/stall, so it keeps the residual form.
2. **CPU occupancy** (`MainActivity`) — the CPU numerator is whole-process, so under overlap the I/O lanes must be in the denominator too (`threads + io lanes`), or occupancy reads above 100%.
3. **`MetricsCsv.column()`** — map the `-1` "not sampled" sentinel to `null` for `cache_hit_pct` and `dense_resident_frac`, so it stops dragging the compare view's min/mean/max and `pearson()` (both pair by index, so `null` preserves alignment). Genuine `-1`s in other columns are untouched.

## Verification (local — CI Actions is billing-blocked)
- `./gradlew :app:compileDevDebugKotlin` — compiles clean.
- Owed on-device: read every changed glossary string; a serial run and an overlap run → flash-wait ≈ io_ms / stall_ms respectively and CPU% ≤ ~100 under overlap; a cache-off run's `dense_resident_frac` correlate/compare view no longer poisoned by `-1`.

