### PR TITLE
docs: correct stale references left by the WorkManager migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Semantic Versioning.
   governor. The dense anon set is stated to sit outside the cache budget.
 - This changelog is versioned again: every release from 0.1.1 to 0.11.0 now has its own dated
   section instead of accumulating under `[Unreleased]`.
+- Stale references corrected in the Android example: the catalog's `DOWNLOADING` status and the
+  add-model section still named the system DownloadManager, retired when in-app downloads moved to
+  WorkManager, and `MANUAL_ONLY` pointed at an `Entry.notes` field that is named `install`.
+- `RunInfo::dense_weights` no longer advertises a `"warm"` default the engine stopped defaulting to;
+  it now reads `"anon"`, matching `RunConfig`. The member is always overwritten in `Session::open()`,
+  so no emitted telemetry changes.
 
 ## [0.11.0] - 2026-07-19
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -141,7 +141,7 @@ struct RunInfo {
     bool o_direct = false;
     bool overlap = false;
     int prefetch_layers = 0;
-    std::string dense_weights = "warm"; // dense (non-expert) policy: "mmap" | "warm" | "anon"
+    std::string dense_weights = "anon"; // dense (non-expert) policy: "mmap" | "warm" | "anon"
 };
 
 // Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_run_info once before the

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -432,7 +432,7 @@ private fun configSummary(s: AppSettings): String {
 
 /**
  * "Get a model" card: one-tap downloads of the models this engine is measured on ([ModelCatalog]),
- * plus the escape hatches — any gguf URL (DownloadManager) or a file the user already has (SAF
+ * plus the escape hatches — any gguf URL (WorkManager) or a file the user already has (SAF
  * picker). Everything lands in the app models dir with no permission; [onModelReady] triggers a
  * re-scan so the new model shows up in the picker above.
  *

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -34,13 +34,13 @@ object ModelCatalog {
         /** Already on the device — nothing to do. */
         ON_DEVICE,
 
-        /** A DownloadManager job for this file is in flight. */
+        /** A WorkManager download job for this file is in flight. */
         DOWNLOADING,
 
         /** Downloadable, not present yet. */
         AVAILABLE,
 
-        /** Listed for reference; [Entry.notes] carries the manual install recipe. */
+        /** Listed for reference; [Entry.install] carries the manual install recipe. */
         MANUAL_ONLY,
     }
 


### PR DESCRIPTION
Comment-only cleanup found while reviewing everything merged since the repo went public. No behaviour changes.

## What was stale

- `ModelCatalog.Status.DOWNLOADING` and `AddModelSection`'s KDoc still named the system **DownloadManager**, which the in-app download path retired when it moved to WorkManager (#67 / #68).
- `ModelCatalog.Status.MANUAL_ONLY` referenced `[Entry.notes]`; the field is named `install`, so the KDoc link pointed at nothing.
- `RunInfo::dense_weights` defaulted to `"warm"` while `RunConfig` defaults to `Anonymous`. The member is always overwritten in `Session::open()`, so no emitted telemetry changes — the header just advertised a policy the engine stopped defaulting to.

## Verification

Host build clean; `ctest -C Release` 6/6 green (chat_parse, config_validate, and the byte-identity gates for qwen3moe and gemma4).

