### PR TITLE
fix(#70): show a reasoning model's thinking instead of hiding it

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -76,10 +76,10 @@ static void emit_progress_line(const TokenMetrics & m) {
     std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
                 "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
                 "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"dense_resident_frac\":%.3f,"
-                "\"text\":\"%s\"}\n",
+                "\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
                 m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
                 m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
-                m.dense_resident_frac, json_escape(m.text).c_str());
+                m.dense_resident_frac, json_escape(m.reasoning).c_str(), json_escape(m.text).c_str());
     std::fflush(stdout);
 }
 
@@ -291,12 +291,13 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
                     "\"prefill_tps\":%.2f,\"load_s\":%.3f,\"cache_hit_pct\":%.1f,\"n_prompt\":%d,\"n_past\":%d,"
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
                     "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"majflt_tok\":%.2f,\"cpu_s_tok\":%.4f,"
-                    "\"token_demand_mib\":%.1f,\"text\":\"%s\"}\n",
+                    "\"token_demand_mib\":%.1f,\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
-                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, json_escape(r.generated_text).c_str());
+                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, json_escape(r.reasoning_text).c_str(),
+                    json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -59,7 +59,12 @@ struct TokenMetrics {
     int turn = 0; // session turn this token belongs to (0 for a one-shot run)
 
     std::string piece; // text of just this token (delta, for inline streaming)
-    std::string text;  // full generated text so far (for UI streaming)
+    std::string text;  // full generated answer so far, reasoning stripped (for UI streaming)
+    // The reasoning span so far, when the model is thinking and the chat parser separated it from
+    // the answer. Empty with chat off, on a non-reasoning model, or on the harmony no-think path.
+    // Display-only, and kept apart from `text` on purpose: the UI shows it as a distinct thinking
+    // block rather than letting it leak into the answer. See docs/telemetry.md.
+    std::string reasoning;
 };
 
 struct RunSummary {

--- a/core/include/bmoe/runtime.h
+++ b/core/include/bmoe/runtime.h
@@ -25,6 +25,10 @@ struct RunResult {
     bool cancelled = false; // generation was interrupted by Session::cancel() (ok stays true)
     std::string error;
     std::string generated_text;
+    // The reasoning span, when a thinking model's chat template separated it from the answer.
+    // Empty otherwise (chat off, non-reasoning model, harmony no-think). Display-only; the answer
+    // in generated_text already has it stripped. See TokenMetrics::reasoning.
+    std::string reasoning_text;
     RunSummary summary;
     explicit operator bool() const { return ok; }
 };

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -595,17 +595,24 @@ RunResult Session::generate(const GenerateRequest & req,
                     "); open the session with a larger n_ctx");
 
     // The text to surface: with chat on, parse the raw output so a reasoning model's internal
-    // thinking is hidden and only the answer is shown. Generation always uses the raw tokens.
-    auto shown_text = [&](const std::string & raw, bool partial) -> std::string {
-        if (!chat_on) return raw;
+    // thinking is separated from the answer. The answer is shown inline; the reasoning is handed to
+    // the UI as a distinct thinking block rather than dropped, so a Thinking-on run does not sit on a
+    // blank screen while the model reasons. Generation always uses the raw tokens.
+    struct ShownView {
+        std::string content;   // the answer, reasoning stripped
+        std::string reasoning; // the thinking span, empty unless the parser split one out
+    };
+    auto shown_view = [&](const std::string & raw, bool partial) -> ShownView {
+        if (!chat_on) return {raw, ""};
         // Forced-final (harmony no-think) output isn't wrapped in a <|start|>assistant turn, so the
         // structured parser has nothing to strip — the raw stream already IS the final answer.
-        if (forced_final) return raw;
+        if (forced_final) return {raw, ""};
         try {
-            return common_chat_parse(raw, partial, parse_params).content;
+            common_chat_msg msg = common_chat_parse(raw, partial, parse_params);
+            return {msg.content, msg.reasoning_content};
         } catch (const std::exception & e) {
             detail::warn_parse_failed_once(e.what());
-            return raw;
+            return {raw, ""};
         }
     };
 
@@ -779,7 +786,11 @@ RunResult Session::generate(const GenerateRequest & req,
         m.steps = req.n_predict;
         m.wall_ms = wall * 1000.0;
         m.piece = delta;
-        m.text = shown_text(gen, /*partial*/ true);
+        {
+            ShownView sv = shown_view(gen, /*partial*/ true);
+            m.text = std::move(sv.content);
+            m.reasoning = std::move(sv.reasoning);
+        }
         // Fault/CPU decomposition is independent of streaming — dense-weight faults show up in the
         // mmap baseline too — so record it for every token before the moe/no-moe split below.
         m.majflt = f1 - f0;
@@ -872,7 +883,11 @@ RunResult Session::generate(const GenerateRequest & req,
     }
     if (sink) sink->on_summary(s);
 
-    res.generated_text = shown_text(gen, /*partial*/ false);
+    {
+        ShownView sv = shown_view(gen, /*partial*/ false);
+        res.generated_text = std::move(sv.content);
+        res.reasoning_text = std::move(sv.reasoning);
+    }
 
     if (res.cancelled) {
         // Undo the whole turn (KV, fed tokens, and the pushed user message) so the conversation

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,7 +12,7 @@ BMOE_LOAD {"mb":<float>,"ms":<float>}
 BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
                "compute_ms":<float>,"mgmt_ms":<float>,"stall_ms":<float>,"read_mb":<float>,
                "cache_hit_pct":<float>,"majflt":<int>,"cpu_ms":<float>,"dense_resident_frac":<float>,
-               "text":"<string>"}
+               "reasoning":"<string>","text":"<string>"}
 ```
 
 - `BMOE_LOAD` appears only when experts were read this token; `mb` is the flash bytes read,
@@ -64,7 +64,12 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
   `mincore`, throttled). Under `--dense-weights anon` it samples our own buffers (is zram holding
   them?); under mmap/warm the model's mmap (is the kernel dropping it?). A diagnostic read alongside
   `majflt` — nothing acts on it. `-1` when unmeasured.
-- `text` is the full generated text so far, JSON-escaped (for streaming into a UI).
+- `text` is the full generated **answer** so far, JSON-escaped (for streaming into a UI), with any
+  reasoning span stripped out.
+- `reasoning` is the thinking span so far, JSON-escaped, when a reasoning model's chat template
+  separated it from the answer. Empty with chat off, on a non-reasoning model, or when thinking was
+  disabled (`think=false`). It is display-only and kept apart from `text` so a UI can render it as a
+  distinct thinking block rather than inline in the answer.
 
 ## End-of-run lines
 
@@ -254,7 +259,7 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "n_prompt":<int>,"n_past":<int>,"compute_s_tok":<float>,"io_s_tok":<float>,
             "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
             "stall_s_tok":<float>,"mgmt_s_tok":<float>,"majflt_tok":<float>,"cpu_s_tok":<float>,
-            "token_demand_mib":<float>,"text":"<string>"}
+            "token_demand_mib":<float>,"reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
 
@@ -266,7 +271,8 @@ context is. `prefill_tps` is the prompt prefill rate; `compute_s_tok`/`io_s_tok`
 AVERAGES over the run (so a UI can show an average compute-vs-I/O split, not just the last token).
 `cache_resident_mib`/`cache_budget_mib` track the fixed cache, `read_mib` is the
 total flash streamed this generation, and `stall_s_tok`/`mgmt_s_tok` the per-token overlap stall and
-cache-management cost. `BMOE_ERROR` with `fatal:false` is a rejected
+cache-management cost. `text` is the final answer and `reasoning` the final thinking span (empty
+unless the model reasoned), same split as the per-token lines. `BMOE_ERROR` with `fatal:false` is a rejected
 request (e.g. the prompt plus `n_predict` exceeds `n_ctx`) and leaves the session usable;
 `fatal:true` means the process is ending.
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.*
@@ -157,8 +158,10 @@ private fun MainScreen(
     var prompt by rememberSaveable { mutableStateOf("Explain what a mixture-of-experts model is, in two sentences.") }
     val listState = rememberLazyListState()
 
-    // Item 0 is the controls block; the transcript and the in-flight answer follow it.
-    val liveShown = ui.answer.isNotEmpty()
+    // Item 0 is the controls block; the transcript and the in-flight answer follow it. The live
+    // turn also shows while only reasoning has streamed (the thinking phase, before any answer),
+    // so a Thinking-on run does not sit on a blank screen while the model reasons.
+    val liveShown = ui.answer.isNotEmpty() || ui.reasoning.isNotEmpty()
     val total = 1 + ui.transcript.size + (if (liveShown) 1 else 0)
 
     // Follow the tail only while the user is parked at the bottom. A long answer streams for a
@@ -181,7 +184,7 @@ private fun MainScreen(
     LaunchedEffect(listState) {
         snapshotFlow { listState.isScrollInProgress }.collect { scrolling -> if (!scrolling) followTail = atBottom }
     }
-    LaunchedEffect(total, ui.answer.length, followTail) {
+    LaunchedEffect(total, ui.answer.length, ui.reasoning.length, followTail) {
         // A long answer is taller than the viewport, so aligning the item's top would park the view
         // on its beginning; the large offset pins the list to the newest text instead.
         if (followTail && total > 1) runCatching { listState.scrollToItem(total - 1, Int.MAX_VALUE) }
@@ -323,9 +326,10 @@ private fun MainScreen(
             items(ui.transcript.size) { i -> TurnView(ui.transcript[i]) }
 
             // The in-flight assistant answer as it streams (its user turn is already in the transcript).
+            // While generating, keep the thinking block open so the reasoning is visible as it arrives.
             if (liveShown) {
                 item(key = "live") {
-                    TurnView(ChatTurn("assistant", ui.answer))
+                    TurnView(ChatTurn("assistant", ui.answer, reasoning = ui.reasoning), reasoningExpanded = true)
                 }
             }
         }
@@ -341,9 +345,14 @@ private fun MainScreen(
     }
 }
 
-/** One transcript bubble: a small role label and the message, with an optional metrics line. */
+/**
+ * One transcript bubble: a small role label and the message, with an optional metrics line and,
+ * for a reasoning model, a collapsible thinking block above the answer. [reasoningExpanded] seeds
+ * the block open (used for the in-flight turn, so the reasoning is visible as it streams); committed
+ * turns default it closed so the transcript stays readable.
+ */
 @Composable
-private fun TurnView(turn: ChatTurn) {
+private fun TurnView(turn: ChatTurn, reasoningExpanded: Boolean = false) {
     val isUser = turn.role == "user"
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(
@@ -351,6 +360,7 @@ private fun TurnView(turn: ChatTurn) {
             fontSize = 12.sp, fontWeight = FontWeight.Bold,
             color = if (isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.tertiary,
         )
+        if (turn.reasoning.isNotEmpty()) ReasoningBlock(turn.reasoning, reasoningExpanded)
         // The user's own prompt is echoed verbatim; only the model's answer is read as Markdown.
         SelectionContainer {
             if (isUser) Text(turn.text, fontSize = 15.sp) else MarkdownText(turn.text)
@@ -358,6 +368,48 @@ private fun TurnView(turn: ChatTurn) {
         if (turn.metrics.isNotEmpty()) {
             Text(turn.metrics, fontFamily = FontFamily.Monospace, fontSize = 11.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+/**
+ * The model's internal reasoning, rendered as a dimmed, collapsible block distinct from the answer.
+ * A thinking model spends its first tokens here; surfacing it (instead of dropping it, or worse,
+ * letting it leak into the answer) is what makes a Thinking-on run legible while it reasons. Tapping
+ * the header toggles it; [initiallyExpanded] is the starting state.
+ */
+@Composable
+private fun ReasoningBlock(reasoning: String, initiallyExpanded: Boolean) {
+    var expanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.small,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded },
+            ) {
+                Text(
+                    "Thinking", fontSize = 12.sp, fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    if (expanded) "▾" else "▸", fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (expanded) {
+                SelectionContainer {
+                    Text(
+                        reasoning, fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
         }
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -12,14 +12,19 @@ import kotlinx.coroutines.flow.update
  */
 enum class EngineState { IDLE, LOADING, READY, GENERATING, ERROR }
 
-/** One committed message in the multi-turn transcript. metrics is a compact per-turn line. */
-data class ChatTurn(val role: String, val text: String, val metrics: String = "")
+/**
+ * One committed message in the multi-turn transcript. metrics is a compact per-turn line.
+ * reasoning is the model's thinking span (assistant turns only), shown as a collapsible block
+ * above the answer; empty when the model did not reason.
+ */
+data class ChatTurn(val role: String, val text: String, val metrics: String = "", val reasoning: String = "")
 
 /** Immutable snapshot of the session + current generation, observed by the Compose UI. */
 data class UiState(
     val state: EngineState = EngineState.IDLE,
     val telemetry: Telemetry = Telemetry(),
     val answer: String = "",
+    val reasoning: String = "",      // in-flight thinking span; streams before the answer while the model reasons
     val summary: String = "",
     val error: String? = null,
     val ioMode: String? = null,     // effective read mode reported by the engine (direct / buffered)
@@ -45,7 +50,7 @@ object RunBus {
 
     /** Reset the per-generation fields for a new prompt, preserving session state and signature. */
     fun resetGeneration() = _state.update {
-        it.copy(telemetry = Telemetry(), answer = "", summary = "", error = null)
+        it.copy(telemetry = Telemetry(), answer = "", reasoning = "", summary = "", error = null)
     }
 
     fun setState(s: EngineState) = _state.update { it.copy(state = s) }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -209,14 +209,15 @@ class RunService : Service() {
                 main.removeCallbacks(idleUnload)
                 RunBus.update {
                     it.copy(state = EngineState.GENERATING, telemetry = telemetry.current.copy(),
-                        answer = "", summary = "", error = null)
+                        answer = "", reasoning = "", summary = "", error = null)
                 }
                 main.post { notify("Generating…") }
             }
             telemetry.onLine(t) -> {
                 sampleCpuTemp()
                 RunBus.update {
-                    it.copy(telemetry = telemetry.current.copy(), answer = telemetry.current.text)
+                    it.copy(telemetry = telemetry.current.copy(), answer = telemetry.current.text,
+                        reasoning = telemetry.current.reasoning)
                 }
             }
             t.startsWith("BMOE_DONE ") -> onDone(t.removePrefix("BMOE_DONE "))
@@ -246,6 +247,7 @@ class RunService : Service() {
             val ttft = if (loadS >= 0 && prefill >= 0) loadS + prefill else -1.0
             val cancelled = o.optBoolean("cancelled")
             val text = o.optString("text")
+            val reasoning = o.optString("reasoning")
             val loc = java.util.Locale.US
             val summary = buildString {
                 append(String.format(loc, "generation: %d tokens (%.2f tok/s)", tokens, tokS))
@@ -277,12 +279,16 @@ class RunService : Service() {
             )
             RunBus.update {
                 val answer = if (text.isNotEmpty()) text else it.answer
+                // The final BMOE_DONE reasoning may be empty (some models drop it from the summary);
+                // fall back to the last streamed thinking span so the committed turn keeps it.
+                val think = if (reasoning.isNotEmpty()) reasoning else it.reasoning
                 // Commit the assistant turn (skip a cancelled empty turn); the user turn was added on send.
                 val transcript =
-                    if (answer.isNotEmpty() || !cancelled) it.transcript + ChatTurn("assistant", answer, turnMetrics)
+                    if (answer.isNotEmpty() || !cancelled)
+                        it.transcript + ChatTurn("assistant", answer, turnMetrics, think)
                     else it.transcript
-                it.copy(state = EngineState.READY, telemetry = tel, answer = "", summary = summary,
-                    transcript = transcript)
+                it.copy(state = EngineState.READY, telemetry = tel, answer = "", reasoning = "",
+                    summary = summary, transcript = transcript)
             }
         }
         sampleCpuTemp()

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -150,7 +150,10 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
 
             Section("Prompt") {
                 SwitchRow(
-                    "Thinking", "Model reasoning; off passes --no-think (works for Qwen and Gemma)",
+                    "Thinking",
+                    "Let a reasoning model think before answering; its reasoning shows in a " +
+                        "collapsible block above the reply. Off tells the model to skip thinking. " +
+                        "No effect on models that don't reason.",
                     current.thinking,
                 ) { onChange(current.copy(thinking = it)) }
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -26,6 +26,9 @@ data class Telemetry(
     var majflt: Double = 0.0,
     var cpuMs: Double = 0.0,
     var text: String = "",
+    // The thinking span so far when the model is reasoning, kept apart from [text] so the UI can
+    // render it as a distinct block. Empty with thinking off or on a non-reasoning model.
+    var reasoning: String = "",
     // Aggregate decode rate over the whole run, parsed from the final summary line; -1 until
     // generation finishes. The per-token [tokensPerSecond] is instantaneous (last token only),
     // so the UI shows this average once it is available.
@@ -81,6 +84,7 @@ class TelemetryParser {
             current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
             current.majflt = o.optDouble("majflt", 0.0)
             current.cpuMs = o.optDouble("cpu_ms", 0.0)
+            current.reasoning = o.optString("reasoning")
             current.text = o.optString("text")
         }.isSuccess
     }

--- a/tests/chat_parse_test.cpp
+++ b/tests/chat_parse_test.cpp
@@ -137,16 +137,20 @@ int main() {
     expect_true("empty-arena ctor does not strip reasoning (the #49 bug)", !unloaded_stripped);
 
     // Partial parse (the streaming path): mid-reasoning, before "</think>", the answer is not yet
-    // available and no reasoning must leak into the shown content.
+    // available and no reasoning must leak into the shown content — but the reasoning span itself
+    // MUST be exposed so a UI can stream it into a thinking block instead of sitting blank while
+    // the model reasons (issue #70). That is what session.cpp's shown_view surfaces per token.
     bool partial_threw = false;
-    std::string partial_content;
+    common_chat_msg partial;
     try {
-        partial_content = common_chat_parse("I'm\nthink", /*is_partial=*/true, good).content;
+        partial = common_chat_parse("I'm\nthink", /*is_partial=*/true, good);
     } catch (const std::exception &) {
         partial_threw = true;
     }
     expect_true("partial parse mid-reasoning does not throw", !partial_threw);
-    expect_true("partial parse leaks no reasoning into content", partial_content.empty());
+    expect_true("partial parse leaks no reasoning into content", partial.content.empty());
+    expect_true("partial parse exposes the reasoning span for a live thinking block",
+                !partial.reasoning_content.empty());
 
     if (failures == 0) {
         std::printf("all chat-parse checks passed\n");


### PR DESCRIPTION
Fixes #70.

## Problem

Since #49 wired the chat reasoning parser correctly, a thinking model's reasoning is stripped from the shown answer **unconditionally** — even when the user turned Thinking ON. With the in-app Thinking toggle on, the answer area stays blank while the model reasons and only the final answer ever appears; on a slow streamed decode that reads as a hang for the entire thinking span.

The reasoning was parsed and then discarded: `shown_text()` kept only `common_chat_parse(...).content` and dropped `.reasoning_content`, and no field downstream (`TokenMetrics`, the line protocol, the app) carried it.

## Change

Surface the reasoning instead of discarding it, kept apart from the answer end to end so the UI can present it as its own block.

**Engine / protocol**
- `TokenMetrics` gains `reasoning`, `RunResult` gains `reasoning_text`; `session.cpp`'s `shown_view` returns `{content, reasoning}` from a single parse. The partial parse already fills `reasoning_content` incrementally, so it streams token by token.
- `BMOE_PROGRESS` and `BMOE_DONE` carry a `reasoning` field alongside `text` (documented in `docs/telemetry.md`).
- The answer (`text` / `generated_text`) is unchanged — reasoning is still stripped from it — so this is **display-only**.

**App**
- Telemetry/RunBus/RunService parse and stream the reasoning span and commit it with the finished turn.
- The transcript renders it as a dimmed, collapsible **Thinking** block above the answer: open while streaming, collapsed once committed. The live turn now appears during the thinking phase (before any answer text), so a slow reasoning decode no longer looks stuck.
- The Thinking setting description is now model-agnostic — it describes the behaviour rather than naming specific model families.

## Verification

- Host gates: `ctest` all 6 pass, including the byte-identity gates for `qwen3moe` and `gemma4` (unchanged — display-only).
- `tests/chat_parse_test.cpp` extended: asserts a **partial** parse exposes the reasoning span — the contract the live thinking block depends on.
- App Kotlin compiles (`:app:compileDevDebugKotlin`).
- Owed: on-device check in the real app (Thinking on/off on a reasoning model; confirm the harmony no-think path is untouched) before tagging a release.