### PR TITLE
fix(android): download models into O_DIRECT-capable internal storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Added
+- **Android: in-app model downloads now land on O_DIRECT-capable internal storage.** The catalog and
+  paste-URL downloads used the system `DownloadManager`, which can only write to the app's external
+  files dir — an emulated/FUSE volume where `O_DIRECT` silently returns wrong data, so the engine
+  fell back to buffered I/O for every downloaded model (measured on device: `o_direct=0`, the exact
+  loss the streaming design exists to avoid). `DownloadManager` cannot target internal storage by
+  design, so it is replaced by `DownloadWorker`: a foreground WorkManager `CoroutineWorker` that
+  streams the gguf over HTTP straight into `filesDir/models` (real f2fs, where `O_DIRECT` works — the
+  same dir the file picker imports to). It resumes an interrupted `.part` with a `Range` request
+  (following Hugging Face's resolve → CDN redirect manually so the header survives) and renames on
+  completion, and it needs free space equal to the model size — no temporary second copy. This is the
+  mechanism Google's own AI Edge Gallery uses. Fixes #67.
 - **Decode traces** (`--compute-trace PATH`, `--io-trace PATH`): returning `true` for every node from
   the eval callback forces ggml to isolate and synchronise each one, so the wall delta between
   callbacks is that node's real compute and the major-fault delta attributes a >RAM stall to the node

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -44,10 +44,16 @@ check). Nothing below needs a storage permission except the last option.
 
 1. **Built-in catalog** (both flavors) — the "Get a model" card offers the models this engine
    is measured on, each a single tap: **Qwen3-30B-A3B-Q4_K_M** (~18.5 GB, the reference model)
-   and **Gemma-4-26B-A4B-it-Q4_K_M** (~17 GB). Downloads run in the background, survive the app
-   being killed, and appear in the picker when done.
+   and **Gemma-4-26B-A4B-it-Q4_K_M** (~17 GB). Downloads run in a foreground worker, survive the
+   app being killed, resume an interrupted transfer instead of restarting, and appear in the
+   picker when done.
 2. **Any other model** — under **Other model**, paste a direct gguf URL (e.g. a Hugging Face
    `…/resolve/main/model.gguf` link), or pick a `.gguf` already on the device to import it.
+
+   In-app downloads and picker imports both land in the app's internal storage (`filesDir`, a
+   real f2fs/ext4 volume), so the streamed expert reads use O_DIRECT at full speed. Only models
+   read from the emulated external dirs (adb-pushed to `/sdcard/Download`) fall back to buffered
+   I/O. A download needs free space equal to the model size — no temporary second copy.
 3. **adb push** (dev flavor only — needs all-files access, which the dev build requests):
 
    ```bash

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
     //         src/dev/AndroidManifest.xml.
     //   play  Play-Store-compliant. No broad storage permission: models arrive only through
     //         the in-app URL downloader or the system file picker (SAF), both writing to the
-    //         app-specific external files dir, which needs no permission.
+    //         app-internal models dir (filesDir), which needs no permission.
     // SHARED_STORAGE gates the storage-permission code paths; no model names or URLs are
     // ever hardcoded — the scanned directories are the only difference.
     flavorDimensions += 'distribution'
@@ -96,6 +96,9 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.activity:activity-compose:1.9.2'
     implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.8.5'
+    // In-app model downloader: a foreground CoroutineWorker that survives process death and
+    // resumes multi-GB transfers (see DownloadWorker). Brings kotlinx-coroutines-android too.
+    implementation 'androidx.work:work-runtime-ktx:2.9.1'
 
     def composeBom = platform('androidx.compose:compose-bom:2024.09.02')
     implementation composeBom

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 13
-        versionName '0.8.3'
+        versionCode 14
+        versionName '0.9.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -5,14 +5,14 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!-- Fetching a model is the only thing this app does over the network: DownloadManager needs
-         INTERNET both to run a download and to report on one. Inference is entirely on-device —
-         nothing about a prompt or an answer leaves the phone. -->
+    <!-- Fetching a model is the only thing this app does over the network: the in-app download
+         worker needs INTERNET. Inference is entirely on-device — nothing about a prompt or an
+         answer leaves the phone. -->
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- No broad storage permission here: models arrive through the in-app URL downloader or
-         the system file picker, both writing to the app-specific external files dir. The dev
-         flavor overlay (src/dev/AndroidManifest.xml) adds all-files access to also read
-         adb-pushed models in place. -->
+         the system file picker, both writing to the app-internal models dir (filesDir, a real
+         filesystem where O_DIRECT works). The dev flavor overlay (src/dev/AndroidManifest.xml)
+         adds all-files access to also read adb-pushed models in place. -->
 
     <application
         android:allowBackup="false"

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
@@ -36,6 +37,15 @@
             android:name=".RunService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+        <!-- WorkManager runs DownloadWorker's foreground transfer through its own
+             SystemForegroundService, which it declares without a foregroundServiceType. On API 34+
+             the type passed to startForeground (dataSync) must be a subset of the type on the
+             <service> element, so merge it in here — without this the download crashes with
+             "foregroundServiceType 0x1 is not a subset of 0x0". -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
         <!-- Hands a metrics CSV to another app (Drive, Gmail, Files) as a content:// URI with a
              one-shot read grant. A file:// URI would be refused outright since Android 7, and the
              alternative — telling the user to go find the file — is not a feature. Scoped to the

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/DownloadWorker.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/DownloadWorker.kt
@@ -75,17 +75,9 @@ class DownloadWorker(ctx: Context, params: WorkerParameters) : CoroutineWorker(c
      */
     private suspend fun transfer(url: String, part: File, onProgress: (Long, Long) -> Unit): Long {
         var from = if (part.isFile) part.length() else 0L
-        val conn = (URL(url).openConnection() as HttpURLConnection).apply {
-            instanceFollowRedirects = true
-            connectTimeout = 30_000
-            readTimeout = 30_000
-            // Defeat gzip: a re-encoded body would make the byte offsets in a Range resume wrong.
-            setRequestProperty("Accept-Encoding", "identity")
-            if (from > 0) setRequestProperty("Range", "bytes=$from-")
-        }
+        val conn = openWithRange(url, from)
         try {
-            val code = conn.responseCode
-            when (code) {
+            when (val code = conn.responseCode) {
                 HttpURLConnection.HTTP_PARTIAL -> { /* 206: server honored the resume */ }
                 HttpURLConnection.HTTP_OK -> from = 0L // 200: no resume, start the .part over
                 416 -> return part.length() // range not satisfiable: .part is already the whole file
@@ -122,6 +114,36 @@ class DownloadWorker(ctx: Context, params: WorkerParameters) : CoroutineWorker(c
             return total
         } finally {
             conn.disconnect()
+        }
+    }
+
+    /**
+     * Open [startUrl] following redirects MANUALLY, re-applying the Range and identity-encoding
+     * headers on every hop. HttpURLConnection's automatic redirect (instanceFollowRedirects) drops
+     * request headers across a cross-host 3xx — which is exactly Hugging Face's resolve → CDN
+     * redirect — so a resume would silently lose its Range header, get a 200, and restart from zero.
+     */
+    private fun openWithRange(startUrl: String, from: Long): HttpURLConnection {
+        var url = startUrl
+        var hops = 0
+        while (true) {
+            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                instanceFollowRedirects = false
+                connectTimeout = 30_000
+                readTimeout = 30_000
+                // Defeat gzip: a re-encoded body would make the byte offsets in a Range resume wrong.
+                setRequestProperty("Accept-Encoding", "identity")
+                if (from > 0) setRequestProperty("Range", "bytes=$from-")
+            }
+            when (conn.responseCode) {
+                301, 302, 303, 307, 308 -> {
+                    val loc = conn.getHeaderField("Location")
+                    conn.disconnect()
+                    if (loc.isNullOrBlank() || ++hops > 5) throw java.io.IOException("too many redirects")
+                    url = URL(URL(url), loc).toString() // resolve a possibly-relative Location
+                }
+                else -> return conn
+            }
         }
     }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/DownloadWorker.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/DownloadWorker.kt
@@ -1,0 +1,177 @@
+package io.bigmoeonedge.example
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.net.Uri
+import android.os.Build
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
+import java.io.RandomAccessFile
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Downloads a gguf over HTTP straight into the app-internal models dir (real f2fs/ext4, where
+ * O_DIRECT works — see [ModelManager.internalModelsDir]). This is why the app does the transfer
+ * itself instead of using the system DownloadManager, which can only write to the emulated
+ * external storage where O_DIRECT is silently unusable and the engine falls back to slow
+ * buffered I/O.
+ *
+ * The bytes go to `<name>.gguf.part` and the file is renamed to `<name>.gguf` only once complete,
+ * so a half-finished download is never listed as a runnable model. A `Range` request resumes an
+ * interrupted `.part` instead of restarting a multi-GB transfer, and the worker runs as a
+ * foreground service so a long download survives the app going to the background.
+ */
+class DownloadWorker(ctx: Context, params: WorkerParameters) : CoroutineWorker(ctx, params) {
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val url = inputData.getString(KEY_URL) ?: return@withContext fail("missing URL")
+        val name = inputData.getString(KEY_NAME) ?: return@withContext fail("missing filename")
+        val expected = inputData.getLong(KEY_EXPECTED, -1L)
+
+        val dir = ModelManager.internalModelsDir(applicationContext)
+        val finalFile = File(dir, name)
+        if (finalFile.isFile) return@withContext Result.success() // already downloaded
+
+        val part = File(dir, name + PART_SUFFIX)
+        // usableSpace already accounts for the bytes on disk in .part, so check the remainder.
+        if (expected > 0 && expected - part.length() > dir.usableSpace) {
+            part.delete()
+            return@withContext fail("needs ${ModelCatalog.gbLabel(expected)}, only ${ModelCatalog.gbLabel(dir.usableSpace)} free")
+        }
+
+        setForeground(foregroundInfo(name, 0f))
+
+        try {
+            val total = transfer(url, part) { downloaded, size ->
+                setProgressAsync(workDataOf(KEY_DONE to downloaded, KEY_TOTAL to size))
+            }
+            if (total >= 0 && part.length() != total) {
+                // Server closed early: keep the .part so the next run's Range request resumes it.
+                return@withContext retryOrFail("download interrupted at ${part.length() shr 20} MiB")
+            }
+            if (!part.renameTo(finalFile)) return@withContext fail("could not finalize the download")
+            Result.success()
+        } catch (c: CancellationException) {
+            throw c // cancellation — leave the .part for a manual resume; the UI deletes it on Cancel
+        } catch (t: Throwable) {
+            // Transient network error: keep the .part and let WorkManager back off and resume.
+            retryOrFail(t.message ?: "network error")
+        }
+    }
+
+    /**
+     * Stream the URL into [part], resuming from its current length with a `Range` request.
+     * Returns the expected total size in bytes, or -1 if the server didn't report one.
+     */
+    private suspend fun transfer(url: String, part: File, onProgress: (Long, Long) -> Unit): Long {
+        var from = if (part.isFile) part.length() else 0L
+        val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+            instanceFollowRedirects = true
+            connectTimeout = 30_000
+            readTimeout = 30_000
+            // Defeat gzip: a re-encoded body would make the byte offsets in a Range resume wrong.
+            setRequestProperty("Accept-Encoding", "identity")
+            if (from > 0) setRequestProperty("Range", "bytes=$from-")
+        }
+        try {
+            val code = conn.responseCode
+            when (code) {
+                HttpURLConnection.HTTP_PARTIAL -> { /* 206: server honored the resume */ }
+                HttpURLConnection.HTTP_OK -> from = 0L // 200: no resume, start the .part over
+                416 -> return part.length() // range not satisfiable: .part is already the whole file
+                else -> throw java.io.IOException("server returned HTTP $code")
+            }
+            // Total = bytes already on disk + what this response will deliver.
+            val remaining = conn.contentLengthLong
+            val total = if (remaining >= 0) from + remaining else -1L
+
+            RandomAccessFile(part, "rw").use { out ->
+                out.seek(from)
+                if (from == 0L) out.setLength(0L)
+                conn.inputStream.use { src ->
+                    val buf = ByteArray(1 shl 20)
+                    var done = from
+                    var lastTick = 0L
+                    onProgress(done, total)
+                    while (true) {
+                        if (isStopped) throw CancellationException("cancelled")
+                        val n = src.read(buf)
+                        if (n < 0) break
+                        out.write(buf, 0, n)
+                        done += n
+                        // Throttle UI/DB writes: progress Data every ~500 ms, not every 1 MiB chunk.
+                        val now = System.currentTimeMillis()
+                        if (now - lastTick >= 500) {
+                            onProgress(done, total)
+                            lastTick = now
+                        }
+                    }
+                    onProgress(done, total)
+                }
+            }
+            return total
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun retryOrFail(message: String): Result =
+        if (runAttemptCount < MAX_ATTEMPTS) Result.retry() else fail(message)
+
+    private fun fail(message: String): Result = Result.failure(workDataOf(KEY_ERROR to message))
+
+    private fun foregroundInfo(name: String, frac: Float): ForegroundInfo {
+        val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            nm.createNotificationChannel(
+                NotificationChannel(CHANNEL, "Model downloads", NotificationManager.IMPORTANCE_LOW)
+            )
+        }
+        val notif: Notification = Notification.Builder(applicationContext, CHANNEL)
+            .setContentTitle("Downloading model")
+            .setContentText(name)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .setProgress(100, (frac * 100).toInt().coerceIn(0, 100), frac < 0f)
+            .build()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(NOTIF_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(NOTIF_ID, notif)
+        }
+    }
+
+    companion object {
+        const val PART_SUFFIX = ".part"
+        const val TAG = "model-download"
+
+        const val KEY_URL = "url"
+        const val KEY_NAME = "name"
+        const val KEY_EXPECTED = "expected"
+        const val KEY_DONE = "done"
+        const val KEY_TOTAL = "total"
+        const val KEY_ERROR = "error"
+
+        private const val CHANNEL = "download"
+        private const val NOTIF_ID = 42
+        private const val MAX_ATTEMPTS = 5
+
+        /** Last path segment of a URL, query stripped, sanitized to a bare filename. */
+        fun fileNameFromUrl(uri: Uri): String {
+            val seg = uri.lastPathSegment?.substringAfterLast('/') ?: ""
+            val cleaned = seg.substringBefore('?').filter { it.isLetterOrDigit() || it in "._-" }
+            require(cleaned.isNotEmpty()) { "cannot derive a filename from the URL" }
+            return cleaned
+        }
+    }
+}

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -408,9 +408,9 @@ private fun AddModelSection(
     var open by rememberSaveable { mutableStateOf<Boolean?>(null) }
     LaunchedEffect(scanning) { if (!scanning && open == null) open = models.isEmpty() }
     val isOpen = open == true
-    // filename -> DownloadManager id. Seeded from DownloadManager rather than remembered, so a
-    // transfer started before the app was killed is picked back up instead of running unseen.
-    var downloads by remember { mutableStateOf<Map<String, Long>>(emptyMap()) }
+    // filename -> download id (also the filename). Seeded from WorkManager rather than remembered,
+    // so a transfer started before the app was killed is picked back up instead of running unseen.
+    var downloads by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var progress by remember { mutableStateOf<Map<String, ModelDownloader.Progress>>(emptyMap()) }
     var importStatus by remember { mutableStateOf<String?>(null) }
     var importFrac by remember { mutableStateOf(-1f) }
@@ -509,7 +509,7 @@ private fun AddModelSection(
                                 }
                         },
                         onCancel = {
-                            downloads[e.fileName]?.let { ModelDownloader.cancel(context, it, e.fileName) }
+                            ModelDownloader.cancel(context, e.fileName)
                             reseed()
                         },
                         onDelete = { deleteTarget = e.fileName },
@@ -583,7 +583,7 @@ private fun AddModelSection(
                         DownloadProgress(
                             p,
                             onCancel = {
-                                ModelDownloader.cancel(context, p.id, name)
+                                ModelDownloader.cancel(context, name)
                                 reseed()
                             },
                         )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -443,7 +443,10 @@ private fun AddModelSection(
     // Poll the in-flight downloads; finalize each (.part → .gguf) as it lands and re-scan. The
     // effect restarts whenever the set changes, which is also how it stops.
     LaunchedEffect(downloads) {
-        if (downloads.isEmpty()) return@LaunchedEffect
+        if (downloads.isEmpty()) {
+            progress = emptyMap() // clear the last bar once nothing is in flight
+            return@LaunchedEffect
+        }
         while (true) {
             val finished = mutableSetOf<String>()
             val live = mutableMapOf<String, ModelDownloader.Progress>()
@@ -777,15 +780,20 @@ private fun DownloadProgress(
     } else {
         null
     }
-    val prefix = if (showName) "${p.name} — " else ""
+    // Name and numbers go on separate lines: a long filename must never ellipsize away the MiB
+    // counter, which is the part the user actually watches.
+    if (showName) {
+        Text(p.name, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
     Text(
         when {
-            p.state == ModelDownloader.State.PAUSED -> prefix + (p.reason ?: "paused")
-            pct != null -> prefix + String.format(
-                Locale.US, "%d%% (%d/%d MiB)",
+            p.state == ModelDownloader.State.PAUSED -> p.reason ?: "paused"
+            pct != null -> String.format(
+                Locale.US, "%d%% (%d / %d MiB)",
                 (pct * 100).toInt(), p.downloadedBytes shr 20, p.totalBytes shr 20,
             )
-            else -> if (showName) "Downloading ${p.name}…" else "Starting…"
+            p.downloadedBytes > 0 -> String.format(Locale.US, "%d MiB", p.downloadedBytes shr 20)
+            else -> "Starting…"
         },
         fontSize = 12.sp,
         maxLines = 1,

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -140,7 +140,9 @@ object ModelDownloader {
 
     /** Cancel a download and delete its leftover .part file. */
     fun cancel(ctx: Context, name: String) {
-        WorkManager.getInstance(ctx).cancelUniqueWork(name)
+        // Block until the cancellation is persisted, so a caller's immediate activeDownloads()
+        // reseed sees the work as finished instead of racing it back in as still-active.
+        WorkManager.getInstance(ctx).cancelUniqueWork(name).result.get()
         File(ModelManager.internalModelsDir(ctx), name + DownloadWorker.PART_SUFFIX).delete()
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -1,25 +1,36 @@
 package io.bigmoeonedge.example
 
-import android.app.DownloadManager
 import android.content.Context
 import android.net.Uri
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 /**
- * Downloads a gguf by URL into the app-specific external files dir using the system
- * [DownloadManager]. That destination needs no storage permission, and DownloadManager keeps
- * going across process death and resumes on reconnect — the right fit for multi-GB models.
+ * Starts and tracks model downloads. The transfer itself runs in [DownloadWorker] (an in-app
+ * HTTP download into the O_DIRECT-capable internal storage — see that class for why the system
+ * DownloadManager can't be used here); this object is the thin facade the UI drives.
  *
- * The file is written as `<name>.gguf.part` and renamed to `<name>.gguf` only on success, so a
- * half-finished download is never listed as a runnable model.
+ * A download is identified by its filename, which is also its unique-work name: enqueuing the
+ * same model twice is a no-op, and an in-flight transfer is re-discoverable after process death
+ * because WorkManager persists it.
  */
 object ModelDownloader {
-    private const val PART_SUFFIX = ".part"
+    private const val NAME_TAG_PREFIX = "name:"
 
     enum class State { PENDING, RUNNING, PAUSED, SUCCESS, FAILED }
 
     data class Progress(
-        val id: Long,
+        val id: String, // the unique-work name == the filename
         val name: String,
         val downloadedBytes: Long,
         val totalBytes: Long, // -1 when the server didn't send a length
@@ -28,29 +39,28 @@ object ModelDownloader {
     )
 
     /**
-     * Start a download. Returns the DownloadManager id, or an error if the URL doesn't name a
-     * .gguf file or the model cannot fit. No model names or hosts are assumed — for a pasted URL
-     * the filename comes from the URL itself.
+     * Start a download. Returns the unique-work id (the filename), or an error if the URL doesn't
+     * name a .gguf file or the model cannot fit. No model names or hosts are assumed — for a pasted
+     * URL the filename comes from the URL itself.
      *
-     * [fileName] overrides that for catalog downloads, where the on-disk name is known upfront
-     * and must not depend on redirects or query strings. [expectedBytes] (when > 0) is checked
-     * against free space before enqueuing: DownloadManager would fail with
-     * ERROR_INSUFFICIENT_SPACE anyway, but only after the user waited for it to try.
+     * [fileName] overrides that for catalog downloads, where the on-disk name is known upfront and
+     * must not depend on redirects or query strings. [expectedBytes] (when > 0) is checked against
+     * free space before enqueuing so the user isn't left waiting for a transfer that can't fit.
      */
     fun enqueue(
         ctx: Context,
         rawUrl: String,
         fileName: String? = null,
         expectedBytes: Long = -1L,
-    ): Result<Long> = runCatching {
+    ): Result<String> = runCatching {
         val url = rawUrl.trim()
         val uri = Uri.parse(url)
         require(uri.scheme == "http" || uri.scheme == "https") { "URL must be http(s)" }
 
-        val name = fileName ?: fileNameFromUrl(uri)
+        val name = fileName ?: DownloadWorker.fileNameFromUrl(uri)
         require(name.endsWith(".gguf")) { "URL must point to a .gguf file" }
 
-        val dir = ModelManager.appModelsDir(ctx) ?: error("no writable app storage")
+        val dir = ModelManager.internalModelsDir(ctx)
         if (expectedBytes > 0 && expectedBytes > dir.usableSpace) {
             error(
                 "needs ${ModelCatalog.gbLabel(expectedBytes)}, " +
@@ -58,114 +68,79 @@ object ModelDownloader {
             )
         }
 
-        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-        val req = DownloadManager.Request(uri)
-            .setTitle(name)
-            .setDescription("BigMoeOnEdge model")
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            .setAllowedOverMetered(true)
-            .setAllowedOverRoaming(false)
-            // App-specific external files dir → no permission required, and the same directory
-            // ModelManager scans. Written as .part so the scanner ignores it until complete.
-            .setDestinationInExternalFilesDir(ctx, null, name + PART_SUFFIX)
-        dm.enqueue(req)
+        val req = OneTimeWorkRequestBuilder<DownloadWorker>()
+            .setInputData(
+                workDataOf(
+                    DownloadWorker.KEY_URL to url,
+                    DownloadWorker.KEY_NAME to name,
+                    DownloadWorker.KEY_EXPECTED to expectedBytes,
+                )
+            )
+            .addTag(DownloadWorker.TAG)
+            .addTag(NAME_TAG_PREFIX + name)
+            .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .build()
+        // Block until the work is persisted so the caller's immediate activeDownloads() reseed
+        // sees it (a fast local DB write) — otherwise the row wouldn't show as downloading.
+        WorkManager.getInstance(ctx).enqueueUniqueWork(name, ExistingWorkPolicy.KEEP, req).result.get()
+        name
     }
 
-    /** Current status of a download, or null if the id is unknown or the provider refused. */
-    fun query(ctx: Context, id: Long): Progress? = runCatching {
-        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-        dm.query(DownloadManager.Query().setFilterById(id)).use { c ->
-            if (c == null || !c.moveToFirst()) return@runCatching null
-            val status = c.getInt(c.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
-            val soFar = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
-            val total = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
-            val title = c.getString(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TITLE)) ?: "model.gguf"
-            val reasonCode = c.getInt(c.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
-            val state = when (status) {
-                DownloadManager.STATUS_PENDING -> State.PENDING
-                DownloadManager.STATUS_RUNNING -> State.RUNNING
-                DownloadManager.STATUS_PAUSED -> State.PAUSED
-                DownloadManager.STATUS_SUCCESSFUL -> State.SUCCESS
-                else -> State.FAILED
+    /** Current status of a download, or null if it is unknown, cancelled, or already cleared. */
+    suspend fun query(ctx: Context, name: String): Progress? = withContext(Dispatchers.IO) {
+        runCatching {
+            val info = WorkManager.getInstance(ctx).getWorkInfosForUniqueWork(name).get().lastOrNull()
+                ?: return@runCatching null
+            when (info.state) {
+                WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED ->
+                    Progress(name, name, 0, -1, State.PENDING)
+                WorkInfo.State.RUNNING -> Progress(
+                    name, name,
+                    info.progress.getLong(DownloadWorker.KEY_DONE, 0),
+                    info.progress.getLong(DownloadWorker.KEY_TOTAL, -1),
+                    State.RUNNING,
+                )
+                WorkInfo.State.SUCCEEDED -> Progress(name, name, 0, 0, State.SUCCESS)
+                WorkInfo.State.FAILED -> Progress(
+                    name, name, 0, -1, State.FAILED,
+                    info.outputData.getString(DownloadWorker.KEY_ERROR) ?: "download failed",
+                )
+                WorkInfo.State.CANCELLED -> null // user cancelled: no error to surface
             }
-            val reason = when (state) {
-                State.FAILED -> failureReason(reasonCode)
-                State.PAUSED -> pauseReason(reasonCode)
-                else -> null
-            }
-            Progress(id, title, soFar, total, state, reason)
-        }
-    }.getOrNull()
+        }.getOrNull()
+    }
 
     /**
-     * Model downloads this app still has in flight, as filename -> DownloadManager id.
-     *
-     * DownloadManager outlives the app process, so a download started before the app was killed
-     * is still running when the user comes back. The UI seeds itself from this instead of losing
-     * track of a multi-GB transfer. Only our own downloads are visible to this query.
-     *
-     * Never throws: this only restores convenience state, and the download provider is a system
-     * component that can refuse the query. An empty map costs the user a progress bar; letting
-     * the exception out would cost them the whole screen.
+     * Model downloads still in flight, as filename -> id (both the filename). WorkManager persists
+     * work across process death, so a download started before the app was killed is picked back up
+     * here instead of running unseen. Never throws — an empty map costs a progress bar, not the
+     * whole screen.
      */
-    fun activeDownloads(ctx: Context): Map<String, Long> = runCatching {
-        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-        val q = DownloadManager.Query().setFilterByStatus(
-            DownloadManager.STATUS_PENDING or DownloadManager.STATUS_RUNNING or DownloadManager.STATUS_PAUSED
-        )
-        val out = mutableMapOf<String, Long>()
-        dm.query(q)?.use { c ->
-            while (c.moveToNext()) {
-                val title = c.getString(c.getColumnIndexOrThrow(DownloadManager.COLUMN_TITLE)) ?: continue
-                val id = c.getLong(c.getColumnIndexOrThrow(DownloadManager.COLUMN_ID))
-                if (title.endsWith(".gguf")) out.putIfAbsent(title, id)
-            }
-        }
-        out as Map<String, Long>
+    fun activeDownloads(ctx: Context): Map<String, String> = runCatching {
+        WorkManager.getInstance(ctx).getWorkInfosByTag(DownloadWorker.TAG).get()
+            .filter { !it.state.isFinished }
+            .mapNotNull { info -> info.tags.firstOrNull { it.startsWith(NAME_TAG_PREFIX) }?.removePrefix(NAME_TAG_PREFIX) }
+            .associateWith { it }
     }.getOrDefault(emptyMap())
 
     /**
-     * Finish a successful download: rename `<name>.gguf.part` to `<name>.gguf` in the app models
-     * dir and return the final file, or null if the part file is missing. Idempotent — if the
-     * final file already exists it is returned as-is.
+     * Finish a successful download by renaming `<name>.gguf.part` to `<name>.gguf`. The worker
+     * already does this on success, so this is an idempotent safety net: if the final file exists
+     * it is returned as-is; otherwise a leftover .part is renamed.
      */
     fun finalizeDownload(ctx: Context, name: String): File? {
-        val dir = ModelManager.appModelsDir(ctx) ?: return null
+        val dir = ModelManager.internalModelsDir(ctx)
         val finalFile = File(dir, name)
         if (finalFile.isFile) return finalFile
-        val part = File(dir, name + PART_SUFFIX)
+        val part = File(dir, name + DownloadWorker.PART_SUFFIX)
         if (!part.isFile) return null
         return if (part.renameTo(finalFile)) finalFile else null
     }
 
-    /** Remove a download from DownloadManager and delete any leftover .part file. */
-    fun cancel(ctx: Context, id: Long, name: String) {
-        val dm = ctx.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-        dm.remove(id)
-        ModelManager.appModelsDir(ctx)?.let { File(it, name + PART_SUFFIX).delete() }
-    }
-
-    // Last path segment, query stripped, sanitized to a bare filename (no separators).
-    private fun fileNameFromUrl(uri: Uri): String {
-        val seg = uri.lastPathSegment?.substringAfterLast('/') ?: ""
-        val cleaned = seg.substringBefore('?').filter { it.isLetterOrDigit() || it in "._-" }
-        require(cleaned.isNotEmpty()) { "cannot derive a filename from the URL" }
-        return cleaned
-    }
-
-    private fun failureReason(code: Int): String = when (code) {
-        DownloadManager.ERROR_INSUFFICIENT_SPACE -> "not enough free space"
-        DownloadManager.ERROR_HTTP_DATA_ERROR -> "network data error"
-        DownloadManager.ERROR_UNHANDLED_HTTP_CODE -> "server returned an unexpected status"
-        DownloadManager.ERROR_FILE_ERROR -> "file error writing the download"
-        DownloadManager.ERROR_CANNOT_RESUME -> "download could not resume"
-        else -> "download failed (code $code)"
-    }
-
-    private fun pauseReason(code: Int): String = when (code) {
-        DownloadManager.PAUSED_WAITING_FOR_NETWORK -> "waiting for network"
-        DownloadManager.PAUSED_WAITING_TO_RETRY -> "waiting to retry"
-        DownloadManager.PAUSED_QUEUED_FOR_WIFI -> "queued for Wi-Fi"
-        else -> "paused"
+    /** Cancel a download and delete its leftover .part file. */
+    fun cancel(ctx: Context, name: String) {
+        WorkManager.getInstance(ctx).cancelUniqueWork(name)
+        File(ModelManager.internalModelsDir(ctx), name + DownloadWorker.PART_SUFFIX).delete()
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -10,8 +10,10 @@ import java.io.File
  *
  * Which directories are scanned depends on the distribution flavor (BuildConfig.SHARED_STORAGE):
  *
- *   always      the app-specific external files dir — no permission needed. The in-app URL
- *               downloader and the file picker both land models here.
+ *   always      the app-internal models dir (filesDir) — no permission needed, on a real
+ *               filesystem where O_DIRECT works. The in-app URL downloader and the file picker
+ *               both land models here. The app-specific external files dir is also scanned so
+ *               models downloaded by older builds keep working.
  *   dev only    the public Downloads folder and /data/local/tmp/bmoe, for models adb-pushed
  *               to the device. These need all-files access, which only the dev flavor requests.
  *
@@ -25,7 +27,11 @@ object ModelManager {
     // untrusted_app domain can open it.
     private val TMP_MODEL_DIR = File("/data/local/tmp/bmoe")
 
-    /** The app-specific external files dir — the download target, readable with no permission. */
+    /**
+     * The app-specific external files dir — still scanned so models downloaded by older builds
+     * (which wrote here, on FUSE) keep working, but no longer a download target: O_DIRECT is
+     * silently unusable on this emulated storage, forcing the engine onto buffered I/O.
+     */
     fun appModelsDir(ctx: Context): File? = ctx.getExternalFilesDir(null)
 
     /**


### PR DESCRIPTION
Fixes #67.

## Problem

In-app downloads (catalog + pasted URL) landed in `getExternalFilesDir` — a FUSE volume where **O_DIRECT is silently broken**. Verified on-device (OnePlus 15R, 2026-07-18): a `pread` with O_DIRECT there reports success without filling the buffer, so the engine's own verify (`core/src/io/file_reader.cpp:38-54`) catches it and falls back to buffered I/O:

```
bmoe: O_DIRECT returns wrong data on this storage — using buffered I/O
bmoe: expert streaming ON  n_expert=128 o_direct=0 io_threads=4 cache=0 MiB
```

So every in-app-downloaded model lost O_DIRECT — the streaming advantage, gone exactly on the >RAM models the engine is for. DownloadManager **cannot** write to internal storage by design (system process, external-only), so it can't be fixed in place.

## Change

Replace DownloadManager with `DownloadWorker`, a foreground `CoroutineWorker` that downloads over HTTP straight into `filesDir/models` (real f2fs, where O_DIRECT works — the same dir SAF import already uses):

- **`Range` resume**: an interrupted `.part` is resumed, not restarted (mandatory at 5–60 GB; HF's CDN supports single-range resume).
- **rename-on-complete**: a partial download is never listed as a runnable model.
- **foreground service** (`dataSync`, permission already present): survives the app backgrounding.
- **no 2× disk cost**: a model needs free space equal to its own size, unlike a download-then-copy workaround.

This mirrors Google's own AI Edge Gallery downloader (`HttpURLConnection` + `Range` + WorkManager foreground worker). `ModelDownloader` keeps its `State`/`Progress` contract and `enqueue`/`query`/`cancel` shape (now backed by unique WorkManager work keyed by filename), so the UI diff is small and in-flight transfers stay re-discoverable after process death. Models downloaded by older builds (in the external dir) are still scanned and keep working.

## Test plan (on-device, before merge)

- [ ] Download a small MoE gguf via the paste-URL flow → lands in `filesDir/models`, loads, app reports ioMode **direct (O_DIRECT)** (`o_direct=1`, no fallback line).
- [ ] Force-stop mid-download, reopen → resumes from the `.part` offset (not from 0).
- [ ] Cancel → `.part` removed, row returns to Available.
- [ ] Enqueue with size > free space → clean error, nothing written.
- [ ] Regression: a previously external-dir model still lists and loads (buffered, as before).

## Follow-ups (not in this PR)

- sha256 verification (catalog has no sha field today).
- Optional "move to internal storage" for models already in the external dir.
- UIDT job (API 34+) when targetSdk moves to 35 (6 h dataSync cap).

