### PR TITLE
refactor: lift control logic out of generate() and the Compose UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Changed
+- **Internal cleanup, no behaviour change.** The per-token metrics block moved out of the middle of
+  `Session::generate()` into a `GenTally` that owns the streaming cursors and run totals (the
+  byte-identity gates pass unchanged). In the Android example, download tracking moved out of the
+  composable: `ModelDownloader.events()` streams progress and outcomes over WorkManager's own flow —
+  finalizing a landed `.part` before reporting it — instead of the UI polling on a timer and
+  re-seeding by hand, and the telemetry panel's compute/flash-wait/CPU-occupancy arithmetic is now a
+  pure `breakdown()` next to the contract it implements.
+
 ### Documentation
 - Benchmark tables standardized across the README and `docs/benchmarks.md` (expert count in-table,
   `k` = `n_expert_used` defined in the key and linked to the Turbo top-k section).

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -49,6 +49,94 @@ llama_token argmax(const float * logits, int n_vocab) {
     return best;
 }
 
+// The generation phase's running measurement state, and the one place a generated token's cost is
+// written down. The cursors hold the source's absolute totals as of the previous token — its stats
+// are cumulative across a warm session, so every per-token flash figure is a delta against these —
+// and the totals are what the summary averages over n_gen. Grouped into one object so the per-token
+// metrics block can be a method instead of ten more locals threaded through generate().
+struct GenTally {
+    // Fixed for the run; kept here so record() needs only the token's own measurements.
+    bool overlap = false;
+    int n_threads = 1;
+
+    long long prev_bytes = 0;
+    double prev_io_s = 0.0;
+    double prev_mgmt_s = 0.0;
+    double prev_stall_s = 0.0;
+
+    uint64_t read_bytes = 0;
+    double io_seconds = 0.0;
+    double mgmt_seconds = 0.0;
+    double stall_seconds = 0.0;
+    uint64_t majflt = 0;
+    double cpu_seconds = 0.0;
+
+    // Fill in everything a generated token is measured by — its wall/fault/CPU decomposition, the
+    // memory picture, and (when streaming) the flash figures taken as deltas against the cursors
+    // above — then advance those cursors and the run totals. The token's TEXT stays with the
+    // caller: what a token says depends on chat state, what it cost does not.
+    //
+    // `wall` is the decode's wall time in seconds and `faults`/`cpu_s` the deltas measured around
+    // that same decode; `st` is the expert source's stats, or null when streaming is off.
+    void
+    record(TokenMetrics & m, double wall, uint64_t faults, double cpu_s, int turn, const IExpertSource::Stats * st) {
+        m.wall_ms = wall * 1000.0;
+        // Fault/CPU decomposition is independent of streaming — dense-weight faults show up in the
+        // mmap baseline too — so record it for every token before the moe/no-moe split below.
+        m.majflt = faults;
+        m.cpu_ms = cpu_s * 1000.0;
+        m.majflt_mib = (double) m.majflt * (double) pio::fault_bytes() / (1024.0 * 1024.0);
+        m.turn = turn;
+        majflt += m.majflt;
+        cpu_seconds += cpu_s;
+
+        // Read the memory picture AFTER the decode, outside the caller's timing bracket: two /proc
+        // reads are cheap but they are not this token's work, and billing them to wall_ms would
+        // corrupt the very number the reader is here to trust.
+        pio::ProcessMemory pm;
+        if (pio::process_memory(&pm)) {
+            m.rss_mib = pm.rss_bytes / (1024.0 * 1024.0);
+            m.rss_anon_mib = pm.rss_anon_bytes / (1024.0 * 1024.0);
+            m.rss_file_mib = pm.rss_file_bytes / (1024.0 * 1024.0);
+            m.swap_mib = pm.swap_bytes / (1024.0 * 1024.0);
+        }
+        pio::DeviceMemory dm;
+        if (pio::device_memory(&dm)) {
+            m.mem_available_mib = dm.available_bytes / (1024.0 * 1024.0);
+            m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
+            m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
+        }
+        if (!st) {
+            m.compute_ms = m.wall_ms;
+            m.cache_hit_pct = -1.0;
+            return;
+        }
+
+        m.dense_resident_frac = st->dense_resident_frac;
+        m.cache_budget_mib = st->cache_budget_bytes / (1024.0 * 1024.0);
+        m.read_bytes = (uint64_t) ((long long) st->read_bytes - prev_bytes);
+        m.io_ms = (st->read_seconds - prev_io_s) * 1000.0;
+        m.mgmt_ms = (st->mgmt_seconds - prev_mgmt_s) * 1000.0;
+        if (overlap) {
+            m.stall_ms = (st->stall_seconds - prev_stall_s) * 1000.0 / n_threads;
+            m.compute_ms = m.wall_ms - m.stall_ms - m.mgmt_ms;
+        } else {
+            m.compute_ms = m.wall_ms - m.io_ms - m.mgmt_ms;
+        }
+        if (m.compute_ms < 0) m.compute_ms = 0;
+        m.cache_hit_pct = st->cache_lookups > 0 ? 100.0 * st->cache_hits / st->cache_lookups : -1.0;
+
+        prev_bytes = (long long) st->read_bytes;
+        prev_io_s = st->read_seconds;
+        prev_mgmt_s = st->mgmt_seconds;
+        prev_stall_s = st->stall_seconds;
+        read_bytes += m.read_bytes;
+        io_seconds += m.io_ms / 1000.0;
+        mgmt_seconds += m.mgmt_ms / 1000.0;
+        stall_seconds += m.stall_ms / 1000.0;
+    }
+};
+
 // The names of the expert weight tensors the streamer rebinds. "Dense" is defined by subtraction —
 // everything the model has that is NOT one of these — so both consumers below start by asking this
 // same question, and used to answer it with their own copy of the same triple loop.
@@ -731,20 +819,19 @@ RunResult Session::generate(const GenerateRequest & req,
     // from real per-token deltas (prefill routes near the whole bank, so folding it into a
     // per-token average would badly inflate the flash-I/O figure). In a warm session these
     // counters carry the prior prompts' totals; the deltas make each prompt self-relative.
-    long long prev_bytes = moe.enabled ? (long long) im.source.stats().read_bytes : 0;
-    double prev_io_s = moe.enabled ? im.source.stats().read_seconds : 0.0;
-    double prev_mgmt_s = moe.enabled ? im.source.stats().mgmt_seconds : 0.0;
-    double prev_stall_s = moe.enabled ? im.source.stats().stall_seconds : 0.0;
+    GenTally tally;
+    tally.overlap = moe.overlap;
+    tally.n_threads = im.cfg.n_threads;
+    if (moe.enabled) {
+        const IExpertSource::Stats st0 = im.source.stats();
+        tally.prev_bytes = (long long) st0.read_bytes;
+        tally.prev_io_s = st0.read_seconds;
+        tally.prev_mgmt_s = st0.mgmt_seconds;
+        tally.prev_stall_s = st0.stall_seconds;
+    }
     long long prev_spec_bytes = moe.enabled ? (long long) im.source.stats().spec_read_bytes : 0;
     long long prev_spec_experts = moe.enabled ? im.source.stats().spec_experts : 0;
     long long prev_spec_useful = moe.enabled ? im.source.stats().spec_useful : 0;
-
-    uint64_t gen_read_bytes = 0;
-    double gen_io_seconds = 0.0;
-    double gen_mgmt_seconds = 0.0;
-    double gen_stall_seconds = 0.0;
-    uint64_t gen_majflt = 0;
-    double gen_cpu_seconds = 0.0;
 
     for (int t = 0; t < req.n_predict; ++t) {
         // Greedy stays argmax (byte-identical to the resident reference the gates check); with a
@@ -788,65 +875,14 @@ RunResult Session::generate(const GenerateRequest & req,
         TokenMetrics m;
         m.step = n_gen;
         m.steps = req.n_predict;
-        m.wall_ms = wall * 1000.0;
         m.piece = delta;
         {
             ShownView sv = shown_view(gen, /*partial*/ true);
             m.text = std::move(sv.content);
             m.reasoning = std::move(sv.reasoning);
         }
-        // Fault/CPU decomposition is independent of streaming — dense-weight faults show up in the
-        // mmap baseline too — so record it for every token before the moe/no-moe split below.
-        m.majflt = f1 - f0;
-        m.cpu_ms = (c1 - c0) * 1000.0;
-        m.majflt_mib = (double) m.majflt * (double) pio::fault_bytes() / (1024.0 * 1024.0);
-        m.turn = im.turn;
-        gen_majflt += m.majflt;
-        gen_cpu_seconds += (c1 - c0);
-
-        // Read the memory picture AFTER the decode, outside the s0..s1 bracket: two /proc reads are
-        // cheap but they are not this token's work, and billing them to wall_ms would corrupt the
-        // very number the reader is here to trust.
-        pio::ProcessMemory pm;
-        if (pio::process_memory(&pm)) {
-            m.rss_mib = pm.rss_bytes / (1024.0 * 1024.0);
-            m.rss_anon_mib = pm.rss_anon_bytes / (1024.0 * 1024.0);
-            m.rss_file_mib = pm.rss_file_bytes / (1024.0 * 1024.0);
-            m.swap_mib = pm.swap_bytes / (1024.0 * 1024.0);
-        }
-        pio::DeviceMemory dm;
-        if (pio::device_memory(&dm)) {
-            m.mem_available_mib = dm.available_bytes / (1024.0 * 1024.0);
-            m.mem_free_mib = dm.free_bytes / (1024.0 * 1024.0);
-            m.swap_free_mib = dm.swap_free_bytes / (1024.0 * 1024.0);
-        }
-        if (moe.enabled) {
-            IExpertSource::Stats st = im.source.stats();
-            m.dense_resident_frac = st.dense_resident_frac;
-            m.cache_budget_mib = st.cache_budget_bytes / (1024.0 * 1024.0);
-            m.read_bytes = (uint64_t) ((long long) st.read_bytes - prev_bytes);
-            m.io_ms = (st.read_seconds - prev_io_s) * 1000.0;
-            m.mgmt_ms = (st.mgmt_seconds - prev_mgmt_s) * 1000.0;
-            if (moe.overlap) {
-                m.stall_ms = (st.stall_seconds - prev_stall_s) * 1000.0 / im.cfg.n_threads;
-                m.compute_ms = m.wall_ms - m.stall_ms - m.mgmt_ms;
-            } else {
-                m.compute_ms = m.wall_ms - m.io_ms - m.mgmt_ms;
-            }
-            if (m.compute_ms < 0) m.compute_ms = 0;
-            m.cache_hit_pct = st.cache_lookups > 0 ? 100.0 * st.cache_hits / st.cache_lookups : -1.0;
-            prev_bytes = (long long) st.read_bytes;
-            prev_io_s = st.read_seconds;
-            prev_mgmt_s = st.mgmt_seconds;
-            prev_stall_s = st.stall_seconds;
-            gen_read_bytes += m.read_bytes;
-            gen_io_seconds += m.io_ms / 1000.0;
-            gen_mgmt_seconds += m.mgmt_ms / 1000.0;
-            gen_stall_seconds += m.stall_ms / 1000.0;
-        } else {
-            m.compute_ms = m.wall_ms;
-            m.cache_hit_pct = -1.0;
-        }
+        const IExpertSource::Stats st = moe.enabled ? im.source.stats() : IExpertSource::Stats{};
+        tally.record(m, wall, f1 - f0, c1 - c0, im.turn, moe.enabled ? &st : nullptr);
         if (on_token) on_token(m);
         if (sink) sink->on_token(m);
     }
@@ -863,15 +899,15 @@ RunResult Session::generate(const GenerateRequest & req,
     s.n_past = chat_on ? (int) im.kv_tokens.size() : n_prompt + n_gen; // total context length now
     s.load_seconds = im.load_seconds;
     s.prefill_seconds = prefill_seconds;
-    s.majflt_per_token = n_gen ? (double) gen_majflt / n_gen : 0.0;
-    s.cpu_s_per_token = n_gen ? gen_cpu_seconds / n_gen : 0.0;
+    s.majflt_per_token = n_gen ? (double) tally.majflt / n_gen : 0.0;
+    s.cpu_s_per_token = n_gen ? tally.cpu_seconds / n_gen : 0.0;
     if (moe.enabled) {
         IExpertSource::Stats st = im.source.stats();
-        s.moe_read_mib = gen_read_bytes / (1024.0 * 1024.0);
-        s.moe_io_seconds = gen_io_seconds;
-        s.moe_io_s_per_token = n_gen ? gen_io_seconds / n_gen : 0.0;
-        s.moe_mgmt_s_per_token = n_gen ? gen_mgmt_seconds / n_gen : 0.0;
-        s.moe_stall_s_per_token = n_gen ? gen_stall_seconds / n_gen : 0.0;
+        s.moe_read_mib = tally.read_bytes / (1024.0 * 1024.0);
+        s.moe_io_seconds = tally.io_seconds;
+        s.moe_io_s_per_token = n_gen ? tally.io_seconds / n_gen : 0.0;
+        s.moe_mgmt_s_per_token = n_gen ? tally.mgmt_seconds / n_gen : 0.0;
+        s.moe_stall_s_per_token = n_gen ? tally.stall_seconds / n_gen : 0.0;
         s.moe_compute_s_per_token =
             s.s_per_token - (moe.overlap ? s.moe_stall_s_per_token : s.moe_io_s_per_token) - s.moe_mgmt_s_per_token;
         if (s.moe_compute_s_per_token < 0) s.moe_compute_s_per_token = 0;

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -460,9 +459,9 @@ private fun AddModelSection(
     var open by rememberSaveable { mutableStateOf<Boolean?>(null) }
     LaunchedEffect(scanning) { if (!scanning && open == null) open = models.isEmpty() }
     val isOpen = open == true
-    // filename -> download id (also the filename). Seeded from WorkManager rather than remembered,
-    // so a transfer started before the app was killed is picked back up instead of running unseen.
-    var downloads by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    // The in-flight transfers, by filename. Driven by ModelDownloader's stream rather than
+    // remembered here, so a download started before the app was killed shows up on its own and
+    // finalization/completion is the downloader's business, not this card's.
     var progress by remember { mutableStateOf<Map<String, ModelDownloader.Progress>>(emptyMap()) }
     var importStatus by remember { mutableStateOf<String?>(null) }
     var importFrac by remember { mutableStateOf(-1f) }
@@ -472,9 +471,6 @@ private fun AddModelSection(
     var rowError by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     val present = remember(models) { models.map { it.name }.toSet() }
-    val reseed = { downloads = ModelDownloader.activeDownloads(context) }
-
-    LaunchedEffect(Unit) { reseed() }
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
@@ -492,38 +488,15 @@ private fun AddModelSection(
         }
     }
 
-    // Poll the in-flight downloads; finalize each (.part → .gguf) as it lands and re-scan. The
-    // effect restarts whenever the set changes, which is also how it stops.
-    LaunchedEffect(downloads) {
-        if (downloads.isEmpty()) {
-            progress = emptyMap() // clear the last bar once nothing is in flight
-            return@LaunchedEffect
-        }
-        while (true) {
-            val finished = mutableSetOf<String>()
-            val live = mutableMapOf<String, ModelDownloader.Progress>()
-            for ((name, id) in downloads) {
-                val p = ModelDownloader.query(context, id)
-                when {
-                    p == null -> finished += name
-                    p.state == ModelDownloader.State.SUCCESS -> {
-                        ModelDownloader.finalizeDownload(context, name)
-                        finished += name
-                    }
-                    p.state == ModelDownloader.State.FAILED -> {
-                        error = "$name: ${p.reason ?: "download failed"}"
-                        finished += name
-                    }
-                    else -> live[name] = p
-                }
+    // Follow the downloads. A landed one is already finalized (.part → .gguf) by the time it is
+    // reported here, so this only has to re-scan; a failed one names itself in the error line.
+    LaunchedEffect(Unit) {
+        ModelDownloader.events(context).collect { ev ->
+            when (ev) {
+                is ModelDownloader.Event.InFlight -> progress = ev.downloads
+                is ModelDownloader.Event.Completed -> onModelReady()
+                is ModelDownloader.Event.Failed -> error = "${ev.name}: ${ev.reason}"
             }
-            progress = live
-            if (finished.isNotEmpty()) {
-                downloads = downloads - finished
-                onModelReady()
-                break
-            }
-            delay(700)
         }
     }
 
@@ -534,9 +507,9 @@ private fun AddModelSection(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Column(Modifier.weight(1f)) {
                     Text("Get a model", fontWeight = FontWeight.SemiBold)
-                    if (!isOpen && downloads.isNotEmpty()) {
+                    if (!isOpen && progress.isNotEmpty()) {
                         Text(
-                            "${downloads.size} downloading…",
+                            "${progress.size} downloading…",
                             fontSize = 12.sp,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -549,7 +522,7 @@ private fun AddModelSection(
                 ModelCatalog.entries.forEach { e ->
                     CatalogRow(
                         entry = e,
-                        status = ModelCatalog.statusOf(e, present, downloads.keys),
+                        status = ModelCatalog.statusOf(e, present, progress.keys),
                         progress = progress[e.fileName],
                         installShown = showInstall == e.fileName,
                         error = rowError?.takeIf { it.first == e.fileName }?.second,
@@ -558,15 +531,11 @@ private fun AddModelSection(
                             error = null
                             rowError = null
                             ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
-                                .onSuccess { reseed() }
                                 .onFailure {
                                     rowError = e.fileName to (it.message ?: "download failed to start")
                                 }
                         },
-                        onCancel = {
-                            ModelDownloader.cancel(context, e.fileName)
-                            reseed()
-                        },
+                        onCancel = { ModelDownloader.cancel(context, e.fileName) },
                         onDelete = { deleteTarget = e.fileName },
                     )
                 }
@@ -621,7 +590,6 @@ private fun AddModelSection(
                         onClick = {
                             error = null
                             ModelDownloader.enqueue(context, url)
-                                .onSuccess { reseed() }
                                 .onFailure { error = it.message ?: "invalid URL" }
                         },
                         enabled = url.isNotBlank(),
@@ -635,13 +603,7 @@ private fun AddModelSection(
                 // A pasted URL has no catalog row to show its progress in.
                 progress.filterKeys { k -> ModelCatalog.entries.none { it.fileName == k } }
                     .forEach { (name, p) ->
-                        DownloadProgress(
-                            p,
-                            onCancel = {
-                                ModelDownloader.cancel(context, name)
-                                reseed()
-                            },
-                        )
+                        DownloadProgress(p, onCancel = { ModelDownloader.cancel(context, name) })
                     }
             }
 
@@ -891,55 +853,31 @@ private fun TelemetryCard(ui: UiState, threads: Int, overlap: Boolean, ioThreads
             if (ui.streaming) {
                 // The compute-vs-flash split and cache hit rate only mean anything with the streamer
                 // running. Under mmap the model faults in through the OS page cache, invisible here.
-                // Once done, show the per-token AVERAGE split; while generating, the live last token.
-                val useAvg = done && t.avgComputeMs >= 0
-                val suffix = if (useAvg) " avg" else ""
-                // The wall-additive breakdown: compute + flash-wait + mgmt SUM to the token's wall time,
-                // so tok/s = 1000 / wall is readable straight off the bars.
-                val mgmt = if (useAvg) t.avgMgmtMs.coerceAtLeast(0.0) else t.mgmtMs
-                val wall = if (useAvg) (if (t.avgTokensPerSecond > 0) 1000.0 / t.avgTokensPerSecond else 0.0)
-                           else t.wallMs
-                // Flash wait is the MEASURED wall-additive read term — stall_ms under overlap (the wall
-                // time compute sat idle), io_ms in serial (the blocking read) — and compute is the
-                // leftover. Deriving it this way keeps the clamp on compute (a near-0 compute is honest)
-                // instead of the old wall−compute−mgmt, which silently dumped a clamped-to-0 compute into
-                // "flash wait". The end-of-run average has no per-mode io/stall to read, so it keeps the
-                // residual form.
-                val flashWait: Double
-                val compute: Double
-                if (useAvg) {
-                    compute = t.avgComputeMs
-                    flashWait = (wall - compute - mgmt).coerceAtLeast(0.0)
-                } else {
-                    flashWait = if (overlap) t.stallMs else t.ioMs
-                    compute = (wall - flashWait - mgmt).coerceAtLeast(0.0)
-                }
-                val total = if (wall > 0.0) wall else (compute + flashWait + mgmt)
+                // The split itself — live last token vs run average, and which term is measured
+                // rather than residual — is derived in breakdown(); this only draws it.
+                val b = breakdown(t, overlap, busyThreads = threads + if (overlap) ioThreads else 0)
+                val suffix = if (b.isAverage) " avg" else ""
 
                 // Headline: token time and its inverse, so no mental arithmetic to get tok/s.
-                if (wall > 0.0) {
-                    Text(String.format(Locale.US, "%.0f ms/token  →  %.2f tok/s", wall, 1000.0 / wall),
+                if (b.wallMs > 0.0) {
+                    Text(String.format(Locale.US, "%.0f ms/token  →  %.2f tok/s", b.wallMs, 1000.0 / b.wallMs),
                         fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
                 }
-                MeterRow("compute$suffix", compute, total, MaterialTheme.colorScheme.primary)
-                MeterRow("flash wait$suffix", flashWait, total, MaterialTheme.colorScheme.tertiary)
-                MeterRow("cache mgmt$suffix", mgmt, total, MaterialTheme.colorScheme.secondary)
+                MeterRow("compute$suffix", b.computeMs, b.totalMs, MaterialTheme.colorScheme.primary)
+                MeterRow("flash wait$suffix", b.flashWaitMs, b.totalMs, MaterialTheme.colorScheme.tertiary)
+                MeterRow("cache mgmt$suffix", b.mgmtMs, b.totalMs, MaterialTheme.colorScheme.secondary)
 
-                // Diagnostic line: WHY compute is what it is, plus cache hit. CPU occupancy = CPU-time ÷
-                // (wall × busy threads); near 100% is genuinely compute-bound, well below means a
-                // throttled/preempted core (a frequency cap, a co-resident process). The CPU numerator is
-                // whole-process, so under overlap the I/O lanes count too — the denominator must include
-                // them, or occupancy reads above 100%. Major faults/token > 0 means dense weights
-                // re-faulted from flash inside the decode. Both 0 ⇒ engine couldn't measure.
-                val busyThreads = threads + if (overlap) ioThreads else 0
-                val useAvgCpu = useAvg && t.avgCpuSPerTok >= 0
-                val cpuSTok = if (useAvgCpu) t.avgCpuSPerTok else t.cpuMs / 1000.0
-                val faults = if (useAvgCpu) t.avgMajfltPerTok else t.majflt
+                // Diagnostic line: WHY compute is what it is, plus cache hit. Near 100% busy is
+                // genuinely compute-bound, well below means a throttled/preempted core (a frequency
+                // cap, a co-resident process). Major faults/token > 0 means dense weights re-faulted
+                // from flash inside the decode.
                 val hit = if (t.cacheHitPct >= 0) String.format(Locale.US, "hit %.0f%%", t.cacheHitPct) else "hit —"
                 val diag = buildString {
-                    if (cpuSTok > 0.0 && wall > 0.0 && busyThreads > 0) {
-                        append(String.format(Locale.US, "CPU %.0f%% busy", cpuSTok / (wall / 1000.0 * busyThreads) * 100.0))
-                        if (faults >= 0.0) append(String.format(Locale.US, "  ·  %.0f faults/tok", faults))
+                    if (b.cpuBusyPct >= 0.0) {
+                        append(String.format(Locale.US, "CPU %.0f%% busy", b.cpuBusyPct))
+                        if (b.faultsPerToken >= 0.0) {
+                            append(String.format(Locale.US, "  ·  %.0f faults/tok", b.faultsPerToken))
+                        }
                         append("  ·  ")
                     }
                     append(hit)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
@@ -114,8 +115,11 @@ object ModelDownloader {
      * fire a spurious re-scan for a model the startup scan has already found.
      */
     fun events(ctx: Context): Flow<Event> = flow {
-        val settled = mutableSetOf<String>() // terminal work already accounted for
-        var primed = false                   // has the first (catch-up) emission been processed?
+        // Terminal work already accounted for, keyed by work id rather than filename: WorkManager
+        // re-emits a finished row on every update, but re-downloading the same model (deleted, then
+        // fetched again) is NEW work with a new id and must still report its own completion.
+        val settled = mutableSetOf<UUID>()
+        var primed = false // has the first (catch-up) emission been processed?
         WorkManager.getInstance(ctx).getWorkInfosByTagFlow(DownloadWorker.TAG).collect { infos ->
             val live = mutableMapOf<String, Progress>()
             val outcomes = mutableListOf<Event>()
@@ -131,17 +135,17 @@ object ModelDownloader {
                         info.progress.getLong(DownloadWorker.KEY_TOTAL, -1),
                         State.RUNNING,
                     )
-                    WorkInfo.State.SUCCEEDED -> if (settled.add(name)) {
+                    WorkInfo.State.SUCCEEDED -> if (settled.add(info.id)) {
                         withContext(Dispatchers.IO) { finalizeDownload(ctx, name) }
                         if (primed) outcomes += Event.Completed(name)
                     }
-                    WorkInfo.State.FAILED -> if (settled.add(name) && primed) {
+                    WorkInfo.State.FAILED -> if (settled.add(info.id) && primed) {
                         outcomes += Event.Failed(
                             name,
                             info.outputData.getString(DownloadWorker.KEY_ERROR) ?: "download failed",
                         )
                     }
-                    WorkInfo.State.CANCELLED -> settled.add(name) // user cancelled: no error to surface
+                    WorkInfo.State.CANCELLED -> settled.add(info.id) // user cancelled: no error to surface
                 }
             }
             primed = true

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -11,6 +11,8 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -37,6 +39,17 @@ object ModelDownloader {
         val state: State,
         val reason: String? = null,
     )
+
+    /** What [events] reports. A download ends in exactly one of [Completed] or [Failed]. */
+    sealed interface Event {
+        /** Every transfer still in flight, by filename. Re-emitted on each WorkManager update. */
+        data class InFlight(val downloads: Map<String, Progress>) : Event
+
+        /** [name] landed and is finalized on disk — the caller should re-scan. */
+        data class Completed(val name: String) : Event
+
+        data class Failed(val name: String, val reason: String) : Event
+    }
 
     /**
      * Start a download. Returns the unique-work id (the filename), or an error if the URL doesn't
@@ -81,48 +94,61 @@ object ModelDownloader {
             .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
             .build()
-        // Block until the work is persisted so the caller's immediate activeDownloads() reseed
-        // sees it (a fast local DB write) — otherwise the row wouldn't show as downloading.
+        // Block until the work is persisted (a fast local DB write) so the next events() emission
+        // already carries it — otherwise the row wouldn't show as downloading.
         WorkManager.getInstance(ctx).enqueueUniqueWork(name, ExistingWorkPolicy.KEEP, req).result.get()
         name
     }
 
-    /** Current status of a download, or null if it is unknown, cancelled, or already cleared. */
-    suspend fun query(ctx: Context, name: String): Progress? = withContext(Dispatchers.IO) {
-        runCatching {
-            val info = WorkManager.getInstance(ctx).getWorkInfosForUniqueWork(name).get().lastOrNull()
-                ?: return@runCatching null
-            when (info.state) {
-                WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED ->
-                    Progress(name, name, 0, -1, State.PENDING)
-                WorkInfo.State.RUNNING -> Progress(
-                    name, name,
-                    info.progress.getLong(DownloadWorker.KEY_DONE, 0),
-                    info.progress.getLong(DownloadWorker.KEY_TOTAL, -1),
-                    State.RUNNING,
-                )
-                WorkInfo.State.SUCCEEDED -> Progress(name, name, 0, 0, State.SUCCESS)
-                WorkInfo.State.FAILED -> Progress(
-                    name, name, 0, -1, State.FAILED,
-                    info.outputData.getString(DownloadWorker.KEY_ERROR) ?: "download failed",
-                )
-                WorkInfo.State.CANCELLED -> null // user cancelled: no error to surface
-            }
-        }.getOrNull()
-    }
-
     /**
-     * Model downloads still in flight, as filename -> id (both the filename). WorkManager persists
-     * work across process death, so a download started before the app was killed is picked back up
-     * here instead of running unseen. Never throws — an empty map costs a progress bar, not the
-     * whole screen.
+     * Every download's progress and outcome, as a stream. WorkManager's own flow drives it, so the
+     * UI observes instead of polling, and a transfer started before the app was killed reappears on
+     * the first emission rather than running unseen.
+     *
+     * Finalization lives here, not in the observer: a landed download is renamed .part -> .gguf
+     * before [Event.Completed] is emitted, so by the time anyone re-scans the model is on disk under
+     * its final name.
+     *
+     * Work that was ALREADY terminal when collection started is finalized but reported silently: on
+     * a fresh launch WorkManager still holds the last run's succeeded rows, and replaying them would
+     * fire a spurious re-scan for a model the startup scan has already found.
      */
-    fun activeDownloads(ctx: Context): Map<String, String> = runCatching {
-        WorkManager.getInstance(ctx).getWorkInfosByTag(DownloadWorker.TAG).get()
-            .filter { !it.state.isFinished }
-            .mapNotNull { info -> info.tags.firstOrNull { it.startsWith(NAME_TAG_PREFIX) }?.removePrefix(NAME_TAG_PREFIX) }
-            .associateWith { it }
-    }.getOrDefault(emptyMap())
+    fun events(ctx: Context): Flow<Event> = flow {
+        val settled = mutableSetOf<String>() // terminal work already accounted for
+        var primed = false                   // has the first (catch-up) emission been processed?
+        WorkManager.getInstance(ctx).getWorkInfosByTagFlow(DownloadWorker.TAG).collect { infos ->
+            val live = mutableMapOf<String, Progress>()
+            val outcomes = mutableListOf<Event>()
+            for (info in infos) {
+                val name = info.tags.firstOrNull { it.startsWith(NAME_TAG_PREFIX) }
+                    ?.removePrefix(NAME_TAG_PREFIX) ?: continue
+                when (info.state) {
+                    WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED ->
+                        live[name] = Progress(name, name, 0, -1, State.PENDING)
+                    WorkInfo.State.RUNNING -> live[name] = Progress(
+                        name, name,
+                        info.progress.getLong(DownloadWorker.KEY_DONE, 0),
+                        info.progress.getLong(DownloadWorker.KEY_TOTAL, -1),
+                        State.RUNNING,
+                    )
+                    WorkInfo.State.SUCCEEDED -> if (settled.add(name)) {
+                        withContext(Dispatchers.IO) { finalizeDownload(ctx, name) }
+                        if (primed) outcomes += Event.Completed(name)
+                    }
+                    WorkInfo.State.FAILED -> if (settled.add(name) && primed) {
+                        outcomes += Event.Failed(
+                            name,
+                            info.outputData.getString(DownloadWorker.KEY_ERROR) ?: "download failed",
+                        )
+                    }
+                    WorkInfo.State.CANCELLED -> settled.add(name) // user cancelled: no error to surface
+                }
+            }
+            primed = true
+            outcomes.forEach { emit(it) }
+            emit(Event.InFlight(live))
+        }
+    }
 
     /**
      * Finish a successful download by renaming `<name>.gguf.part` to `<name>.gguf`. The worker
@@ -140,8 +166,8 @@ object ModelDownloader {
 
     /** Cancel a download and delete its leftover .part file. */
     fun cancel(ctx: Context, name: String) {
-        // Block until the cancellation is persisted, so a caller's immediate activeDownloads()
-        // reseed sees the work as finished instead of racing it back in as still-active.
+        // Block until the cancellation is persisted, so the next events() emission reports the work
+        // as finished instead of racing it back in as still-active.
         WorkManager.getInstance(ctx).cancelUniqueWork(name).result.get()
         File(ModelManager.internalModelsDir(ctx), name + DownloadWorker.PART_SUFFIX).delete()
     }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -51,6 +51,76 @@ data class Telemetry(
 }
 
 /**
+ * One token's time, split into the three wall-additive terms the panel draws, plus the diagnostics
+ * that explain the compute term. Derived by [breakdown]; see MetricFields for the same contract as
+ * the CSV states it.
+ */
+data class Breakdown(
+    val wallMs: Double,
+    val computeMs: Double,
+    val flashWaitMs: Double,
+    val mgmtMs: Double,
+    /** These are run averages, not the last token — the panel labels them "avg". */
+    val isAverage: Boolean,
+    /** CPU-time ÷ (wall × busy threads), or -1 when the platform couldn't measure it. */
+    val cpuBusyPct: Double,
+    /** Major faults per token, or -1 when unmeasured. */
+    val faultsPerToken: Double,
+) {
+    /** Denominator for the meter bars: the wall time, or the terms themselves before it is known. */
+    val totalMs: Double get() = if (wallMs > 0.0) wallMs else computeMs + flashWaitMs + mgmtMs
+}
+
+/**
+ * Split a token's wall time into compute / flash-wait / cache-mgmt.
+ *
+ * While generating this reads the live last token; once the run has a summary it switches to the
+ * run averages. The two derive the split differently on purpose. Live, flash wait is the MEASURED
+ * wall-additive read term — stall_ms under overlap (the wall time compute sat idle), io_ms in
+ * serial (the blocking read) — and compute is the leftover, which keeps the clamp on compute so a
+ * near-0 compute stays honest instead of being dumped into "flash wait". The end-of-run average
+ * has no per-mode io/stall to read, so it keeps the residual form.
+ *
+ * [busyThreads] must include the I/O lanes under overlap: the CPU numerator is whole-process, so a
+ * denominator that counts only compute threads reads occupancy above 100%.
+ */
+fun breakdown(t: Telemetry, overlap: Boolean, busyThreads: Int): Breakdown {
+    val useAvg = t.avgTokensPerSecond > 0 && t.avgComputeMs >= 0
+    val mgmt = if (useAvg) t.avgMgmtMs.coerceAtLeast(0.0) else t.mgmtMs
+    val wall = if (useAvg) {
+        if (t.avgTokensPerSecond > 0) 1000.0 / t.avgTokensPerSecond else 0.0
+    } else {
+        t.wallMs
+    }
+    val compute: Double
+    val flashWait: Double
+    if (useAvg) {
+        compute = t.avgComputeMs
+        flashWait = (wall - compute - mgmt).coerceAtLeast(0.0)
+    } else {
+        flashWait = if (overlap) t.stallMs else t.ioMs
+        compute = (wall - flashWait - mgmt).coerceAtLeast(0.0)
+    }
+
+    val useAvgCpu = useAvg && t.avgCpuSPerTok >= 0
+    val cpuSPerTok = if (useAvgCpu) t.avgCpuSPerTok else t.cpuMs / 1000.0
+    val cpuBusy = if (cpuSPerTok > 0.0 && wall > 0.0 && busyThreads > 0) {
+        cpuSPerTok / (wall / 1000.0 * busyThreads) * 100.0
+    } else {
+        -1.0
+    }
+    return Breakdown(
+        wallMs = wall,
+        computeMs = compute,
+        flashWaitMs = flashWait,
+        mgmtMs = mgmt,
+        isAverage = useAvg,
+        cpuBusyPct = cpuBusy,
+        faultsPerToken = if (useAvgCpu) t.avgMajfltPerTok else t.majflt,
+    )
+}
+
+/**
  * Incrementally parses the CLI's per-token telemetry contract (see docs/telemetry.md):
  *   BMOE_LOAD     {"mb":..,"ms":..}
  *   BMOE_PROGRESS {"step":..,"steps":..,"wall_ms":..,"io_ms":..,"compute_ms":..,


### PR DESCRIPTION
Structural cleanup from the same review that produced #79. No behaviour change in any of the three commits.

## Core — `GenTally`

`Session::generate()` carried ten measurement locals and a ~60-line inline block that populated `TokenMetrics` from them, in the middle of the generation loop. Those are now one `GenTally` whose `record()` fills a token's metrics and advances the cursors. The token's *text* stays in the loop — what a token says depends on chat state, what it cost does not.

## Android — download tracking behind a Flow

`AddModelSection` owned the download control loop: a 700 ms polling timer, `.part` → `.gguf` finalization, a second id map alongside the progress map, and manual re-seeding after every enqueue and cancel.

`ModelDownloader.events()` now exposes this as a `Flow` over WorkManager's own, emitting the in-flight set plus a `Completed`/`Failed` outcome per download, and finalizing a landed file before reporting it. The composable collects and renders. Work that was *already* terminal when collection starts is finalized but reported silently, so a relaunch does not replay the last run's downloads as fresh completions. `query()` and `activeDownloads()` lost their last callers and are removed.

## Android — `breakdown()`

`TelemetryCard` mixed drawing with interpretation: the live-vs-average choice, the wall-additive residual (and which of compute or flash-wait is the *measured* term), and the CPU-occupancy arithmetic sat inline between the meter rows, away from the contract `MetricFields` documents. That derivation is now a pure `breakdown()` in `Telemetry.kt`.

## Verification

- Host build clean, `clang-format` 18 clean, `ctest -C Release` **6/6** including the byte-identity gates — the bar that matters for the core commit.
- `compileDevDebugKotlin` clean.

**Still owed: on-device testing before merge.** The gates prove the core refactor is byte-identical, but the download and telemetry changes are UI behaviour that only the real app exercises:
1. Catalog download → live progress, finalize, auto re-scan, model appears in the picker.
2. Kill the app mid-download, reopen → the transfer is still tracked.
3. Relaunch after a completed download → no spurious re-scan or phantom completion.
4. Bad URL → the error names the file and the row clears.
5. A streaming run → the telemetry panel reads the same as before, live and at end-of-run.

