### PR TITLE
feat(defaults): align n_predict at 128 and fix the app expert cache at 2000 MiB

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -185,7 +185,7 @@ struct SessionCmd {
     enum Kind { kGenerate, kClose } kind;
     std::string prompt;
     int id = 0;
-    int n_predict = 32;
+    int n_predict = 128;
     bool think = true;
     bool clear_kv = true;
 };
@@ -313,7 +313,7 @@ static void print_usage(const char * argv0) {
         "\n"
         "  -m, --model PATH        gguf model (required)\n"
         "  -p, --prompt STR        prompt text\n"
-        "  -n, --n-predict N       tokens to generate (default 32)\n"
+        "  -n, --n-predict N       tokens to generate (default 128)\n"
         "  -t, --threads N         compute threads (default 4)\n"
         "  -c, --ctx-size N        context size (default 2048)\n"
         "      --chatml            wrap the prompt in the model family's chat turn (gemma/chatml)\n"

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -107,7 +107,7 @@ struct MoeStreamConfig {
 struct RunConfig {
     std::string model_path;
     std::string prompt = "The capital of Japan is";
-    int n_predict = 32;
+    int n_predict = 128;
     int n_threads = 4;
     int n_ctx = 2048;
     bool chatml = false;   // wrap the prompt in the model family's chat turn (arch-aware)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -18,11 +18,12 @@ enum class DenseWeights(val flag: String, val label: String, val blurb: String) 
  * flags; the Settings screen edits them and [toArgv] builds the command line.
  */
 data class AppSettings(
-    // Conservative, device-agnostic defaults: an auto-sized expert cache capped at 3000 MiB,
-    // streaming with overlap, 4 compute + 4 read lanes, model's own top-k. No device- or
+    // Predictable, device-agnostic defaults: a fixed 2000 MiB expert cache (reproducible across
+    // runs, unlike Auto which sizes to whatever RAM happens to be free — issue #71), streaming
+    // with overlap, 4 compute + 4 read lanes, model's own top-k. No device- or
     // benchmark-specific tuning — the knobs below let the user tune for their own hardware.
     val mmap: Boolean = false,          // baseline: no streaming — llama.cpp mmap loads the whole model
-    val cacheMb: Int = CACHE_AUTO,      // LRU expert cache budget; Auto / 0 / 500..6000 (see CACHE_CHOICES)
+    val cacheMb: Int = 2000,            // LRU expert cache budget; Auto / 0 / 500..6000 (see CACHE_CHOICES)
     val cacheCeilMb: Int = 3000,        // with cacheMb=Auto: upper bound on the auto budget (0 = no cap)
     val ioThreads: Int = 4,             // parallel expert-read lanes
     val threads: Int = 4,               // compute threads (-t)
@@ -122,8 +123,9 @@ data class AppSettings(
 
         // Tokens to generate per turn, when nothing says otherwise. The service falls back to this
         // for a request that arrives without one, so the default lives here rather than in two
-        // places free to disagree.
-        const val DEFAULT_N_PREDICT = 48
+        // places free to disagree. 128 matches the CLI default (issue #71): shorter budgets
+        // truncate most answers mid-sentence, which reads as broken rather than slow.
+        const val DEFAULT_N_PREDICT = 128
 
         /**
          * A fresh CSV path for a session about to open, under the app's own external files dir —


### PR DESCRIPTION
## Why

Issue #71: the default generation length diverged across surfaces (CLI `n_predict = 32`, app `DEFAULT_N_PREDICT = 48`) and both truncate most answers mid-sentence — the demo feels broken rather than slow. The app''s expert cache defaulted to Auto (ceil 3000), which sizes to whatever RAM happens to be free at load, so first-run impressions and benchmarks varied with unrelated device state.

## What

- `n_predict` defaults to **128** everywhere: `RunConfig` (core), the session-mode per-request fallback (CLI), and `DEFAULT_N_PREDICT` (app). One documented default instead of two free to disagree. Usage text updated.
- The app''s expert cache defaults to a **fixed 2000 MiB** instead of Auto. Predictable and reproducible across runs; 2000 sits above the engine''s 1500 MiB floor so no `--force-cache` is involved. Auto remains selectable in Settings for devices where a fixed budget is the wrong call.

## Open questions from the issue, resolved

- **128 vs 64:** 128 — it is the smallest `NPREDICT_CHOICES` rung at which a typical answer finishes; a fast-but-truncated first impression is worse than a complete one.
- **Shared default:** yes — core `RunConfig` is now the single source; CLI session fallback and app constant match it.
- **Low-RAM regression vs Auto:** fresh installs on tight devices can still pick Auto (or a smaller rung) in Settings; existing installs keep their saved prefs, so nothing changes under anyone already tuned.

## Verification

- Defaults only — no streaming-path or seam change; gates run in CI.
- Existing installs are unaffected (prefs are read with the saved value winning over the default).

Closes #71.