### PR TITLE
feat(arch): register lfm2moe (Liquid AI LFM2 / LFM2.5 MoE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+- **Liquid AI LFM2 / LFM2.5 MoE support** (arch `lfm2moe`, e.g. LFM2.5-8B-A1B, LFM2-24B-A2B). A
+  hybrid short-convolution/attention stack whose routed experts use the standard split expert
+  layout, so it streams through the existing path unchanged — one registry row, no engine change.
+  Two structural notes recorded in `docs/limitations.md`: the leading dense blocks name no expert
+  tensors and stay resident, and the router's per-expert bias (`ffn_exp_probs_b`) applies before the
+  top-k, so the node the engine reads is unaffected. Not added to the in-app download catalog: at
+  ~8B total the model fits in phone RAM, which is not the case the engine exists for.
+
 ## [0.11.1] - 2026-07-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Highlights:
 | `qwen2moe` | Qwen2 MoE family | Same layout as qwen3moe |
 | `gemma4` | Gemma 4 MoE (e.g. 26B-A4B) | Fused expert layout, handled by its registry row |
 | `gpt-oss` | OpenAI gpt-oss-20b / 120b | Purely routed; MXFP4 weights stream unchanged |
+| `lfm2moe` | Liquid AI LFM2 / LFM2.5 MoE (e.g. 8B-A1B) | Hybrid conv/attention stack with leading dense blocks; those stay resident |
 
 Adding an architecture is one row in the registry; expert counts and layouts are discovered from
 the model file at runtime. Procedure: [docs/adding-a-model.md](docs/adding-a-model.md).

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -32,6 +32,15 @@ static const MoeRecipe k_recipes[] = {
     // the tensor's nb[2], whatever the block layout), so the native MXFP4 layout needs no special
     // handling and the split-layout gate (qwen3moe) already covers this streaming path.
     {"gpt-oss", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
+    // lfm2moe (Liquid AI LFM2/LFM2.5 MoE, e.g. 8B-A1B and 24B-A2B) is a hybrid stack like
+    // qwen35moe — some blocks run attention, others a short-convolution block — and it names its
+    // experts with the standard split suffixes, so streaming is one row. Two structural notes: the
+    // first `<arch>.leading_dense_block_count` blocks are dense and name no expert tensors at all,
+    // so they simply never bind and stay mmap-resident; and the router applies a per-expert bias
+    // (ffn_exp_probs_b) before the top-k, which changes which experts are selected but not the
+    // node the hook reads (ffn_moe_topk). Both lower the streamed fraction relative to a purely
+    // routed model — see docs/limitations.md.
+    {"lfm2moe", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
 };
 
 static const int k_n_recipes = (int) (sizeof(k_recipes) / sizeof(k_recipes[0]));

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -28,7 +28,13 @@ serial path, and only a single ~25-line hook (with an explicit sunset) for the o
   `gemma4`) stream the routed experts but keep the shared expert — and any dense layers —
   resident (in the page cache, or in the engine's own buffers under `--dense-weights anon`),
   so the streamed fraction (and the memory saving) is smaller than for a purely routed model
-  like `qwen3moe`.
+  like `qwen3moe`. The same applies to architectures whose first blocks are dense by design
+  (`lfm2moe` has a `leading_dense_block_count`): those blocks name no expert tensors, so they
+  are never streamed.
+- **Streaming does not help a model that fits.** The engine's reason to exist is a model
+  larger than RAM. Registering an architecture says the layout streams losslessly, not that
+  streaming is the fast way to run every model using it — a small MoE that fits in memory is
+  faster loaded resident, and the registry rows are about coverage, not a recommendation.
 - **Repack must stay off.** Loading uses `use_extra_bufts=false`; you cannot combine
   streaming with weight repacking.
 - **Windows throughput.** The cache's reserve-then-commit-per-slice path is heavier on


### PR DESCRIPTION
## What

Adds `lfm2moe` to the architecture registry, so Liquid AI's LFM2 / LFM2.5 MoE models
(LFM2.5-8B-A1B, LFM2-24B-A2B) load under `--moe-stream`. One row, no engine change.

## Why it is one row

LFM2 MoE is a hybrid stack — some blocks run attention, others a short-convolution block —
but the MoE blocks name their experts with the standard split suffixes
(`ffn_{gate,up,down}_exps`) and go through llama.cpp's `build_moe_ffn`, so the routing node
the engine hooks (`ffn_moe_topk-<il>`) is exactly the one it already reads. llama.cpp has
supported the architecture since before the pinned submodule, so no bump is needed.

Two structural properties are documented in the row and in `docs/limitations.md` rather than
left to be rediscovered:

- The first `<arch>.leading_dense_block_count` blocks are dense and name no expert tensors.
  Binding is per-name, so they simply never bind and stay mmap-resident — the same effect a
  shared expert has on the streamed fraction.
- The router applies a per-expert bias (`ffn_exp_probs_b`) before the top-k. It changes which
  experts are selected, not the node the hook observes.

## Scope — what this does not claim

Registering an architecture says the layout streams losslessly. It does not say streaming is
the right way to run these models: at ~8B total, LFM2.5-8B-A1B fits in phone RAM, and a model
that fits is faster loaded resident. The model is deliberately **not** added to the in-app
download catalog, which lists the models the engine is measured on. `docs/limitations.md`
now states the distinction explicitly.

## Verification

- `ctest` — all 6 tests pass, including both byte-identity gates. The split-layout gate
  (`qwen3moe`) already covers this streaming path, as it does for `gpt-oss` and `qwen35moe`;
  `make-tiny-moe.py` emits no lfm2moe fixture, so there is no new gate.
- `clang-format` (18, matching CI) clean.
- `bmoe-cli --list-archs` reports `lfm2moe`.
- On-device run against a real LFM2.5-8B-A1B gguf still owed — this PR is the layout claim,
  not a measurement.

## Docs

`CHANGELOG.md` (Unreleased), README architecture table, `docs/limitations.md`.
