### PR TITLE
chore(app): bump to 0.8.2 (versionCode 12)

### DIFF
--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 11
-        versionName '0.8.1'
+        versionCode 12
+        versionName '0.8.2'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.


### PR DESCRIPTION
Release bump for the six fixes merged into main:
- #49 reasoning parser (core)
- #51 opt-in sampling (core)
- #53 metrics scroll (app)
- #50 metrics glossary + telemetry miscounts (app)
- #52 delete on-device models (app)
- #47 telemetry clamp note (docs, issue closed as not planned)

versionCode 11→12, versionName 0.8.1→0.8.2. Tag v0.8.2 follows the merge.

