### PR TITLE
feat: add Qwen3.6-35B-A3B to the model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Semantic Versioning.
   after that install cleanly. The distributed artifact is now `app-dev-release.apk`.
 
 ### Added
+- **Qwen3.6-35B-A3B support** (arch `qwen35moe`). A hybrid attention/SSM MoE (256 experts, top-8,
+  41 blocks) whose routed experts stream through the existing `qwen3moe` path unchanged — no engine
+  change, one registry row. Added to the in-app one-tap download catalog. At ~2× device RAM it needs
+  streaming: mmap baseline 0.1 tok/s (fault storm) vs **5.0 tok/s** streamed at the model's own
+  width (cache 3000 MiB, byte-identical output), or **5.8 tok/s** with turbo top-k (`k=6`, lossy).
+  Measured on the OnePlus 15R (indicative 96-token run, not yet the full 256-token protocol); see
+  the README benchmarks section.
 - **Layer-granularity compute trace** (`--compute-trace-layers PATH`). The per-node trace
   (`--compute-trace`) pays ~3000 barriers per token, which serializes the graph against the expert
   stream — on a model that streams heavily it mostly measures its own serialization (Qwen3-30B:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Highlights:
 | Architecture | Reference models | Notes |
 |---|---|---|
 | `qwen3moe` | Qwen3-30B-A3B and siblings | Shipped default, validated below |
+| `qwen35moe` | Qwen3.6-35B-A3B and siblings | Hybrid attention/SSM stack; routed experts stream unchanged |
 | `qwen2moe` | Qwen2 MoE family | Same layout as qwen3moe |
 | `gemma4` | Gemma 4 MoE (e.g. 26B-A4B) | Fused expert layout, handled by its registry row |
 | `gpt-oss` | OpenAI gpt-oss-20b / 120b | Purely routed; MXFP4 weights stream unchanged |
@@ -138,6 +139,30 @@ quality notes are in [docs/benchmarks-gpt-oss.md](docs/benchmarks-gpt-oss.md).
 Cache size is the dominant lever here, and the auto-sized cache with a ceiling
 ([docs/adaptive-cache.md](docs/adaptive-cache.md)) is the winning recipe. The mmap baseline
 averages ~2 tok/s but swings wildly token to token and evicts other apps.
+
+### Qwen3.6-35B-A3B (Q4_K_M) — 22.3 GB
+
+A hybrid attention/SSM MoE (256 experts, top-8, 41 blocks): most layers are linear attention
+(Gated Delta Net) rather than full attention, and the routed experts stream exactly like a plain
+`qwen3moe`. At ~2× device RAM the mmap baseline collapses into a fault storm; streaming with the
+dense weights kept out of the page cache (`--dense-weights anon`) runs it stably.
+
+| Configuration | tok/s | Flash/token | Cache hit |
+|---|---:|---:|---:|
+| mmap baseline (no streaming) | 0.1 (unstable) | — | — |
+| streamed, cache 2000 MiB, 4 lanes, overlap | 4.3 | 206 MiB | 56% |
+| streamed, cache 3000 MiB, 4 lanes, overlap | 5.0 | 144 MiB | 65% |
+| streamed, cache 2000 MiB, *k=6*, 4 lanes, overlap | 5.4 | 137 MiB | 60% |
+| **streamed, cache 3000 MiB, *k=6*, 4 lanes, overlap** | **5.8** | 91 MiB | 68% |
+
+All streamed rows use `--overlap --dense-weights anon`. A larger cache is the main lossless lever
+(cache 3000 is worth +16% over 2000); the *k=6* rows are the one lossy option (turbo top-k, below),
+worth a further ~16% by routing to six experts instead of eight. The lossless best here is cache
+3000 at the model's own width, **5.0 tok/s** — output byte-identical to the resident model.
+
+> Unlike the tables above, these Qwen3.6 figures are a single 96-token run rather than the
+> 256-token best-of protocol — treat them as indicative, and not strictly comparable to the other
+> models until re-measured under the full protocol.
 
 ### Gemma-4-26B-A4B (Q4_K_M) — 17.0 GB
 

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -50,8 +50,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 17
-        versionName '0.10.0'
+        versionCode 18
+        versionName '0.11.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -57,6 +57,15 @@ object ModelCatalog {
             blurb = "3B active of 30B. The published numbers use this one.",
         ),
         Entry(
+            title = "Qwen3.6-35B-A3B",
+            quant = "Q4_K_M",
+            fileName = "Qwen_Qwen3.6-35B-A3B-Q4_K_M.gguf",
+            approxBytes = 22_285_080_192L,
+            url = "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF/resolve/main/" +
+                "Qwen_Qwen3.6-35B-A3B-Q4_K_M.gguf?download=true",
+            blurb = "3B active of 35B. Hybrid attention/SSM, comfortably past RAM.",
+        ),
+        Entry(
             title = "Gemma-4-26B-A4B-it",
             quant = "Q4_K_M",
             fileName = "google_gemma-4-26B-A4B-it-Q4_K_M.gguf",


### PR DESCRIPTION
Adds **Qwen3.6-35B-A3B** (arch `qwen35moe`) as a supported, one-tap model.

## What
- **App**: new `ModelCatalog` entry (one-tap download, ~22.3 GB, HF bartowski Q4_K_M).
- **README**: `qwen35moe` row in *Supported models* + a Qwen3.6 benchmarks subsection.
- **Version**: 0.10.0 → 0.11.0 (versionCode 17 → 18), CHANGELOG entry.

## Why it needs no engine change
Qwen3.6-35B-A3B reports `general.architecture = qwen35moe`, already in the registry — a hybrid
attention/SSM MoE (256 experts, top-8, 41 blocks, Gated Delta Net layers) whose routed experts
stream through the existing `qwen3moe` path unchanged.

## On-device validation (model ~2× RAM)
Streamed, `--overlap --dense-weights anon`, 4 lanes:

| Config | tok/s | Flash/token | Cache hit |
|---|---:|---:|---:|
| mmap baseline (no streaming) | 0.1 | — | — |
| cache 2000 | 4.3 | 206 MiB | 56% |
| cache 3000 | 5.0 | 144 MiB | 65% |
| cache 2000, k=6 | 5.4 | 137 MiB | 60% |
| **cache 3000, k=6** | **5.8** | 91 MiB | 68% |

Output correct and coherent; `--dense-weights anon` eliminates the >RAM fault storm (major faults
per token 0–53 streamed vs ~19k on the mmap baseline).

> Note: these figures are a single 96-token run, not the repo's 256-token best-of protocol — flagged
> as indicative in the README pending a full re-measure.