### PR TITLE
feat(trace): layer-granularity compute trace (--compute-trace-layers)

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -324,6 +324,13 @@ static void print_usage(const char * argv0) {
         "      --route-trace PATH  diagnostics: write the per-step per-layer MoE routing trace\n"
         "                          (which experts each layer routed, their weight, cache state).\n"
         "                          Needs --moe-stream; costs speed — not for benchmark runs\n"
+        "      --compute-trace PATH\n"
+        "                          diagnostics: isolate and time EVERY graph node (per-op detail,\n"
+        "                          major faults per node). Serializes the graph — proportions only\n"
+        "      --compute-trace-layers PATH\n"
+        "                          same trace at layer granularity: one barrier per layer, so\n"
+        "                          coalescing and the expert prefetch survive and the numbers stay\n"
+        "                          close to an untraced run. Rows aggregate per layer (op LAYER)\n"
         "      --n-expert-used N   override active MoE experts per token (top-k); lower = faster\n"
         "                          but changes the output (quality). 0 = model default\n"
         "\n"
@@ -407,7 +414,10 @@ int main(int argc, char ** argv) {
             route_trace_path = next("--route-trace");
         else if (a == "--compute-trace")
             compute_trace_path = next("--compute-trace");
-        else if (a == "--io-trace")
+        else if (a == "--compute-trace-layers") {
+            compute_trace_path = next("--compute-trace-layers");
+            cfg.compute_trace_layers = true;
+        } else if (a == "--io-trace")
             io_trace_path = next("--io-trace");
         else if (a == "--moe-stream")
             cfg.moe.enabled = true;

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -127,6 +127,13 @@ struct RunConfig {
     // expert_used_count metadata key; must stay in [1, n_expert]. Independent of streaming.
     int n_expert_used = 0;
 
+    // Compute-trace granularity. false (default): a barrier per graph node — exact per-op
+    // attribution, but it serializes the graph against the expert stream and distorts the run.
+    // true: a barrier only at layer boundaries, cheap enough that the traced numbers stay close
+    // to an untraced run. Only meaningful when a compute-trace sink is attached; see
+    // bmoe/decode_trace.h for what the layer-mode rows contain.
+    bool compute_trace_layers = false;
+
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
 };

--- a/core/include/bmoe/decode_trace.h
+++ b/core/include/bmoe/decode_trace.h
@@ -20,6 +20,15 @@
 // Both are diagnostics, not telemetry, and both perturb what they measure — isolating nodes
 // forbids ggml the operator coalescing it would otherwise do, and the I/O rows take a lock on the
 // read path. A traced run is NOT a benchmark run: read the proportions, not the absolutes.
+//
+//   Layer granularity — the compute trace can instead isolate only the FIRST node of each layer
+//   (RunConfig::compute_trace_layers). ~n_layer barriers per token instead of ~3000 preserves
+//   operator coalescing and, crucially, the async expert prefetch: the io lanes keep streaming
+//   across a boundary, so the numbers stay close to an untraced run. Rows carry op "LAYER" and
+//   aggregate everything since the previous boundary: name "blk.<il>" is layer il's segment,
+//   "pre" is the embedding lookup before layer 0, and "post" (emitted when the batch closes) is
+//   the last layer's tail plus the final norm and LM head — per-op detail inside a segment is
+//   what this mode trades away.
 #pragma once
 
 #include <cstdint>

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -40,6 +40,9 @@ struct SessionConfig {
     // Active-expert (top-k) override applied at load via a kv_override on the arch-prefixed
     // expert_used_count key. 0 = use the model's own count. See RunConfig::n_expert_used.
     int n_expert_used = 0;
+    // Compute-trace granularity: false = a barrier per graph node, true = per layer boundary.
+    // Only read when a compute-trace sink is attached. See RunConfig::compute_trace_layers.
+    bool compute_trace_layers = false;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
 };

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -14,7 +14,8 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
     sc.chatml = cfg.chatml;
     sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
-    sc.sampling = cfg.sampling;           // greedy by default; opt-in stochastic decoding
+    sc.compute_trace_layers = cfg.compute_trace_layers;
+    sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
     return sc;
 }

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -437,7 +437,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         st.overlap = cfg.moe.enabled && cfg.moe.overlap;
         if (compute_trace) {
             im.compute_trace = compute_trace;
-            im.hook->set_compute_trace(true);
+            im.hook->set_compute_trace(true, cfg.compute_trace_layers);
             compute_trace->on_static(st);
         }
         if (im.io_trace) im.io_trace->on_static(st);
@@ -667,6 +667,10 @@ RunResult Session::generate(const GenerateRequest & req,
         trace_step = base_pos + n_tokens - 1;
     };
     auto trace_flush = [&]() {
+        // Close the compute trace's dangling interval FIRST: at layer granularity the "post" row
+        // is charged the wall since the last boundary, and everything trace_flush does before the
+        // close would be billed to the LM head.
+        if (im.compute_trace) im.hook->end_compute_batch();
         if (im.route_trace) {
             im.hook->end_trace_batch();
             std::vector<RouteTraceRow> & rows = im.hook->trace_rows();

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -166,8 +166,9 @@ static int node_layer(const char * name) {
     return std::atoi(dash + 1);
 }
 
-void RouterHook::set_compute_trace(bool on) {
+void RouterHook::set_compute_trace(bool on, bool per_layer) {
     ctrace_on_ = on;
+    ctrace_layers_ = per_layer;
     compute_rows_.clear();
 }
 
@@ -176,10 +177,40 @@ void RouterHook::begin_compute_batch(int step, int phase, int turn) {
     ctrace_phase_ = phase;
     ctrace_turn_ = turn;
     ctrace_seq_ = 0;
+    ctrace_ask_layer_ = -1;
+    ctrace_obs_layer_ = -1;
     // The first node of the graph is charged from here, so the mark must be taken as close to
     // llama_decode as the caller can manage — anything between them lands on node 0.
     ctrace_mark_ = std::chrono::steady_clock::now();
     ctrace_faults_ = pio::major_faults();
+}
+
+// Layer granularity: emit the closing row for the segment `interval_layer`, charged the wall
+// and faults since the previous boundary. Shared by the observe path and end_compute_batch.
+void RouterHook::ctrace_close_segment(int interval_layer, const char * tail_name) {
+    const auto now = std::chrono::steady_clock::now();
+    const uint64_t faults = pio::major_faults();
+    ComputeTraceRow r;
+    r.turn = ctrace_turn_;
+    r.phase = ctrace_phase_;
+    r.step = ctrace_step_;
+    r.seq = ctrace_seq_++;
+    r.layer = interval_layer;
+    r.op = "LAYER";
+    r.name = tail_name ? tail_name : (interval_layer < 0 ? "pre" : "blk." + std::to_string(interval_layer));
+    r.wall_ns = (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(now - ctrace_mark_).count();
+    r.majflt = faults - ctrace_faults_;
+    compute_rows_.push_back(std::move(r));
+    ctrace_mark_ = now;
+    ctrace_faults_ = faults;
+}
+
+void RouterHook::end_compute_batch() {
+    // Node granularity has no dangling interval: the last node was itself isolated and observed.
+    // The tail row absorbs whatever ran between the last boundary and this call — keep the call
+    // adjacent to llama_decode's return or the decode epilogue is billed to the LM head.
+    if (!ctrace_on_ || !ctrace_layers_) return;
+    ctrace_close_segment(-1, "post");
 }
 
 bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
@@ -188,21 +219,32 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     // boundary as possible and the streamer's own work (load_layer, the residency query) lands
     // inside the routing node's interval where it belongs — that IS what routing costs here.
     if (ctrace_on_ && !ask) {
-        const auto now = std::chrono::steady_clock::now();
-        const uint64_t faults = pio::major_faults();
-        ComputeTraceRow r;
-        r.turn = ctrace_turn_;
-        r.phase = ctrace_phase_;
-        r.step = ctrace_step_;
-        r.seq = ctrace_seq_++;
-        r.layer = node_layer(t->name);
-        r.op = ggml_op_name(t->op);
-        r.name = t->name;
-        r.wall_ns = (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(now - ctrace_mark_).count();
-        r.majflt = faults - ctrace_faults_;
-        compute_rows_.push_back(std::move(r));
-        ctrace_mark_ = now;
-        ctrace_faults_ = faults;
+        if (ctrace_layers_) {
+            // Only isolated nodes reach this branch: layer boundaries, plus the routing nodes the
+            // streamer isolates anyway (a barrier that exists untraced too, so it is free to use).
+            // The interval since the previous boundary belongs to the segment we are LEAVING —
+            // attributing it to this node's layer would misfile nearly a whole layer, since a
+            // boundary node is the first node of the next one.
+            ctrace_close_segment(ctrace_obs_layer_, nullptr);
+            const int nl = node_layer(t->name);
+            if (nl >= 0) ctrace_obs_layer_ = nl; // layerless nodes (reshapes, views) don't move the cursor
+        } else {
+            const auto now = std::chrono::steady_clock::now();
+            const uint64_t faults = pio::major_faults();
+            ComputeTraceRow r;
+            r.turn = ctrace_turn_;
+            r.phase = ctrace_phase_;
+            r.step = ctrace_step_;
+            r.seq = ctrace_seq_++;
+            r.layer = node_layer(t->name);
+            r.op = ggml_op_name(t->op);
+            r.name = t->name;
+            r.wall_ns = (uint64_t) std::chrono::duration_cast<std::chrono::nanoseconds>(now - ctrace_mark_).count();
+            r.majflt = faults - ctrace_faults_;
+            compute_rows_.push_back(std::move(r));
+            ctrace_mark_ = now;
+            ctrace_faults_ = faults;
+        }
     }
 
     // ── capture: harvest expert weight tensors from every node's sources ──
@@ -238,8 +280,26 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     // Only a traced run asks for the weight nodes: each extra ask is another barrier.
     int wl = -1;
     const bool is_weights = trace_on_ && match_weights(t->name, wl);
-    // The compute trace wants every node isolated; the streamer only wants the routing ones.
-    if (ask) return ctrace_on_ || is_topk || is_weights;
+    // The compute trace wants every node isolated — or, at layer granularity, only the first
+    // node of each layer: the cursor advances on the ask stream (every node passes through
+    // here), so one isolation request per layer transition. Layerless names (embeddings, the
+    // head, mid-layer reshapes) never move the cursor, so they cannot fake a boundary. The
+    // streamer only wants the routing ones.
+    if (ask) {
+        bool ctrace_iso = false;
+        if (ctrace_on_) {
+            if (!ctrace_layers_) {
+                ctrace_iso = true;
+            } else {
+                const int nl = node_layer(t->name);
+                if (nl >= 0 && nl != ctrace_ask_layer_) {
+                    ctrace_iso = true;
+                    ctrace_ask_layer_ = nl;
+                }
+            }
+        }
+        return ctrace_iso || is_topk || is_weights;
+    }
 
     // Weights follow their layer's topk, so the pending record is already open; keep the last
     // one offered (match_weights explains why) and let the flush read it.

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -80,12 +80,21 @@ public:
     // This is the only way to measure compute from outside llama.cpp, and it is expensive by
     // construction: a barrier per node, and no operator coalescing. Off by default; a traced run
     // is not a benchmark run. Independent of streaming — a dense baseline can be traced too.
-    void set_compute_trace(bool on);
+    //
+    // per_layer trades the per-op detail for fidelity: only the first node of each layer is
+    // isolated (~n_layer barriers per token instead of thousands), coalescing and the async
+    // expert prefetch survive, and each row aggregates one layer's segment (op "LAYER").
+    void set_compute_trace(bool on, bool per_layer = false);
 
     // Frame the rows of one llama_decode, as begin_trace_batch does for the route trace. Rows are
     // stamped with `step`; a prefill chunk attributes its whole graph to the batch's last position,
     // since a node is computed once for the batch, not per token.
     void begin_compute_batch(int step, int phase, int turn);
+
+    // Close the batch's final interval (layer-granularity only): the last layer's tail plus the
+    // final norm and LM head have no successor boundary to observe them, so the session must call
+    // this right after llama_decode returns — the row is charged the wall since the last boundary.
+    void end_compute_batch();
 
     std::vector<ComputeTraceRow> & compute_rows() { return compute_rows_; }
 
@@ -112,6 +121,7 @@ private:
         std::vector<uint8_t> residency;
     };
     void flush_pending();
+    void ctrace_close_segment(int interval_layer, const char * tail_name);
 
     // Stored by value, not by reference: the caller often constructs us from a temporary
     // (a `cond ? *ptr : MoeRecipe{}` ternary yields a prvalue even when ptr is non-null),
@@ -139,7 +149,13 @@ private:
 
     // Compute trace. All of this is inert unless ctrace_on_. `ctrace_mark_` is the previous
     // isolation boundary: the node reported by the next callback is charged the wall since it.
+    // Layer granularity keeps two cursors because ask and observe see different node streams:
+    // ask_layer_ decides which nodes to isolate (every node is asked), obs_layer_ names the
+    // segment an observed interval belongs to (only isolated nodes are observed). -1 = before
+    // layer 0, i.e. the "pre" segment.
     bool ctrace_on_ = false;
+    bool ctrace_layers_ = false;
+    int ctrace_ask_layer_ = -1, ctrace_obs_layer_ = -1;
     int ctrace_step_ = 0, ctrace_phase_ = 0, ctrace_turn_ = 0;
     int ctrace_seq_ = 0;
     std::chrono::steady_clock::time_point ctrace_mark_;

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -311,6 +311,23 @@ suffix (`-1` = belongs to no layer: embeddings, the output head, masks). `op` an
 which node is attention vs dense FFN vs expert matmul is naming policy that varies by
 architecture, so the engine reports what the graph said and the analysis script classifies.
 
+### `--compute-trace-layers` — one row per layer segment
+
+The per-node trace's barrier count is also its distortion: ~3000 barriers per token serialize the
+graph against the expert stream, so on a model that streams heavily the trace mostly measures its
+own serialization. Layer granularity isolates only the **first node of each layer** — ~`n_layer`
+barriers per token — which preserves operator coalescing and, crucially, the async expert
+prefetch: the io lanes keep reading across a boundary, so the traced numbers sit close to an
+untraced run and can be compared across models. The trade is per-op detail: a row aggregates
+everything since the previous boundary.
+
+Rows share the per-node schema with `op` fixed to `LAYER`. `name` says which segment: `blk.<il>`
+is layer il's, `pre` is the embedding lookup before layer 0, and `post` — emitted when the batch
+closes — is the last layer's tail plus the final norm and LM head. The routing nodes the streamer
+isolates anyway also close a segment (a barrier that exists untraced too, so it costs nothing
+extra); those rows carry the same `blk.<il>` name and simply sum into their layer.
+`scripts/decode-analyze.py compute` detects the granularity and prints the per-segment table.
+
 ### `--io-trace` — one row per flash read
 
 Needs `--moe-stream` (no engine-issued reads without it). Records every `pread` the streamer

--- a/scripts/decode-analyze.py
+++ b/scripts/decode-analyze.py
@@ -35,11 +35,53 @@ def decode_only(rows):
     return d if d else rows
 
 
+def cmd_compute_layers(meta, rows):
+    """Layer-granularity trace (--compute-trace-layers): one row per layer segment.
+
+    Cheap enough that absolutes are meaningful, at the cost of per-op detail. "pre" is the
+    embedding lookup, "post" the last layer's tail plus the final norm and LM head.
+    """
+    steps = sorted({int(r["step"]) for r in rows})
+    n_steps = len(steps)
+    total = sum(int(r["wall_ns"]) for r in rows)
+    faults = sum(int(r["majflt"]) for r in rows)
+
+    print(f"model={meta.get('model','?')} arch={meta.get('arch','?')} "
+          f"n_layer={meta.get('n_layer','?')} threads={meta.get('n_threads','?')}")
+    print(f"decode steps={n_steps}  layer granularity  "
+          f"measured compute={fmt_ms(total/max(1,n_steps))} ms/token  majflt={faults/max(1,n_steps):.0f}/token")
+    print("\nNOTE: one barrier per layer - coalescing and the expert prefetch survive, so these\n"
+          "      numbers sit close to an untraced run. No per-op detail inside a segment.\n")
+
+    by_seg = defaultdict(lambda: [0, 0])  # ns, majflt
+    for r in rows:
+        e = by_seg[r["name"]]
+        e[0] += int(r["wall_ns"])
+        e[1] += int(r["majflt"])
+
+    def seg_key(name):
+        if name == "pre":
+            return (-1,)
+        if name == "post":
+            return (1 << 30,)
+        return (int(name.split(".")[1]),) if name.startswith("blk.") else (1 << 29,)
+
+    mx = max(v[0] for v in by_seg.values()) or 1
+    print(f"{'segment':<10}{'ms/token':>10}{'share':>8}  {'majflt/tok':>10}")
+    for name in sorted(by_seg, key=seg_key):
+        ns, mf = by_seg[name]
+        print(f"{name:<10}{fmt_ms(ns/max(1,n_steps))}{ns/total*100 if total else 0:7.1f}%  "
+              f"{mf/max(1,n_steps):10.1f}  {bar(ns/mx)}")
+
+
 def cmd_compute(args):
     meta, rows = read_trace(args.path)
     rows = decode_only(rows)
     if not rows:
         sys.exit("no rows")
+    if all(r["op"] == "LAYER" for r in rows):
+        cmd_compute_layers(meta, rows)
+        return
     steps = sorted({int(r["step"]) for r in rows})
     n_steps = len(steps)
     total = sum(int(r["wall_ns"]) for r in rows)


### PR DESCRIPTION
## Why

The per-node compute trace (`--compute-trace`) pays ~3000 barriers per token. That serializes the graph against the expert stream, so on a model that streams heavily the trace mostly measures its own serialization — Qwen3-30B-A3B traced at 9.4 s/token vs 0.39 untraced on the OnePlus 15R, with 91% of the measured time in fault-laden expert-wait nodes. Per-node absolutes cannot be compared across models; per-op detail is only trustworthy on runs that stream little.

## What

`--compute-trace-layers PATH`: the same trace at layer granularity. Only the **first node of each layer** is isolated (~`n_layer` barriers per token), so operator coalescing and the async expert prefetch survive and the traced numbers sit close to an untraced run — cheap enough to compare Qwen vs Gemma vs gpt-oss head-to-head, per layer, with major faults attributed per segment.

- Rows share the per-node schema, `op` fixed to `LAYER`: `blk.<il>` is layer il''s segment, `pre` the embedding lookup, `post` the last layer''s tail + final norm + LM head (closed by the session right after `llama_decode` — the tail has no successor boundary to observe it).
- The routing nodes the streamer isolates anyway also close a segment: that barrier exists untraced too, so it is free to use.
- Granularity flows `RunConfig` → `SessionConfig` → `RouterHook` (no env vars in core; `session_config_from` stays the single mapping point).
- `scripts/decode-analyze.py compute` detects the granularity and prints the per-segment table; `docs/telemetry.md` documents the mode.
- `--compute-trace` / `--compute-trace-layers` added to the CLI usage text.

## Verification

- All 6 host gates pass (byte-identity `moe_gates_qwen3moe` + `moe_gates_gemma4`) — the ask-path change is inert with tracing off.
- Smoke-tested on the tiny-moe models with streaming on: per-segment table renders (`pre`, `blk.0..3`, `post`), rows sum to the decode.
- clang-format 18 clean.


https://claude.ai/code/session_01VeCJ1G2uucwHtapEdU6qSQ
