### PR TITLE
fix: honour the Thinking toggle on models whose template ignores enable_thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ Semantic Versioning.
   the tokens spent inside one reasoning block; `-1` unlimited (default), `0` closes it immediately.
   Enforced on logits, so it applies whatever the template supports.
 
+- **Whitespace before a reasoning block no longer leaves the markers in the answer.** The generated
+  PEG parser anchors its reasoning rule immediately after the generation prompt and makes it
+  optional, so a single leading space or newline stops it matching — and the parse still succeeds,
+  with both markers falling through into the content. Suppressing the block made this visible rather
+  than causing it (an empty block is all markers, with no reasoning text to disguise the leak), so
+  the trim applies to normal reasoning spans too. It fires only when whitespace is all that stands
+  between the stream and the opening tag; an answer that legitimately opens with a blank line keeps it.
+
 ### Notes
 - The byte-identity gates pass unchanged: nothing is armed on the raw-prompt path the gates run, so
   the decode loop reduces to exactly the line it replaced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-19
+
+### Fixed
+- **The Thinking toggle is no longer a silent no-op on models whose chat template ignores it**
+  (issue #82). `--no-think` set the template's `enable_thinking` kwarg and stopped there, which is
+  only a *request*: LFM2.5's template never reads the variable, so it rendered the same prompt
+  either way and the model reasoned regardless, with nothing to tell the user. The request is now
+  enforced where the template cannot veto it — a reasoning-budget sampler closes the block on the
+  first token the model opens it with, driven by the thinking tags the loaded model itself reports.
+  gpt-oss keeps its existing primed-final-channel path (it exposes no tags), and templates that do
+  honour the kwarg are untouched, so nothing that already worked changes.
+
+### Added
+- **`think_ctl` in `BMOE_READY`**: which mechanism will honour a `think:false` request for the
+  loaded model — `template`, `forced_final`, `sampler`, or `none`. Decided by rendering the chat
+  template with thinking on and off and comparing, because llama.cpp's published `supports_thinking`
+  cannot answer it (per-handler it is a hardcoded literal meaning "this model can reason"). Probe
+  failures report `template`, so an unknown template is never wrongly accused. The Android app uses
+  it to describe the Thinking switch honestly instead of offering a control that does nothing.
+- **`--reasoning-budget N`** (and the matching `reasoning_budget` field on generate requests): cap
+  the tokens spent inside one reasoning block; `-1` unlimited (default), `0` closes it immediately.
+  Enforced on logits, so it applies whatever the template supports.
+
+### Notes
+- The byte-identity gates pass unchanged: nothing is armed on the raw-prompt path the gates run, so
+  the decode loop reduces to exactly the line it replaced.
+
 ## [0.12.0] - 2026-07-19
 
 ### Added

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -188,6 +188,7 @@ struct SessionCmd {
     int n_predict = 128;
     bool think = true;
     bool clear_kv = true;
+    int reasoning_budget = -1;
 };
 
 // Interactive session: keep the model loaded and the expert cache warm across prompts, reading
@@ -203,8 +204,11 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
         std::fflush(stdout);
         return 1;
     }
-    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d}\n", session->load_seconds(),
-                json_escape(session->arch()).c_str(), session->n_ctx());
+    // think_ctl tells the client which mechanism, if any, will honour a "think":false request for
+    // this model, so a UI can stop offering a control the template silently discards (issue #82).
+    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d,\"think_ctl\":\"%s\"}\n",
+                session->load_seconds(), json_escape(session->arch()).c_str(), session->n_ctx(),
+                think_control_name(session->think_control()));
     std::fflush(stdout);
 
     std::mutex mtx;
@@ -234,6 +238,7 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
                 c.n_predict = json_get_int(line, "n_predict", cfg.n_predict);
                 c.think = json_get_bool(line, "think", cfg.think);
                 c.clear_kv = json_get_bool(line, "clear_kv", true);
+                c.reasoning_budget = json_get_int(line, "reasoning_budget", cfg.reasoning_budget);
             } else {
                 continue;
             }
@@ -270,6 +275,7 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
         req.n_predict = cmd.n_predict;
         req.think = cmd.think;
         req.clear_kv = cmd.clear_kv;
+        req.reasoning_budget = cmd.reasoning_budget;
 
         RunResult r = session->generate(req, emit_progress_line, sink);
         if (!r) {
@@ -317,7 +323,14 @@ static void print_usage(const char * argv0) {
         "  -t, --threads N         compute threads (default 4)\n"
         "  -c, --ctx-size N        context size (default 2048)\n"
         "      --chatml            wrap the prompt in the model family's chat turn (gemma/chatml)\n"
-        "      --no-think          render the chat template with reasoning disabled\n"
+        "      --no-think          suppress reasoning: renders the chat template with thinking\n"
+        "                          disabled, and for templates that ignore that kwarg, closes the\n"
+        "                          reasoning block while decoding instead. --session reports which\n"
+        "                          applies as think_ctl in BMOE_READY\n"
+        "      --reasoning-budget N\n"
+        "                          cap the tokens spent inside one reasoning block (-1 = unlimited,\n"
+        "                          the default; 0 = close it immediately). Enforced on logits, so it\n"
+        "                          works regardless of what the chat template supports\n"
         "      --progress          emit machine telemetry (one JSON line per token)\n"
         "      --session           keep the model loaded and serve JSON prompt requests from stdin\n"
         "      --csv PATH          also write per-token metrics as CSV\n"
@@ -404,6 +417,8 @@ int main(int argc, char ** argv) {
             cfg.chatml = true;
         else if (a == "--no-think")
             cfg.think = false;
+        else if (a == "--reasoning-budget")
+            cfg.reasoning_budget = std::atoi(next("--reasoning-budget"));
         else if (a == "--progress")
             cfg.progress = true;
         else if (a == "--session")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BMOE_HAVE_LLAMA)
         src/moe/router_hook.cpp
         src/engine/session.cpp
         src/engine/chat_parse.cpp
+        src/engine/thinking_control.cpp
         src/engine/runtime.cpp
         src/metrics/csv_metrics_sink.cpp
         src/metrics/route_trace_sink.cpp

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -118,7 +118,17 @@ struct RunConfig {
     // its thinking channel when true. Off suppresses reasoning at the source rather than
     // relying on the display-time parser, which cannot strip a format it does not know.
     // Only meaningful with chatml; the raw-prompt path ignores it.
+    //
+    // Whether it is obeyed is the template's choice: Qwen3-style templates read the kwarg,
+    // LFM2.5 never does. When the template ignores it the engine enforces the request while
+    // decoding instead (see reasoning_budget and Session::think_control).
     bool think = true;
+
+    // Cap on the tokens the model may spend inside a single reasoning block. -1 (the default)
+    // leaves it unlimited; 0 closes the block as soon as the model opens it; N allows N tokens
+    // and then forces the close. Enforced on logits during decoding, so unlike `think` it does
+    // not depend on the template cooperating. Only meaningful with chatml.
+    int reasoning_budget = -1;
 
     // Override the number of active MoE experts per token (top-k routing). 0 = use the
     // model's own <arch>.expert_used_count from the gguf. A lower value cuts per-token

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -53,6 +53,21 @@ struct SessionConfig {
 // remembering to touch both. n_batch = n_ctx so any prompt that fits the context prefills in one batch.
 SessionConfig session_config_from(const RunConfig & cfg);
 
+// How a "no thinking" request can actually be honoured for the loaded model. Setting the
+// template's enable_thinking kwarg is only a request; templates that never read it discard it
+// silently (issue #82). Decided once at open() by observing the template, never by model name.
+enum class ThinkControl {
+    Template,    // the template renders differently with thinking off — honoured at the source
+    ForcedFinal, // harmony/gpt-oss shape: the final channel is primed in the prompt instead
+    Sampler,     // the template ignores the flag, but the model's thinking tags let the engine
+                 // force the block closed while decoding
+    None,        // the flag is ignored and no tags are exposed: the request cannot be honoured
+};
+
+// Stable wire/display name for a control mode: "template" | "forced_final" | "sampler" | "none".
+// Part of the CLI's line protocol (docs/telemetry.md), so these strings are a contract.
+const char * think_control_name(ThinkControl c);
+
 // Per-prompt request. clear_kv=true (the default) makes each prompt independent while the
 // expert cache stays warm; clear_kv=false continues the KV cache for multi-turn chat.
 struct GenerateRequest {
@@ -60,6 +75,10 @@ struct GenerateRequest {
     int n_predict = 32;
     bool think = true;
     bool clear_kv = true;
+    // Cap on the tokens the model may spend inside one reasoning block; -1 leaves it
+    // unlimited. Enforced while decoding, so it applies even to templates that ignore
+    // `think`. Only meaningful with chatml. See RunConfig::reasoning_budget.
+    int reasoning_budget = -1;
 };
 
 class Session {
@@ -99,6 +118,11 @@ public:
     double load_seconds() const;      // model load + streaming setup, measured once at open()
     const std::string & arch() const; // model architecture ("qwen3moe", "gemma4", …)
     int n_ctx() const;
+
+    // Which mechanism honours GenerateRequest::think for this model. Callers surface it so a
+    // user is told when the control is real; None means the request cannot be honoured at all.
+    // Template when chat is off — the raw-prompt path has no template to disagree with.
+    ThinkControl think_control() const;
 
     // Set the expert-cache budget in MiB and evict down to it now. PRECONDITION: no generate() in
     // flight — call it between generations (e.g. from an app's memory-pressure callback). A no-op

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -24,6 +24,10 @@ ValidationResult validate(const RunConfig & cfg) {
     if (cfg.n_ctx <= 0) {
         return fail("n_ctx must be positive");
     }
+    // -1 is the "unlimited" sentinel; 0 (close the block immediately) is a legitimate request.
+    if (cfg.reasoning_budget < -1) {
+        return fail("reasoning_budget must be -1 (unlimited) or >= 0");
+    }
     // Lower bound only: 0 means "use the model default". The upper bound (<= the model's
     // real expert count) needs the loaded gguf, so it is deferred to run() where the model
     // is available — same rationale as the streaming checks that stay out of this pure path.

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -51,6 +51,7 @@ RunResult run(const RunConfig & cfg,
     req.prompt = cfg.prompt;
     req.n_predict = cfg.n_predict;
     req.think = cfg.think;
+    req.reasoning_budget = cfg.reasoning_budget;
     req.clear_kv = true;
 
     return session->generate(req, on_token, sink);

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -635,6 +635,9 @@ RunResult Session::generate(const GenerateRequest & req,
     bool history_pushed = false; // did we append this turn's user message to chat_history?
     bool forced_final = false;   // harmony no-think: primed the final channel, so skip reasoning parse
     common_chat_parser_params parse_params;
+    // This turn's reasoning opener, when the model declares one. Only used to keep whitespace the
+    // model emits ahead of the block from defeating the parser — see reasoning_prefix_offset.
+    std::string think_start_tag;
     // Decode-time enforcement of the thinking request, armed below only for the models that need
     // it. Per-turn (it is bound to this turn's rendered tags and generation prompt) and scoped so
     // every early return — cancel, decode failure, template fallback — frees it.
@@ -659,6 +662,7 @@ RunResult Session::generate(const GenerateRequest & req,
             common_chat_params cp = common_chat_templates_apply(im.chat_tmpls.get(), inputs);
             prompt = cp.prompt;
             parse_params = detail::build_parse_params(cp);
+            think_start_tag = cp.thinking_start_tag;
 
             // gpt-oss / harmony ignores enable_thinking: its template always opens an
             // <|channel|>analysis turn (only the "Reasoning:" effort level is tunable), so a
@@ -727,7 +731,11 @@ RunResult Session::generate(const GenerateRequest & req,
         // structured parser has nothing to strip — the raw stream already IS the final answer.
         if (forced_final) return {raw, ""};
         try {
-            common_chat_msg msg = common_chat_parse(raw, partial, parse_params);
+            // Whitespace ahead of the opening tag would otherwise leave the whole reasoning block
+            // sitting in the answer as literal <think></think> markers (the parser's reasoning rule
+            // is anchored and optional, so it just does not match and the parse still succeeds).
+            const size_t skip = detail::reasoning_prefix_offset(raw, think_start_tag);
+            common_chat_msg msg = common_chat_parse(skip ? raw.substr(skip) : raw, partial, parse_params);
             return {msg.content, msg.reasoning_content};
         } catch (const std::exception & e) {
             detail::warn_parse_failed_once(e.what());

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -3,6 +3,7 @@
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
 #include "chat_parse.h"
+#include "thinking_control.h"
 #include "../moe/router_hook.h"
 #include "../moe/expert_stream_source.h"
 #include "../moe/gguf_offsets.h"
@@ -192,6 +193,13 @@ struct Session::Impl {
     common_chat_templates_ptr chat_tmpls;
     bool backend_inited = false;
 
+    // How a "thinking off" request can be honoured for this model, probed once from the template
+    // at open() (issue #82). Template is the fail-open answer, and the only one the raw-prompt
+    // path can give. Candidate scratch for the forced close, reused to keep it off the per-token
+    // allocation path; only touched on the few steps that actually force.
+    ThinkControl think_ctl = ThinkControl::Template;
+    std::vector<llama_token_data> think_scratch;
+
     // Sampling chain, built once at open() only when sampling is requested (temp > 0); null on the
     // greedy default, where the decode loop stays on the argmax fast path. See open()/generate().
     llama_sampler * smpl = nullptr;
@@ -251,6 +259,9 @@ const std::string & Session::arch() const {
 }
 int Session::n_ctx() const {
     return impl_->cfg.n_ctx;
+}
+ThinkControl Session::think_control() const {
+    return impl_->think_ctl;
 }
 void Session::set_cache_budget_mb(int mib) {
     impl_->source.set_cache_budget((size_t) std::max(0, mib) * 1024ull * 1024ull);
@@ -352,6 +363,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         try {
             im.chat_tmpls = common_chat_templates_init(model, "");
             im.chat_on = true;
+            // Ask the template, once, whether it actually reads enable_thinking — two renders,
+            // amortised over the session. Everything downstream keys on the answer instead of
+            // assuming the kwarg lands (issue #82).
+            im.think_ctl = detail::probe_think_control(im.chat_tmpls.get(), im.vocab);
         } catch (const std::exception & e) {
             std::fprintf(stderr, "bmoe: chat template unavailable (%s); using raw prompts\n", e.what());
             im.chat_on = false;
@@ -620,6 +635,10 @@ RunResult Session::generate(const GenerateRequest & req,
     bool history_pushed = false; // did we append this turn's user message to chat_history?
     bool forced_final = false;   // harmony no-think: primed the final channel, so skip reasoning parse
     common_chat_parser_params parse_params;
+    // Decode-time enforcement of the thinking request, armed below only for the models that need
+    // it. Per-turn (it is bound to this turn's rendered tags and generation prompt) and scoped so
+    // every early return — cancel, decode failure, template fallback — frees it.
+    std::unique_ptr<llama_sampler, void (*)(llama_sampler *)> think_smpl{nullptr, llama_sampler_free};
     if (chat_on) {
         try {
             common_chat_msg user_msg;
@@ -649,14 +668,25 @@ RunResult Session::generate(const GenerateRequest & req,
             // that suffix is unique to it (Qwen/Gemma use different markers), so keying on it
             // leaves every other family's --no-think behaviour untouched.
             if (!req.think) {
-                size_t last = prompt.find_last_not_of(" \t\r\n");
-                std::string trimmed = (last == std::string::npos) ? prompt : prompt.substr(0, last + 1);
-                static const std::string kHarmonyAsst = "<|start|>assistant";
-                if (trimmed.size() >= kHarmonyAsst.size() &&
-                    trimmed.compare(trimmed.size() - kHarmonyAsst.size(), kHarmonyAsst.size(), kHarmonyAsst) == 0) {
+                std::string trimmed;
+                if (detail::ends_with_harmony_assistant(prompt, &trimmed)) {
                     prompt = trimmed + "<|channel|>final<|message|>";
                     forced_final = true;
                 }
+            }
+
+            // Enforcement for the templates that discard enable_thinking outright (issue #82).
+            // The kwarg is only a request; a template that never reads it renders the same
+            // prompt either way and the model reasons on. A reasoning budget is enforced on
+            // logits instead, so it needs no cooperation from the template. It engages only
+            // where the probe found no other mechanism — Template models suppress at the source
+            // and harmony is already handled above, so neither is touched.
+            int budget = req.reasoning_budget; // -1 = unlimited
+            if (!req.think && im.think_ctl == ThinkControl::Sampler) {
+                budget = 0; // close the block the moment the model opens it
+            }
+            if (budget >= 0 && !forced_final) {
+                think_smpl.reset(detail::make_think_budget_sampler(im.vocab, cp, budget));
             }
         } catch (const std::exception & e) {
             std::fprintf(stderr, "bmoe: chat template apply failed (%s); using raw prompt\n", e.what());
@@ -665,6 +695,7 @@ RunResult Session::generate(const GenerateRequest & req,
                 history_pushed = false;
             }
             chat_on = false;
+            think_smpl.reset(); // the raw-prompt fallback has no rendered tags to enforce against
         }
     }
 
@@ -834,10 +865,25 @@ RunResult Session::generate(const GenerateRequest & req,
     long long prev_spec_useful = moe.enabled ? im.source.stats().spec_useful : 0;
 
     for (int t = 0; t < req.n_predict; ++t) {
+        // A reasoning budget, when armed, overrides the choice only on the handful of steps that
+        // force the block closed; every other step falls through untouched. Outside those steps
+        // the sampler is a passthrough, so skipping it entirely (rather than applying it and
+        // relying on it to do nothing) keeps the normal path bit-for-bit what it was — which is
+        // what the byte-identity gates check. They render no template, so nothing is ever armed
+        // there and this reduces to the line it replaced.
+        //
         // Greedy stays argmax (byte-identical to the resident reference the gates check); with a
         // sampling chain, draw from the context's last-position logits, which llama_sampler_sample
         // reads at index -1 — the same logits argmax would have read.
-        llama_token tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, -1) : argmax(logits, im.n_vocab);
+        llama_token tok;
+        if (!think_smpl || !detail::think_forced_token(think_smpl.get(), logits, im.n_vocab, im.think_scratch, tok)) {
+            tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, -1) : argmax(logits, im.n_vocab);
+        }
+        // Every generated token drives the budget's state machine: it is how the opening tag is
+        // spotted, the allowance counted down, and the forced close walked to completion. A forced
+        // token is not fed back into the sampling chain — its stages are stateless bar the dist
+        // RNG, which simply does not advance on a step whose outcome was never in question.
+        if (think_smpl) llama_sampler_accept(think_smpl.get(), tok);
         if (llama_vocab_is_eog(im.vocab, tok)) break;
 
         char piece[256];

--- a/core/src/engine/thinking_control.cpp
+++ b/core/src/engine/thinking_control.cpp
@@ -152,6 +152,22 @@ llama_sampler * make_think_budget_sampler(const llama_vocab * vocab, const commo
     return smpl;
 }
 
+size_t reasoning_prefix_offset(const std::string & raw, const std::string & start_tag) {
+    if (start_tag.empty()) {
+        return 0;
+    }
+    size_t i = 0;
+    while (i < raw.size() && std::isspace((unsigned char) raw[i])) {
+        ++i;
+    }
+    // Only when the whitespace is what stands between the parser and the opening tag; leading
+    // whitespace in an ordinary answer must be left exactly as the model wrote it.
+    if (i > 0 && raw.compare(i, start_tag.size(), start_tag) == 0) {
+        return i;
+    }
+    return 0;
+}
+
 bool think_forced_token(llama_sampler * smpl,
                         const float * logits,
                         int n_vocab,

--- a/core/src/engine/thinking_control.cpp
+++ b/core/src/engine/thinking_control.cpp
@@ -1,0 +1,188 @@
+#include "thinking_control.h"
+
+#include "common.h"
+#include "reasoning-budget.h"
+
+#include <cctype>
+#include <cstdio>
+#include <exception>
+
+namespace bmoe {
+
+const char * think_control_name(ThinkControl c) {
+    switch (c) {
+    case ThinkControl::Template:
+        return "template";
+    case ThinkControl::ForcedFinal:
+        return "forced_final";
+    case ThinkControl::Sampler:
+        return "sampler";
+    case ThinkControl::None:
+        return "none";
+    }
+    return "template";
+}
+
+} // namespace bmoe
+
+namespace bmoe::detail {
+
+namespace {
+
+// Harmony's generation prompt ends with this and no other family's does, so keying on it
+// leaves every other template untouched.
+const std::string kHarmonyAsst = "<|start|>assistant";
+
+// Render a one-turn conversation exactly the way generate() renders a real turn — same jinja
+// path, same reasoning format — so what the probe observes is what generation will produce.
+// The message content is irrelevant: templates branch on the flag, not on the text.
+common_chat_params apply_probe(const common_chat_templates * tmpls, bool enable_thinking) {
+    common_chat_msg user;
+    user.role = "user";
+    user.content = "hi";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = {user};
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
+    inputs.enable_thinking = enable_thinking;
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+
+    return common_chat_templates_apply(const_cast<common_chat_templates *>(tmpls), inputs);
+}
+
+// A tag is usable only if it survives tokenization: the sampler matches token sequences, not
+// text, so a tag the tokenizer cannot produce would arm nothing.
+bool tag_tokenizes(const llama_vocab * vocab, const std::string & tag) {
+    if (tag.empty()) {
+        return false;
+    }
+    if (vocab == nullptr) {
+        return true; // no vocab to check against (probe without a model): trust the tag
+    }
+    return !common_tokenize(vocab, tag, /*add_special=*/false, /*parse_special=*/true).empty();
+}
+
+} // namespace
+
+bool ends_with_harmony_assistant(const std::string & prompt, std::string * trimmed_out) {
+    const size_t last = prompt.find_last_not_of(" \t\r\n");
+    const std::string trimmed = (last == std::string::npos) ? prompt : prompt.substr(0, last + 1);
+    if (trimmed_out != nullptr) {
+        *trimmed_out = trimmed;
+    }
+    return trimmed.size() >= kHarmonyAsst.size() &&
+           trimmed.compare(trimmed.size() - kHarmonyAsst.size(), kHarmonyAsst.size(), kHarmonyAsst) == 0;
+}
+
+ThinkControl probe_think_control(const common_chat_templates * tmpls, const llama_vocab * vocab) {
+    if (tmpls == nullptr) {
+        return ThinkControl::Template;
+    }
+    try {
+        const common_chat_params off = apply_probe(tmpls, /*enable_thinking=*/false);
+
+        // Harmony first: generate() primes the final channel on prompt shape alone, so that
+        // mechanism wins regardless of what the flag does to the render. Reporting anything
+        // else here would name a mechanism that never runs.
+        if (ends_with_harmony_assistant(off.prompt)) {
+            return ThinkControl::ForcedFinal;
+        }
+
+        const common_chat_params on = apply_probe(tmpls, /*enable_thinking=*/true);
+
+        // The whole question, answered empirically: does the flag change the prompt at all?
+        // This is the same render-and-diff llama.cpp's own template analyzer performs. The
+        // published `supports_thinking` flag cannot answer it — per-handler it is a hardcoded
+        // literal reporting "this model can reason", not "this template reads the variable".
+        if (on.prompt != off.prompt) {
+            return ThinkControl::Template;
+        }
+
+        // The flag is inert. The model can still be silenced if it declares where its
+        // reasoning block starts and ends, because that can be enforced on logits.
+        if (tag_tokenizes(vocab, off.thinking_start_tag) && tag_tokenizes(vocab, off.thinking_end_tag)) {
+            return ThinkControl::Sampler;
+        }
+
+        // Flag ignored and no tags to enforce against: the request cannot be honoured. Say so
+        // rather than offering a control that does nothing.
+        return ThinkControl::None;
+    } catch (const std::exception & e) {
+        std::fprintf(stderr, "bmoe: thinking-control probe failed (%s); assuming the template honours it\n", e.what());
+        return ThinkControl::Template;
+    }
+}
+
+llama_sampler * make_think_budget_sampler(const llama_vocab * vocab, const common_chat_params & cp, int32_t budget) {
+    if (vocab == nullptr || cp.thinking_start_tag.empty() || cp.thinking_end_tag.empty()) {
+        return nullptr;
+    }
+
+    const std::vector<llama_token> start = common_tokenize(vocab, cp.thinking_start_tag, false, true);
+    const std::vector<llama_token> end = common_tokenize(vocab, cp.thinking_end_tag, false, true);
+    if (start.empty() || end.empty()) {
+        return nullptr;
+    }
+
+    // Forced sequence = the closing tag: when the budget runs out the model is made to emit
+    // exactly the close it would have written itself, so the reasoning parser still sees a
+    // well-formed (empty) block and the answer stays clean.
+    llama_sampler * smpl = common_reasoning_budget_init(vocab, start, end, /*forced_tokens=*/end, budget);
+    if (smpl == nullptr) {
+        return nullptr;
+    }
+
+    // Replay whatever the template already placed after the last turn boundary. When a
+    // template pre-opens the thinking tag there, the model never samples it, so this is the
+    // only chance the counter has to arm.
+    if (!cp.generation_prompt.empty()) {
+        const std::vector<llama_token> prefill = common_tokenize(vocab, cp.generation_prompt, false, true);
+        for (size_t i = 0; i < prefill.size(); ++i) {
+            const std::string piece = common_token_to_piece(vocab, prefill[i], true);
+            // Some tokenizers prepend a space before a leading special token; feeding it would
+            // desync the matcher against what the model actually emits.
+            if (i == 0 && !piece.empty() && std::isspace((unsigned char) piece[0]) &&
+                !std::isspace((unsigned char) cp.generation_prompt[0])) {
+                continue;
+            }
+            llama_sampler_accept(smpl, prefill[i]);
+        }
+    }
+    return smpl;
+}
+
+bool think_forced_token(llama_sampler * smpl,
+                        const float * logits,
+                        int n_vocab,
+                        std::vector<llama_token_data> & scratch,
+                        llama_token & tok) {
+    if (smpl == nullptr || logits == nullptr || n_vocab <= 0) {
+        return false;
+    }
+    // Outside FORCING the sampler is a passthrough; skipping it entirely keeps the normal
+    // sampling path bit-for-bit what it was before this feature existed.
+    if (common_reasoning_budget_get_state(smpl) != REASONING_BUDGET_FORCING) {
+        return false;
+    }
+
+    scratch.resize((size_t) n_vocab);
+    for (int i = 0; i < n_vocab; ++i) {
+        scratch[(size_t) i] = llama_token_data{i, logits[i], 0.0f};
+    }
+    llama_token_data_array cur = {scratch.data(), scratch.size(), -1, false};
+
+    // Drives every candidate but the pinned one to -inf, so the max is the forced token.
+    llama_sampler_apply(smpl, &cur);
+
+    size_t best = 0;
+    for (size_t i = 1; i < cur.size; ++i) {
+        if (cur.data[i].logit > cur.data[best].logit) {
+            best = i;
+        }
+    }
+    tok = cur.data[best].id;
+    return true;
+}
+
+} // namespace bmoe::detail

--- a/core/src/engine/thinking_control.h
+++ b/core/src/engine/thinking_control.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// How a model honours the "think" request, and the enforcement that makes it true when the
+// chat template does not (issue #82).
+//
+// Setting `enable_thinking = false` only hands a kwarg to the model's Jinja template; whether
+// reasoning is actually suppressed is entirely the template's choice. Qwen3-style templates
+// render a different prompt and honour it; LFM2.5 never reads the variable, so the request was
+// silently discarded and a reasoning model burned its budget on chain-of-thought anyway.
+//
+// Two separable questions, answered here:
+//   * which mechanism can suppress reasoning for THIS model — probe_think_control()
+//   * how to actually suppress it when the template will not — make_think_budget_sampler()
+//
+// Both are derived at runtime from the template's own behaviour and from the tags the loaded
+// model reports; no model names, no template string matching, no per-architecture table.
+//
+// Internal header: includes llama.cpp's `common` (not the stable public API), so it must not
+// be pulled into core/include/bmoe/. See docs/seam.md.
+
+#include "bmoe/session.h"
+
+#include "chat.h"
+#include "llama.h"
+
+#include <string>
+#include <vector>
+
+namespace bmoe::detail {
+
+// Which mechanism, if any, can honour a "no thinking" request for a given chat template.
+// Decided once per session by rendering the template both ways and comparing (see the .cpp).
+// Fails open to Template: an unknown template is assumed to honour the flag, so a probe
+// failure never invents a scary "your toggle does nothing" claim.
+ThinkControl probe_think_control(const common_chat_templates * tmpls, const llama_vocab * vocab);
+
+// True when a rendered prompt ends in harmony's assistant marker ("<|start|>assistant", modulo
+// trailing whitespace) — the shape gpt-oss uses and no other family does. `trimmed_out`, when
+// given, receives the right-trimmed prompt so the caller can append to it without re-trimming.
+bool ends_with_harmony_assistant(const std::string & prompt, std::string * trimmed_out = nullptr);
+
+// Build a reasoning-budget sampler bound to THIS turn's rendered template, or nullptr when the
+// model exposes no usable thinking tags (fail open — better to reason than to force garbage).
+//
+// budget: 0 closes the reasoning block the instant the model opens it; N > 0 allows N tokens
+// then forces the close. The returned sampler is owned by the caller (llama_sampler_free).
+//
+// The generation prompt is replayed through the sampler so a template that pre-opens the
+// thinking tag in the prompt (rather than letting the model emit it) still arms the counter —
+// the tag is never sampled in that case, so without the replay the budget would never engage.
+llama_sampler * make_think_budget_sampler(const llama_vocab * vocab, const common_chat_params & cp, int32_t budget);
+
+// When `smpl` is forcing the close of a reasoning block, resolve the token it is pinning and
+// return true; otherwise return false and leave `tok` untouched, so the caller falls through to
+// its normal sampling path. `scratch` is reused across calls to keep the candidate array off
+// the per-token allocation path.
+bool think_forced_token(llama_sampler * smpl,
+                        const float * logits,
+                        int n_vocab,
+                        std::vector<llama_token_data> & scratch,
+                        llama_token & tok);
+
+} // namespace bmoe::detail

--- a/core/src/engine/thinking_control.h
+++ b/core/src/engine/thinking_control.h
@@ -50,6 +50,16 @@ bool ends_with_harmony_assistant(const std::string & prompt, std::string * trimm
 // the tag is never sampled in that case, so without the replay the budget would never engage.
 llama_sampler * make_think_budget_sampler(const llama_vocab * vocab, const common_chat_params & cp, int32_t budget);
 
+// Drop whitespace that precedes the opening of a reasoning block, returning the offset the
+// parser should start from (0 when there is nothing to trim).
+//
+// A generated PEG parser anchors its reasoning rule immediately after the generation prompt and
+// makes it optional, so a single space or newline emitted before the opening tag stops the rule
+// from matching — and because it is optional, the parse quietly succeeds with the whole block,
+// markers and all, falling through into the answer. Whitespace before a reasoning block is not
+// answer text, so removing it costs nothing and lets the parser see the shape it expects.
+size_t reasoning_prefix_offset(const std::string & raw, const std::string & start_tag);
+
 // When `smpl` is forcing the close of a reasoning block, resolve the token it is pinning and
 // return true; otherwise return false and leave `tok` untouched, so the caller falls through to
 // its normal sampling path. `scratch` is reused across calls to keep the candidate array off

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -90,10 +90,18 @@ unit, `chat_parse.cpp` — the PEG parser arena has to be loaded explicitly or `
 throws on the first token, which is how issue #49 stayed invisible; keeping it separate makes
 that seam unit-testable without a model.
 
+`thinking_control.cpp` sits beside it for the same reason. Asking the template to disable
+reasoning is only a request — a template that never reads `enable_thinking` discards it silently
+(issue #82) — so the engine settles the question by rendering the template both ways and
+comparing, and enforces the request with `common_reasoning_budget_init` when the template will
+not. Both are template-derived, never keyed on a model name, and both are unit-tested against the
+vendored templates with no gguf (`tests/think_control_test.cpp`).
+
 Unlike the public-C-API streaming seam, `common` is **not a stable API** — it can change
 between upstream versions. So a submodule bump may require updating this chat glue in
-`session.cpp` / `chat_parse.cpp`; the build and gates catch a break at compile time rather than
-at runtime (`tests/chat_parse_test.cpp` covers the parser wiring directly). This
+`session.cpp` / `chat_parse.cpp` / `thinking_control.cpp`; the build and gates catch a break at
+compile time rather than at runtime (`tests/chat_parse_test.cpp` and
+`tests/think_control_test.cpp` cover that wiring directly). This
 trade-off is deliberate and is also noted at the link site in the root `CMakeLists.txt`. The
 gates themselves run with the template off (raw prompt), so they stay deterministic and are
 unaffected by this dependency.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -237,13 +237,17 @@ extends to them naturally.
 Requests (stdin):
 
 ```
-{"cmd":"generate","id":<int>,"prompt":"<string>","n_predict":<int>,"think":<bool>,"clear_kv":<bool>}
+{"cmd":"generate","id":<int>,"prompt":"<string>","n_predict":<int>,"think":<bool>,"clear_kv":<bool>,
+ "reasoning_budget":<int>}
 {"cmd":"cancel"}          # interrupt the in-flight generation; the session stays loaded
 {"cmd":"close"}           # end the session (EOF on stdin does the same)
 ```
 
-`prompt` is JSON-escaped (newlines as `\n`); `n_predict`/`think`/`clear_kv` are optional and
-default to the process's flags / `true`. `clear_kv:true` starts a **new chat** (drops the KV and
+`prompt` is JSON-escaped (newlines as `\n`); `n_predict`/`think`/`clear_kv`/`reasoning_budget` are
+optional and default to the process's flags / `true`. `reasoning_budget` caps the tokens the model
+may spend inside one reasoning block (`-1` unlimited, `0` closes it as soon as it opens); it is
+enforced while decoding, so unlike `think` it does not depend on the chat template cooperating.
+`clear_kv:true` starts a **new chat** (drops the KV and
 the engine-held conversation); `clear_kv:false` **continues** the conversation — send only the new
 user message, the engine re-renders the whole history and reuses the KV prefix (see
 [session.md](session.md)). `cancel` may arrive at any time, including mid-generation.
@@ -251,7 +255,8 @@ user message, the engine re-renders the whole history and reuses the KV prefix (
 Responses (stdout):
 
 ```
-BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>}          # once, after the model loads
+BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>,
+            "think_ctl":"template"|"forced_final"|"sampler"|"none"}     # once, after the model loads
 BMOE_BEGIN {"id":<int>}                                                # a generation started
 BMOE_LOAD / BMOE_PROGRESS ...                                          # per token, as above
 BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
@@ -262,6 +267,21 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "token_demand_mib":<float>,"reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
+
+`think_ctl` reports how a `think:false` request will be honoured for the loaded model, decided at
+load by rendering the chat template both ways and comparing. Setting the template's
+`enable_thinking` kwarg is only a *request*: templates that never read it discard it in silence, so
+a client that assumes otherwise shows a control that does nothing (issue #82). The values:
+
+| value | meaning |
+|---|---|
+| `template` | the template renders differently with thinking off — honoured in the prompt |
+| `forced_final` | harmony/gpt-oss: the engine primes the final channel in the prompt instead |
+| `sampler` | the template ignores the request, but the model's thinking tags let the engine force the block closed while decoding |
+| `none` | the request cannot be honoured: the flag is ignored and no tags are exposed |
+
+Only `none` means the control is decorative — surface that rather than offering it. Probe failures
+report `template` (fail open), so an unknown template is never accused of ignoring the flag.
 
 `BMOE_DONE` carries the end-of-generation summary (the one-shot mode's `generation:` /
 `moe-stream:` text lines are not emitted in session mode). `n_prompt` is the tokens actually

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -86,6 +86,19 @@ llama-gguf-split --merge gpt-oss-120b-Q4_K_M-00001-of-00002.gguf gpt-oss-120b-Q4
 adb push gpt-oss-120b-Q4_K_M.gguf /data/local/tmp/bmoe/   # or import it with the file picker
 ```
 
+## Settings
+
+The Settings screen mirrors the CLI flags one-to-one (streaming, cache, I/O lanes, threads,
+top-k, metrics CSV). One control is worth calling out because its effect is model-dependent:
+
+**Thinking.** Off asks a reasoning model to answer without reasoning first. Whether that is obeyed
+is the model's decision, not the app's — the request reaches the model as a chat-template variable,
+and plenty of templates never read it. The engine settles the question at load and reports it, so
+the switch says what it will actually do for the model you loaded: honoured by the template,
+enforced by the engine (either by priming the answer channel, as gpt-oss needs, or by closing the
+reasoning block while decoding, as LFM2.5 needs), or — for a model that offers no way to stop —
+stated plainly as ignored. See `think_ctl` in `../../docs/telemetry.md`.
+
 ## Expected numbers
 
 On a phone with UFS 4.x storage and ~12 GB RAM, streaming Qwen3-30B-A3B-Q4_K_M with the

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -50,8 +50,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 20
-        versionName '0.12.0'
+        versionCode 21
+        versionName '0.13.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -33,7 +33,10 @@ data class AppSettings(
     val overlap: Boolean = true,        // read the next experts while the current layer computes
     val denseWeights: DenseWeights = DenseWeights.ANON, // dense (non-expert) weight residency policy
     val prefetchLayers: Int = 0,        // temporal prefetch depth K (0 = off); needs the cache
-    val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
+    // Reasoning. Per-prompt, so it rides the generate request's "think" field rather than argv.
+    // Whether "off" is obeyed depends on the model; the engine reports which mechanism applies as
+    // think_ctl in BMOE_READY (UiState.thinkCtl) and Settings says so. See issue #82.
+    val thinking: Boolean = false,
     val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
 ) {
     /**

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -117,11 +119,16 @@ private fun Root() {
         scanning = false
     }
 
+    // Only this one field of the session state, so Root does not recompose on every token.
+    val thinkCtl by remember { RunBus.state.map { it.thinkCtl }.distinctUntilChanged() }
+        .collectAsStateWithLifecycle(null)
+
     if (showSettings) {
         SettingsScreen(
             current = settings,
             onChange = { settings = it; it.save(context) },
             onBack = { showSettings = false },
+            thinkCtl = thinkCtl,
         )
     } else if (showMetrics) {
         MetricsScreen(onBack = { showMetrics = false })

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -30,6 +30,11 @@ data class UiState(
     val ioMode: String? = null,     // effective read mode reported by the engine (direct / buffered)
     val cpuTempC: Double? = null,   // SoC/CPU temperature (°C), sampled while generating (battery fallback)
     val sessionSig: String? = null, // signature of the loaded session (AppSettings.sessionSignature)
+    // How the loaded model honours the Thinking switch, reported by the engine at load:
+    // "template" (its chat template obeys), "forced_final"/"sampler" (the engine enforces it), or
+    // "none" — the model ignores the request and there is no way to make it stop. Null until a
+    // session is up. See docs/telemetry.md and issue #82.
+    val thinkCtl: String? = null,
     val transcript: List<ChatTurn> = emptyList(), // committed turns; the in-flight answer is `answer`
     val streaming: Boolean = true,  // is the loaded session using the MoE streamer (vs mmap baseline)?
 ) {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -184,7 +184,7 @@ class RunService : Service() {
                 releaseWake()
                 procWriter = null
                 proc = null
-                if (!shuttingDown) RunBus.update { if (it.state != EngineState.ERROR) it.copy(state = EngineState.IDLE, sessionSig = null) else it.copy(sessionSig = null) }
+                if (!shuttingDown) RunBus.update { if (it.state != EngineState.ERROR) it.copy(state = EngineState.IDLE, sessionSig = null, thinkCtl = null) else it.copy(sessionSig = null, thinkCtl = null) }
                 main.post {
                     stopForegroundCompat()
                     stopSelf()
@@ -199,7 +199,12 @@ class RunService : Service() {
         val t = line.trim()
         when {
             t.startsWith("BMOE_READY ") -> {
-                RunBus.setState(EngineState.READY)
+                // The engine reports here whether the Thinking switch can actually be honoured for
+                // this model; the Settings screen says so rather than offering a dead control (#82).
+                val ctl = runCatching {
+                    JSONObject(t.removePrefix("BMOE_READY ")).optString("think_ctl").ifEmpty { null }
+                }.getOrNull()
+                RunBus.update { it.copy(state = EngineState.READY, thinkCtl = ctl) }
                 main.post { notify("Model ready") }
                 pending?.let { p -> pending = null; sendGenerate(p) } ?: scheduleIdleUnload()
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -15,10 +15,19 @@ import androidx.compose.ui.unit.sp
 /**
  * Groups every tunable the engine exposes. Changes are applied to [current] live and
  * persisted by the caller. The layout mirrors the CLI flags one-to-one.
+ *
+ * [thinkCtl] is the engine's verdict on whether the Thinking switch can be honoured by the
+ * loaded model (UiState.thinkCtl); null when no session is loaded, in which case the switch is
+ * described in general terms because the answer is model-dependent.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack: () -> Unit) {
+fun SettingsScreen(
+    current: AppSettings,
+    onChange: (AppSettings) -> Unit,
+    onBack: () -> Unit,
+    thinkCtl: String? = null,
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -149,11 +158,21 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
             }
 
             Section("Prompt") {
+                // Whether "off" is obeyed is the model's call, not ours: a chat template that never
+                // reads the request renders the same prompt either way. The engine probes that at
+                // load and reports it, so the switch can say what it will actually do (issue #82).
+                val thinkingNote = when (thinkCtl) {
+                    "none" ->
+                        " This model ignores the request and offers no way to stop it, so it will " +
+                            "reason anyway — its reasoning still shows separately from the answer."
+                    "sampler", "forced_final" -> " The engine enforces this for the loaded model."
+                    else -> " No effect on models that don't reason."
+                }
                 SwitchRow(
                     "Thinking",
                     "Let a reasoning model think before answering; its reasoning shows in a " +
-                        "collapsible block above the reply. Off tells the model to skip thinking. " +
-                        "No effect on models that don't reason.",
+                        "collapsible block above the reply. Off tells the model to skip thinking." +
+                        thinkingNote,
                     current.thinking,
                 ) { onChange(current.copy(thinking = it)) }
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,18 @@ target_compile_definitions(bmoe_chat_parse_test PRIVATE
     BMOE_QWEN3_TEMPLATE_PATH="${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates/Qwen3.5-4B.jinja")
 add_test(NAME chat_parse COMMAND bmoe_chat_parse_test)
 
+# Thinking-control probe (issue #82). Needs no model either — it classifies real vendored
+# templates, one per regime: honours the flag (Qwen3), ignores it but exposes tags (LFM2.5),
+# no tags and a primed final channel instead (gpt-oss).
+add_executable(bmoe_think_control_test think_control_test.cpp)
+target_link_libraries(bmoe_think_control_test PRIVATE bmoe_core)
+target_include_directories(bmoe_think_control_test PRIVATE ${CMAKE_SOURCE_DIR}/core/src/engine)
+target_compile_definitions(bmoe_think_control_test PRIVATE
+    BMOE_QWEN3_TEMPLATE_PATH="${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates/Qwen3.5-4B.jinja"
+    BMOE_LFM25_TEMPLATE_PATH="${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates/LFM2.5-8B-A1B.jinja"
+    BMOE_GPTOSS_TEMPLATE_PATH="${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates/openai-gpt-oss-120b.jinja")
+add_test(NAME think_control COMMAND bmoe_think_control_test)
+
 # validate() unit tests (issue #51 + the pre-existing rules). Pure config, no model — runs
 # unconditionally, and makes good on config.h's "unit-tested" claim.
 add_executable(bmoe_config_test config_test.cpp)

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -77,6 +77,23 @@ int main() {
         c.n_expert_used = -1;
         expect_fail("n_expert_used must be >= 0", c);
     }
+    // reasoning_budget: -1 is the "unlimited" sentinel and 0 ("close the block at once") is a
+    // real request, so only values below the sentinel are nonsense.
+    {
+        RunConfig c = ok_base();
+        c.reasoning_budget = -2;
+        expect_fail("reasoning_budget below the unlimited sentinel", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.reasoning_budget = 0;
+        expect_ok("reasoning_budget 0 suppresses reasoning", c);
+    }
+    {
+        RunConfig c = ok_base();
+        c.reasoning_budget = 512;
+        expect_ok("reasoning_budget caps reasoning", c);
+    }
 
     // Streaming rules.
     {

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -1,0 +1,158 @@
+// Regression test for the thinking-control probe (issue #82).
+//
+// The bug: `--no-think` set the template's enable_thinking kwarg and stopped there. A template
+// that never reads the variable (LFM2.5) renders the same prompt either way, so the request was
+// discarded in silence and a reasoning model spent its budget reasoning anyway. Worse, nothing
+// could tell the difference — llama.cpp's own `supports_thinking` is a hardcoded per-handler
+// literal meaning "this model can reason", not "this template reads the flag".
+//
+// The fix answers it empirically: render the template with thinking on and off and compare. This
+// drives that classifier against three real vendored templates, one per regime, with no model —
+// the whole point is that the decision is testable without a gguf. Assertions are explicit (not
+// <cassert>) because the Release gates build with NDEBUG, which would compile assert() out.
+
+#include "thinking_control.h"
+
+#include "chat.h"
+#include "common.h"
+
+#include <cstdio>
+#include <exception>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+// Real templates from the vendored submodule (paths injected by CMake). Hand-rolled stubs do not
+// reliably reproduce how the handlers populate thinking tags, so the genuine files are used; a
+// submodule bump that moves or changes them fails here loudly rather than rotting.
+#if !defined(BMOE_QWEN3_TEMPLATE_PATH) || !defined(BMOE_LFM25_TEMPLATE_PATH) || !defined(BMOE_GPTOSS_TEMPLATE_PATH)
+#error "template paths must be defined by the build"
+#endif
+
+static int failures = 0;
+
+static void expect_true(const char * name, bool cond) {
+    if (cond) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+static void expect_ctl(const char * name, bmoe::ThinkControl got, bmoe::ThinkControl want) {
+    if (got == want) {
+        std::printf("[PASS] %s (%s)\n", name, bmoe::think_control_name(got));
+    } else {
+        std::printf("[FAIL] %s\n  got:  %s\n  want: %s\n", name, bmoe::think_control_name(got),
+                    bmoe::think_control_name(want));
+        ++failures;
+    }
+}
+
+static std::string read_file(const char * path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        std::printf("[FAIL] cannot open template: %s\n", path);
+        ++failures;
+        return {};
+    }
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+// Probe a template file the way a session would, minus the model: no vocab, so tag usability is
+// taken on trust (a loaded model tightens that by checking the tags tokenize).
+static bmoe::ThinkControl probe_file(const char * path) {
+    const std::string tmpl = read_file(path);
+    if (tmpl.empty()) {
+        return bmoe::ThinkControl::None;
+    }
+    auto tmpls = common_chat_templates_init(/*model=*/nullptr, tmpl);
+    return bmoe::detail::probe_think_control(tmpls.get(), /*vocab=*/nullptr);
+}
+
+// The applied params for a template, to assert what the classifier saw.
+static common_chat_params apply(const char * path, bool enable_thinking) {
+    const std::string tmpl = read_file(path);
+    auto tmpls = common_chat_templates_init(/*model=*/nullptr, tmpl);
+
+    common_chat_msg user;
+    user.role = "user";
+    user.content = "hi";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = {user};
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
+    inputs.enable_thinking = enable_thinking;
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    return common_chat_templates_apply(tmpls.get(), inputs);
+}
+
+int main() {
+    using bmoe::ThinkControl;
+
+    // Qwen3: reads enable_thinking and prefills the opening tag when on, so the two renders differ
+    // and the request is honoured where it is cheapest — in the prompt.
+    expect_ctl("qwen3 template honours enable_thinking", probe_file(BMOE_QWEN3_TEMPLATE_PATH), ThinkControl::Template);
+    expect_true("qwen3 renders differ across the flag",
+                apply(BMOE_QWEN3_TEMPLATE_PATH, true).prompt != apply(BMOE_QWEN3_TEMPLATE_PATH, false).prompt);
+
+    // LFM2.5: the case from issue #82. The flag changes nothing, but the model declares where its
+    // reasoning block begins and ends, which is enough to enforce the request while decoding.
+    expect_ctl("lfm2.5 needs decode-time enforcement", probe_file(BMOE_LFM25_TEMPLATE_PATH), ThinkControl::Sampler);
+    {
+        const common_chat_params on = apply(BMOE_LFM25_TEMPLATE_PATH, true);
+        const common_chat_params off = apply(BMOE_LFM25_TEMPLATE_PATH, false);
+        expect_true("lfm2.5 renders are identical across the flag (the silent no-op)", on.prompt == off.prompt);
+        expect_true("lfm2.5 exposes thinking tags to enforce against",
+                    !off.thinking_start_tag.empty() && !off.thinking_end_tag.empty());
+    }
+
+    // gpt-oss: no thinking tags at all; suppression happens by priming the final channel in the
+    // prompt, which generate() keys on the harmony marker to do.
+    expect_ctl("gpt-oss uses the primed final channel", probe_file(BMOE_GPTOSS_TEMPLATE_PATH),
+               ThinkControl::ForcedFinal);
+
+    // The harmony marker check itself: trailing whitespace must not hide it, and a chatml tail
+    // must not be mistaken for it (that would prime a channel no other family understands).
+    expect_true("harmony marker survives trailing whitespace",
+                bmoe::detail::ends_with_harmony_assistant("...<|start|>assistant\n  "));
+    expect_true("chatml tail is not harmony", !bmoe::detail::ends_with_harmony_assistant("<|im_start|>assistant\n"));
+    {
+        std::string trimmed;
+        bmoe::detail::ends_with_harmony_assistant("abc<|start|>assistant \n", &trimmed);
+        expect_true("harmony check returns the right-trimmed prompt", trimmed == "abc<|start|>assistant");
+    }
+
+    // The fourth regime: a plain template that ignores the flag and declares no reasoning tags.
+    // Nothing can honour the request here, and saying so is the entire point — an engine that
+    // reported "template" would be repeating the lie issue #82 was filed about.
+    {
+        const std::string plain = "{% for m in messages %}<|im_start|>{{ m.role }}\n{{ m.content }}<|im_end|>\n"
+                                  "{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}";
+        auto tmpls = common_chat_templates_init(/*model=*/nullptr, plain);
+        expect_ctl("a template with no thinking support reports none",
+                   bmoe::detail::probe_think_control(tmpls.get(), nullptr), ThinkControl::None);
+    }
+
+    // Fail open on the defensive path: with nothing to probe, assume the template honours the
+    // flag. Claiming "your switch does nothing" on a guess is worse than staying quiet.
+    expect_ctl("null templates fail open", bmoe::detail::probe_think_control(nullptr, nullptr), ThinkControl::Template);
+
+    // The wire names are a protocol contract (docs/telemetry.md), not a debug string.
+    expect_true("wire names are stable",
+                std::string(bmoe::think_control_name(ThinkControl::Template)) == "template" &&
+                    std::string(bmoe::think_control_name(ThinkControl::ForcedFinal)) == "forced_final" &&
+                    std::string(bmoe::think_control_name(ThinkControl::Sampler)) == "sampler" &&
+                    std::string(bmoe::think_control_name(ThinkControl::None)) == "none");
+
+    if (failures == 0) {
+        std::printf("all thinking-control checks passed\n");
+        return 0;
+    }
+    std::printf("%d thinking-control check(s) failed\n", failures);
+    return 1;
+}

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -13,6 +13,8 @@
 
 #include "thinking_control.h"
 
+#include "chat_parse.h"
+
 #include "chat.h"
 #include "common.h"
 
@@ -141,6 +143,60 @@ int main() {
     // Fail open on the defensive path: with nothing to probe, assume the template honours the
     // flag. Claiming "your switch does nothing" on a guess is worse than staying quiet.
     expect_ctl("null templates fail open", bmoe::detail::probe_think_control(nullptr, nullptr), ThinkControl::Template);
+
+    // The block the enforcement actually produces must parse. Forcing the close the instant the
+    // model opens the block yields an EMPTY reasoning span, which is a different shape from the
+    // one the parser sees in normal use — if it does not match, the markers leak into the answer
+    // verbatim and the user reads "<think></think>" instead of a clean reply.
+    {
+        const common_chat_params cp = apply(BMOE_LFM25_TEMPLATE_PATH, false);
+        common_chat_parser_params pp = bmoe::detail::build_parse_params(cp);
+        // Whitespace before the opening tag is the shape that bites: the parser's reasoning rule is
+        // anchored right after the generation prompt and is optional, so one leading space makes it
+        // silently not match and the markers land in the answer. That is what reasoning_prefix_offset
+        // exists to absorb, so parse through it exactly as session.cpp does.
+        for (const char * raw : {"<think></think>Hello", "<think>\n</think>Hello", "<think> </think>Hello",
+                                 "\n<think></think>Hello", " <think></think>Hello", "  \n<think> </think>Hello"}) {
+            const std::string s = raw;
+            const size_t skip = bmoe::detail::reasoning_prefix_offset(s, cp.thinking_start_tag);
+            common_chat_msg m;
+            bool threw = false;
+            try {
+                m = common_chat_parse(skip ? s.substr(skip) : s, /*is_partial=*/false, pp);
+            } catch (const std::exception & e) {
+                threw = true;
+                std::printf("  parse threw on \"%s\": %s\n", raw, e.what());
+            }
+            expect_true("forced-close block parses", !threw);
+            expect_true("forced-close block leaves no markers in the answer", m.content == "Hello");
+        }
+
+        // The trim is surgical: it fires only when whitespace is all that separates the stream from
+        // the opening tag. An answer that legitimately starts with a blank line keeps it.
+        expect_true("ordinary leading whitespace is preserved",
+                    bmoe::detail::reasoning_prefix_offset("\n  Hello", cp.thinking_start_tag) == 0);
+        expect_true("no trim when the block opens the stream",
+                    bmoe::detail::reasoning_prefix_offset("<think></think>Hi", cp.thinking_start_tag) == 0);
+        expect_true("no tag, no trim", bmoe::detail::reasoning_prefix_offset(" <think>x", "") == 0);
+
+        // The streaming path. The app renders the partial parse token by token, so what the user
+        // reads mid-stream is this, not the final message: an opening tag whose block has not
+        // closed yet must not be shown as answer text.
+        for (const char * raw : {"<think>", "<think></think>", "<think></think>Hel"}) {
+            common_chat_msg m;
+            bool threw = false;
+            try {
+                m = common_chat_parse(raw, /*is_partial=*/true, pp);
+            } catch (const std::exception & e) {
+                threw = true;
+                std::printf("  partial parse threw on \"%s\": %s\n", raw, e.what());
+            }
+            std::printf("  partial raw=\"%s\" -> content=\"%s\" reasoning=\"%s\"%s\n", raw, m.content.c_str(),
+                        m.reasoning_content.c_str(), threw ? " (THREW)" : "");
+            expect_true("streamed forced close shows no markers as answer text",
+                        !threw && m.content.find("think>") == std::string::npos);
+        }
+    }
 
     // The wire names are a protocol contract (docs/telemetry.md), not a debug string.
     expect_true("wire names are stable",


### PR DESCRIPTION
Closes #82.

The Thinking toggle only ever set the chat template's `enable_thinking` kwarg. That is a
*request*, and a template is free to ignore it — LFM2.5's never reads the variable, so it
rendered an identical prompt either way and the model reasoned on, with nothing to tell the
user the request had been dropped.

Following the direction settled in the issue: detection and enforcement are separate
questions, and both are needed. The sampler alone leaves a UI unable to say when the toggle is
real; the probe alone cannot stop a model that has no off switch.

## Detection — `probe_think_control`

Renders the template with thinking on and off and compares. This is the only honest way to ask
the question, and it is what llama.cpp's own template analyzer does internally. The published
`common_chat_templates_support_enable_thinking()` cannot answer it: for any template matching a
known handler `supports_thinking` is a hardcoded literal (`true` at nine sites), reporting
"this model can reason" rather than "this template reads the flag".

Runs once per session, classifying into four regimes:

| `think_ctl` | meaning |
|---|---|
| `template` | renders differently with thinking off — honoured in the prompt (Qwen3/3.6) |
| `forced_final` | harmony/gpt-oss: the engine primes the final channel instead |
| `sampler` | flag ignored, but the model's thinking tags let the engine force the close (LFM2.5) |
| `none` | flag ignored and no tags: the request cannot be honoured |

Reported in `BMOE_READY` so a client can stop offering a control that does nothing. Failures
fail open to `template` — an unknown template is never accused of ignoring the flag.

## Enforcement — `make_think_budget_sampler`

llama.cpp's reasoning-budget sampler, driven by the tags the loaded model reports. It acts on
logits, so it never asks the template's permission — precisely the failure in this issue. With
budget 0 it closes the block on the first token the model opens it with; the model emits
`<think></think>` and the reasoning parser yields an empty block and a clean answer.

It arms only where the probe found no other mechanism, so templates that already honour the
flag and harmony models are untouched. `--reasoning-budget N` generalises it to a cap rather
than all-or-nothing, and rides generate requests as `reasoning_budget`.

Nothing here keys on a model name or a template pattern — the tags, the generation prompt and
the verdict all come from the loaded model (hard rule 4). `common/reasoning-budget.h` is
already in the pinned submodule's build and `llama-common` is already linked, so this is not a
llama.cpp patch and needs no build changes (hard rule 1).

## No regressions

The byte-identity gates pass unchanged, and by construction rather than by luck: they render no
template, so nothing is ever armed and the decode line reduces to exactly the ternary it
replaced. Outside the few forcing steps the sampler is a passthrough and is skipped entirely
rather than applied and trusted to do nothing. One documented deviation from upstream's
composition: forced steps bypass the sampling chain (result-equivalent, since only one
candidate survives), so the dist RNG does not advance on a step whose outcome was never in
question.

## Tests

`tests/think_control_test.cpp` — model-free, mirroring `chat_parse_test`: classifies the three
real vendored templates one per regime (Qwen3 → `template`, LFM2.5 → `sampler` with identical
renders and `<think>`/`</think>` tags, gpt-oss → `forced_final`), plus the no-support case,
the harmony-marker edge cases, fail-open, and the wire-name contract. Local run: all 7 ctest
tests green, including both `moe_gates` fixtures.

## Still owed before release

The on-device A/B through the app: LFM2.5 with the toggle off should produce no thinking block,
toggle on unchanged, and Qwen3.6/gpt-oss unchanged in both states. Host gates prove the wiring,
not the behaviour on a real gguf.
