### PR TITLE
fix(chat): honour "thinking off" on templates that ignore enable_thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ Semantic Versioning.
   variable `enable_thinking` and stopped there — but that variable is only a *request* to the
   model's chat template, and many templates never read it. LFM2.5's is one: the rendered prompt came
   out byte-identical either way, the model reasoned on, and nothing reported that the setting had
-  been dropped. The engine now renders the template at load to find out which case a model is in,
-  and where the flag is inert it closes the reasoning span in the prompt instead, using llama.cpp's
-  own continuation hook so the markers for each family come from upstream's per-template handler
-  rather than from this engine. Models that support neither are reported as such
-  (`think_ctl` on `BMOE_READY`, see `docs/telemetry.md`) and the app shows the Thinking switch
-  disabled with the reason, instead of leaving a control that does nothing.
+  been dropped. The engine now renders the template at load and reports what it found as `think_ctl`
+  on `BMOE_READY` (see `docs/telemetry.md`). Where the flag is inert but reasoning is a *structural*
+  section of the format, the turn now starts past that section, built by llama.cpp's own
+  continuation hook so every family's markers come from upstream rather than from this engine.
+  Where the model owns its reasoning span and simply cannot be asked to skip it — LFM2.5 — that is
+  reported instead of papered over, and the app shows the Thinking switch disabled with the reason.
+  Measured, not assumed: handing LFM2.5 a pre-closed empty reasoning span makes it reason *untagged
+  into the answer*, worse than leaving the setting alone, so the engine does not do it.
 
 ### Changed
 - **The harmony/gpt-oss marker strings are gone from the decode path.** Priming gpt-oss to answer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+- **Thinking off no longer silently does nothing** (#82). Turning Thinking off set the template
+  variable `enable_thinking` and stopped there — but that variable is only a *request* to the
+  model's chat template, and many templates never read it. LFM2.5's is one: the rendered prompt came
+  out byte-identical either way, the model reasoned on, and nothing reported that the setting had
+  been dropped. The engine now renders the template at load to find out which case a model is in,
+  and where the flag is inert it closes the reasoning span in the prompt instead, using llama.cpp's
+  own continuation hook so the markers for each family come from upstream's per-template handler
+  rather than from this engine. Models that support neither are reported as such
+  (`think_ctl` on `BMOE_READY`, see `docs/telemetry.md`) and the app shows the Thinking switch
+  disabled with the reason, instead of leaving a control that does nothing.
+
 ### Changed
+- **The harmony/gpt-oss marker strings are gone from the decode path.** Priming gpt-oss to answer
+  without reasoning used to be a literal `<|start|>assistant` suffix test and a literal
+  `<|channel|>final<|message|>` appended in `session.cpp`. It is now the same generic mechanism as
+  every other family, so the engine names no model's markers and a submodule bump that changes them
+  needs no engine change.
 - **README front page reworked around the result.** A copyable result banner under the title, an
   autoplay hero GIF of gpt-oss-120b generating on-device (real time, cut from the existing demo
   footage), and a "Try it on your phone" quickstart that starts from the release APK and the

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -203,8 +203,11 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
         std::fflush(stdout);
         return 1;
     }
-    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d}\n", session->load_seconds(),
-                json_escape(session->arch()).c_str(), session->n_ctx());
+    // think_ctl states, once, whether this model can honour a think=false request at all, so a UI
+    // can disable its Thinking control instead of leaving one that silently does nothing (#82).
+    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d,\"think_ctl\":\"%s\"}\n",
+                session->load_seconds(), json_escape(session->arch()).c_str(), session->n_ctx(),
+                bmoe::think_control_name(session->think_control()));
     std::fflush(stdout);
 
     std::mutex mtx;

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,6 +25,7 @@ if(BMOE_HAVE_LLAMA)
         src/moe/router_hook.cpp
         src/engine/session.cpp
         src/engine/chat_parse.cpp
+        src/engine/thinking_control.cpp
         src/engine/runtime.cpp
         src/metrics/csv_metrics_sink.cpp
         src/metrics/route_trace_sink.cpp

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -53,6 +53,22 @@ struct SessionConfig {
 // remembering to touch both. n_batch = n_ctx so any prompt that fits the context prefills in one batch.
 SessionConfig session_config_from(const RunConfig & cfg);
 
+// How a GenerateRequest::think=false request can be honoured on THIS model. Decided once at
+// open() by rendering the model's own chat template, never from a list of model names.
+//
+// Turning thinking off is a request to the template, and a template is free to ignore it: the
+// flag reaches the jinja context either way, so a model whose template never reads it reasons on
+// regardless and nothing reports that the setting was dropped. Probing says which case a model is
+// in, so a caller can stop offering a control that does nothing.
+enum class ThinkControl {
+    Template, // the template reads enable_thinking — passing the flag is the whole mechanism
+    Prefill,  // it does not; the reasoning span is closed in the prompt before generation instead
+    None,     // neither is available: the model cannot be asked to skip reasoning
+};
+
+// Stable lowercase name ("template", "prefill", "none") for logs and the telemetry protocol.
+const char * think_control_name(ThinkControl c);
+
 // Per-prompt request. clear_kv=true (the default) makes each prompt independent while the
 // expert cache stays warm; clear_kv=false continues the KV cache for multi-turn chat.
 struct GenerateRequest {
@@ -99,6 +115,11 @@ public:
     double load_seconds() const;      // model load + streaming setup, measured once at open()
     const std::string & arch() const; // model architecture ("qwen3moe", "gemma4", …)
     int n_ctx() const;
+
+    // Which thinking-off mechanism this model supports (probed at open()). Report it to the user
+    // rather than leaving a Thinking toggle that silently does nothing. Always Template when chat
+    // mode is off, where no template is rendered and the question does not arise.
+    ThinkControl think_control() const;
 
     // Set the expert-cache budget in MiB and evict down to it now. PRECONDITION: no generate() in
     // flight — call it between generations (e.g. from an app's memory-pressure callback). A no-op

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -3,6 +3,7 @@
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
 #include "chat_parse.h"
+#include "thinking_control.h"
 #include "../moe/router_hook.h"
 #include "../moe/expert_stream_source.h"
 #include "../moe/gguf_offsets.h"
@@ -190,6 +191,9 @@ struct Session::Impl {
     int n_layer = 0;
     bool chat_on = false;
     common_chat_templates_ptr chat_tmpls;
+    // How a think=false request can be honoured on this model; probed once at open(). Template
+    // (the fail-open default) means the flag alone does the job and generate() adds nothing.
+    ThinkControl think_ctl = ThinkControl::Template;
     bool backend_inited = false;
 
     // Sampling chain, built once at open() only when sampling is requested (temp > 0); null on the
@@ -251,6 +255,9 @@ const std::string & Session::arch() const {
 }
 int Session::n_ctx() const {
     return impl_->cfg.n_ctx;
+}
+ThinkControl Session::think_control() const {
+    return impl_->think_ctl;
 }
 void Session::set_cache_budget_mb(int mib) {
     impl_->source.set_cache_budget((size_t) std::max(0, mib) * 1024ull * 1024ull);
@@ -352,6 +359,9 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         try {
             im.chat_tmpls = common_chat_templates_init(model, "");
             im.chat_on = true;
+            // Which "thinking off" mechanism this template supports is a property of the model, so
+            // it is settled once here rather than re-derived on every turn.
+            im.think_ctl = detail::probe_think_control(im.chat_tmpls.get());
         } catch (const std::exception & e) {
             std::fprintf(stderr, "bmoe: chat template unavailable (%s); using raw prompts\n", e.what());
             im.chat_on = false;
@@ -617,8 +627,8 @@ RunResult Session::generate(const GenerateRequest & req,
     // reasoning is stripped from the shown answer. req.think drives enable_thinking, per prompt.
     std::string prompt = req.prompt;
     bool chat_on = im.chat_on;
-    bool history_pushed = false; // did we append this turn's user message to chat_history?
-    bool forced_final = false;   // harmony no-think: primed the final channel, so skip reasoning parse
+    bool history_pushed = false;   // did we append this turn's user message to chat_history?
+    bool prefilled_answer = false; // closed the reasoning span in the prompt, so skip reasoning parse
     common_chat_parser_params parse_params;
     if (chat_on) {
         try {
@@ -637,27 +647,23 @@ RunResult Session::generate(const GenerateRequest & req,
             // here, before apply — the field defaults to NONE, which produces a content-only
             // grammar that leaves <think> markers in the answer no matter how the parse is wired.
             inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+
+            // Many templates never read enable_thinking (LFM2.5 among them): the flag reaches the
+            // jinja context, is discarded, and the model reasons anyway — the setting silently does
+            // nothing. For those, close the reasoning span in the prompt instead, so the model
+            // resumes at the first token of its answer with the reasoning already behind it.
+            //
+            // The span is rendered by llama.cpp's own handler for this template, so no marker for
+            // any family — harmony's primed final channel included — is spelled out here. Which
+            // models need this was measured at open(), not assumed. See thinking_control.h.
+            if (!req.think && im.think_ctl == ThinkControl::Prefill) {
+                detail::add_no_think_prefill(inputs);
+                prefilled_answer = true;
+            }
+
             common_chat_params cp = common_chat_templates_apply(im.chat_tmpls.get(), inputs);
             prompt = cp.prompt;
             parse_params = detail::build_parse_params(cp);
-
-            // gpt-oss / harmony ignores enable_thinking: its template always opens an
-            // <|channel|>analysis turn (only the "Reasoning:" effort level is tunable), so a
-            // reasoning model burns the whole budget on chain-of-thought before the answer.
-            // When the caller disabled thinking, prime the final channel directly so the model
-            // answers with no analysis tokens. Harmony's generation prompt ends "<|start|>assistant";
-            // that suffix is unique to it (Qwen/Gemma use different markers), so keying on it
-            // leaves every other family's --no-think behaviour untouched.
-            if (!req.think) {
-                size_t last = prompt.find_last_not_of(" \t\r\n");
-                std::string trimmed = (last == std::string::npos) ? prompt : prompt.substr(0, last + 1);
-                static const std::string kHarmonyAsst = "<|start|>assistant";
-                if (trimmed.size() >= kHarmonyAsst.size() &&
-                    trimmed.compare(trimmed.size() - kHarmonyAsst.size(), kHarmonyAsst.size(), kHarmonyAsst) == 0) {
-                    prompt = trimmed + "<|channel|>final<|message|>";
-                    forced_final = true;
-                }
-            }
         } catch (const std::exception & e) {
             std::fprintf(stderr, "bmoe: chat template apply failed (%s); using raw prompt\n", e.what());
             if (history_pushed) {
@@ -692,9 +698,12 @@ RunResult Session::generate(const GenerateRequest & req,
     };
     auto shown_view = [&](const std::string & raw, bool partial) -> ShownView {
         if (!chat_on) return {raw, ""};
-        // Forced-final (harmony no-think) output isn't wrapped in a <|start|>assistant turn, so the
-        // structured parser has nothing to strip — the raw stream already IS the final answer.
-        if (forced_final) return {raw, ""};
+        // A prefilled turn resumes mid-answer: the reasoning span and the turn header the parser
+        // anchors on are already in the prompt, not in the stream, so there is nothing to strip —
+        // the raw stream already IS the answer. (If a model reasons anyway despite the closed span,
+        // that reasoning surfaces verbatim rather than being cut out here. Hiding it would only
+        // disguise a model this mechanism does not work on; the honest report is ThinkControl::None.)
+        if (prefilled_answer) return {raw, ""};
         try {
             common_chat_msg msg = common_chat_parse(raw, partial, parse_params);
             return {msg.content, msg.reasoning_content};
@@ -937,8 +946,10 @@ RunResult Session::generate(const GenerateRequest & req,
         // Commit the assistant turn to the running conversation. Parsing separates a thinking
         // model's reasoning from the answer; the next turn re-renders history from these messages.
         common_chat_msg assistant;
-        if (forced_final) {
-            // No <|start|>assistant wrapper to parse; the raw generation is the answer verbatim.
+        if (prefilled_answer) {
+            // Prefilled turn: no turn header in the stream to parse; the generation is the answer
+            // verbatim. It is committed without the prefill, so history holds a normal assistant
+            // message and the next turn re-renders cleanly whatever this turn's think setting was.
             assistant.content = gen;
         } else {
             try {

--- a/core/src/engine/thinking_control.cpp
+++ b/core/src/engine/thinking_control.cpp
@@ -62,14 +62,29 @@ void add_no_think_prefill(common_chat_templates_inputs & inputs) {
 ThinkControl probe_think_control(const common_chat_templates * tmpls) {
     if (tmpls == nullptr) return ThinkControl::Template;
     try {
-        const std::string off = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/false).prompt;
+        const common_chat_params off_p = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/false);
+        const std::string & off = off_p.prompt;
         const std::string on = apply_probe(tmpls, /*enable_thinking=*/true, /*prefill=*/false).prompt;
         if (on != off) return ThinkControl::Template;
 
         const std::string prefilled = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/true).prompt;
-        if (prefilled != off) return ThinkControl::Prefill;
+        if (prefilled == off) return ThinkControl::None; // nothing reaches this model at all
 
-        return ThinkControl::None;
+        // The prefill changes the prompt — but that alone does not mean the model will honour it,
+        // and the difference is visible in whether the model declares reasoning tags.
+        //
+        // Tags declared: reasoning is a span the MODEL opens and closes at will. Handing it one that
+        // is already closed and empty is a suggestion, and a model not trained on that convention
+        // reasons straight past it — measured on LFM2.5-8B-A1B, which ignores the closed span and
+        // reasons into the answer instead (issue #82). Worse than leaving it alone, because the
+        // reasoning arrives untagged. Report it as uncontrollable rather than making it worse.
+        //
+        // No tags declared: reasoning is structural — a channel or section the format itself
+        // separates — so the prefill does not ask the model to skip anything, it places the model
+        // past the reasoning section entirely. That the model cannot ignore (harmony/gpt-oss).
+        if (!off_p.thinking_start_tag.empty() || !off_p.thinking_end_tag.empty()) return ThinkControl::None;
+
+        return ThinkControl::Prefill;
     } catch (const std::exception & e) {
         std::fprintf(stderr, "bmoe: thinking-control probe failed (%s); assuming the template honours it\n", e.what());
         return ThinkControl::Template;

--- a/core/src/engine/thinking_control.cpp
+++ b/core/src/engine/thinking_control.cpp
@@ -1,0 +1,79 @@
+#include "thinking_control.h"
+
+#include <cstdio>
+#include <exception>
+#include <string>
+
+namespace bmoe {
+
+const char * think_control_name(ThinkControl c) {
+    switch (c) {
+    case ThinkControl::Template:
+        return "template";
+    case ThinkControl::Prefill:
+        return "prefill";
+    case ThinkControl::None:
+        return "none";
+    }
+    return "template";
+}
+
+} // namespace bmoe
+
+namespace bmoe::detail {
+
+namespace {
+
+// What a natively-supporting template puts inside the closed span. See add_no_think_prefill:
+// whitespace, so the engine contributes no words to the model's own reasoning.
+const char * const kEmptyReasoning = "\n\n";
+
+// Render a one-turn conversation the way generate() renders a real one — same jinja path, same
+// reasoning format — so what the probe observes is what generation will produce. The message text
+// is irrelevant: templates branch on the flag, never on the words.
+common_chat_params apply_probe(const common_chat_templates * tmpls, bool enable_thinking, bool prefill) {
+    common_chat_msg user;
+    user.role = "user";
+    user.content = "hi";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = {user};
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
+    inputs.enable_thinking = enable_thinking;
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    if (prefill) add_no_think_prefill(inputs);
+
+    return common_chat_templates_apply(const_cast<common_chat_templates *>(tmpls), inputs);
+}
+
+} // namespace
+
+void add_no_think_prefill(common_chat_templates_inputs & inputs) {
+    common_chat_msg prefill;
+    prefill.role = "assistant";
+    prefill.reasoning_content = kEmptyReasoning;
+    // content stays empty: the handler renders the closing tag and then nothing, leaving the model
+    // at the first token of its answer. Nothing is appended that would have to be stripped back off.
+    inputs.messages.push_back(prefill);
+    inputs.continue_final_message = COMMON_CHAT_CONTINUATION_CONTENT;
+}
+
+ThinkControl probe_think_control(const common_chat_templates * tmpls) {
+    if (tmpls == nullptr) return ThinkControl::Template;
+    try {
+        const std::string off = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/false).prompt;
+        const std::string on = apply_probe(tmpls, /*enable_thinking=*/true, /*prefill=*/false).prompt;
+        if (on != off) return ThinkControl::Template;
+
+        const std::string prefilled = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/true).prompt;
+        if (prefilled != off) return ThinkControl::Prefill;
+
+        return ThinkControl::None;
+    } catch (const std::exception & e) {
+        std::fprintf(stderr, "bmoe: thinking-control probe failed (%s); assuming the template honours it\n", e.what());
+        return ThinkControl::Template;
+    }
+}
+
+} // namespace bmoe::detail

--- a/core/src/engine/thinking_control.h
+++ b/core/src/engine/thinking_control.h
@@ -38,10 +38,16 @@ void add_no_think_prefill(common_chat_templates_inputs & inputs);
 //      analyzer performs; `common_chat_params::supports_thinking` cannot answer the question,
 //      because per handler it is a hardcoded literal reporting "this model can reason", not
 //      "this template reads the variable".
-//   2. with the prefill applied — if that changes the prompt, the handler implements the
-//      continuation hook and the span can be closed ahead of generation.
-// Neither: the request cannot be honoured on this model, and saying so is better than offering a
-// control that does nothing.
+//   2. with the prefill applied — if that leaves the prompt untouched, nothing reaches this model
+//      and the request cannot be honoured.
+//   3. otherwise the prefill lands, and whether the model must OBEY it is read off the reasoning
+//      tags it declares: a declared span is the model's own to open and close, so a pre-closed
+//      empty one is only a suggestion (LFM2.5 ignores it — see probe_think_control); no declared
+//      span means the format separates reasoning structurally and the prefill places the model
+//      past it, which it cannot ignore.
+//
+// Saying "this model cannot be silenced" is better than offering a control that does nothing — and
+// far better than one that makes the output worse.
 //
 // Fails open to Template (the pre-existing behaviour: pass the flag and let the template decide),
 // because a probe that itself failed is no evidence that the flag is inert.

--- a/core/src/engine/thinking_control.h
+++ b/core/src/engine/thinking_control.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// How a "thinking off" request is actually honoured, decided from the model rather than from a
+// table of model names. Kept separate from session.cpp so the decision is unit-testable against
+// llama.cpp's bundled templates, with no model and no live session.
+//
+// Internal header: includes llama.cpp's `common` (not the stable public API), so it must not be
+// pulled into core/include/bmoe/. See docs/seam.md.
+
+#include "bmoe/session.h"
+
+#include "chat.h"
+
+namespace bmoe::detail {
+
+// Turn a rendered turn into one that starts with the model's reasoning span already closed.
+//
+// This sets no markers of its own. It appends a synthetic assistant message and asks for a
+// CONTENT continuation, which makes llama.cpp's own per-template handler emit whatever "reasoning
+// is over, answer now" looks like for that family — `<think></think>` for the LFM2 and Qwen
+// handlers, a primed `<|channel|>final<|message|>` for harmony, and so on. The engine never spells
+// any of them out.
+//
+// The reasoning span carries whitespace, not words: a continuation is only rendered when the
+// message is non-empty (`has_continuation()`), and whitespace is exactly what a template that
+// implements this natively puts there (Qwen3 renders `<think>\n\n</think>` for enable_thinking
+// false). Anything language-bearing would be the engine inventing content for the model.
+//
+// CONTENT is passed explicitly rather than AUTO: AUTO resolves a reasoning-only message to a
+// REASONING continuation, which *opens* the span instead of closing it — the opposite request.
+void add_no_think_prefill(common_chat_templates_inputs & inputs);
+
+// Decide which mechanism this model's template supports, by rendering it and looking.
+//
+// Three renders, once per session:
+//   1. enable_thinking true vs false — if the prompt changes, the template reads the flag and
+//      nothing further is needed. This is the same render-and-diff llama.cpp's own template
+//      analyzer performs; `common_chat_params::supports_thinking` cannot answer the question,
+//      because per handler it is a hardcoded literal reporting "this model can reason", not
+//      "this template reads the variable".
+//   2. with the prefill applied — if that changes the prompt, the handler implements the
+//      continuation hook and the span can be closed ahead of generation.
+// Neither: the request cannot be honoured on this model, and saying so is better than offering a
+// control that does nothing.
+//
+// Fails open to Template (the pre-existing behaviour: pass the flag and let the template decide),
+// because a probe that itself failed is no evidence that the flag is inert.
+ThinkControl probe_think_control(const common_chat_templates * tmpls);
+
+} // namespace bmoe::detail

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ core/
     engine/     session — composition + the generation loop (open/generate/close)
                 runtime — the one-shot run() wrapper over a Session
                 chat_parse — reasoning-parser wiring (llama.cpp `common`, see seam.md)
+                thinking_control — how "thinking off" is honoured, probed per model
     metrics/    csv_metrics_sink, route_trace_sink, decode_trace_sink
 third_party/
   llama.cpp     upstream submodule; public-API consumer, plus one optional overlap hook

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -93,12 +93,17 @@ that seam unit-testable without a model.
 A second translation unit, `thinking_control.cpp`, crosses the same boundary for "thinking off".
 `enable_thinking` is only a *request* to the template, and many templates never read it, so the
 engine renders the template to find out (three renders at open, no model names involved) and, where
-the flag is inert, asks for a **continuation** instead: the `continue_final_message` field of
-`common_chat_templates_inputs`, plus a synthetic trailing assistant message, makes llama.cpp's own
-per-template handler emit that family's "reasoning is over" span into the prompt. This is why no `<think>` or
-harmony channel marker appears anywhere in `core/` — the markers stay upstream, where a submodule
-bump keeps them current. `tests/think_control_test.cpp` pins the behaviour against the vendored
-templates, again with no model.
+the flag is inert *and* reasoning is a structural section of the format, asks for a **continuation**
+instead: the `continue_final_message` field of `common_chat_templates_inputs`, plus a synthetic
+trailing assistant message, makes llama.cpp's own per-template handler emit that family's "reasoning
+is over" span into the prompt. This is why no `<think>` or harmony channel marker appears anywhere in
+`core/` — the markers stay upstream, where a submodule bump keeps them current.
+
+Whether the continuation is *binding* is read off `common_chat_params::thinking_start_tag`/
+`thinking_end_tag`: a model that declares a reasoning span owns it, so a pre-closed empty one is a
+suggestion it can decline (LFM2.5 does), while a model that declares none separates reasoning
+structurally and cannot. Both facts come from the loaded model, never from its name.
+`tests/think_control_test.cpp` pins all of it against the vendored templates, again with no model.
 
 Unlike the public-C-API streaming seam, `common` is **not a stable API** — it can change
 between upstream versions. So a submodule bump may require updating this chat glue in

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -90,10 +90,21 @@ unit, `chat_parse.cpp` — the PEG parser arena has to be loaded explicitly or `
 throws on the first token, which is how issue #49 stayed invisible; keeping it separate makes
 that seam unit-testable without a model.
 
+A second translation unit, `thinking_control.cpp`, crosses the same boundary for "thinking off".
+`enable_thinking` is only a *request* to the template, and many templates never read it, so the
+engine renders the template to find out (three renders at open, no model names involved) and, where
+the flag is inert, asks for a **continuation** instead: the `continue_final_message` field of
+`common_chat_templates_inputs`, plus a synthetic trailing assistant message, makes llama.cpp's own
+per-template handler emit that family's "reasoning is over" span into the prompt. This is why no `<think>` or
+harmony channel marker appears anywhere in `core/` — the markers stay upstream, where a submodule
+bump keeps them current. `tests/think_control_test.cpp` pins the behaviour against the vendored
+templates, again with no model.
+
 Unlike the public-C-API streaming seam, `common` is **not a stable API** — it can change
 between upstream versions. So a submodule bump may require updating this chat glue in
-`session.cpp` / `chat_parse.cpp`; the build and gates catch a break at compile time rather than
-at runtime (`tests/chat_parse_test.cpp` covers the parser wiring directly). This
+`session.cpp` / `chat_parse.cpp` / `thinking_control.cpp`; the build and gates catch a break at
+compile time rather than at runtime (`tests/chat_parse_test.cpp` and
+`tests/think_control_test.cpp` cover these seams directly). This
 trade-off is deliberate and is also noted at the link site in the root `CMakeLists.txt`. The
 gates themselves run with the template off (raw prompt), so they stay deterministic and are
 unaffected by this dependency.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -271,8 +271,15 @@ model's own chat template, not from a list of model names:
 | value | meaning | what the UI should do |
 |---|---|---|
 | `template` | the chat template reads `enable_thinking` (Qwen3 and most reasoning models) | offer the toggle |
-| `prefill` | it does not, so the engine closes the reasoning span in the prompt instead (LFM2.5, gpt-oss) | offer the toggle |
-| `none` | neither is available — the model reasons on every turn | show the control disabled, and say why |
+| `prefill` | it does not, but reasoning is a structural section the prompt can start past (harmony/gpt-oss) | offer the toggle |
+| `none` | the model reasons on every turn and cannot be asked not to (LFM2.5) | show the control disabled, and say why |
+
+The `prefill` / `none` split is decided by the reasoning tags the model declares, not by its name.
+A model that declares a `<think>`-style span owns that span: handing it one already closed and empty
+is a suggestion, and a model not trained on the convention reasons past it — measured on LFM2.5,
+which then emits its reasoning *untagged into the answer*, worse than not asking at all. A model
+that declares no tags separates reasoning structurally (a channel), and starting the turn past that
+section is not something it can decline.
 
 `BMOE_DONE` carries the end-of-generation summary (the one-shot mode's `generation:` /
 `moe-stream:` text lines are not emitted in session mode). `n_prompt` is the tokens actually

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -251,7 +251,8 @@ user message, the engine re-renders the whole history and reuses the KV prefix (
 Responses (stdout):
 
 ```
-BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>}          # once, after the model loads
+BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>,
+            "think_ctl":"template|prefill|none"}                        # once, after the model loads
 BMOE_BEGIN {"id":<int>}                                                # a generation started
 BMOE_LOAD / BMOE_PROGRESS ...                                          # per token, as above
 BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
@@ -262,6 +263,16 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "token_demand_mib":<float>,"reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
+
+`BMOE_READY`'s `think_ctl` states how a `"think":false` request can be honoured on the model that
+was just loaded, so a UI need not offer a control that does nothing. It is decided by rendering the
+model's own chat template, not from a list of model names:
+
+| value | meaning | what the UI should do |
+|---|---|---|
+| `template` | the chat template reads `enable_thinking` (Qwen3 and most reasoning models) | offer the toggle |
+| `prefill` | it does not, so the engine closes the reasoning span in the prompt instead (LFM2.5, gpt-oss) | offer the toggle |
+| `none` | neither is available — the model reasons on every turn | show the control disabled, and say why |
 
 `BMOE_DONE` carries the end-of-generation summary (the one-shot mode's `generation:` /
 `moe-stream:` text lines are not emitted in session mode). `n_prompt` is the tokens actually

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -30,6 +30,11 @@ data class UiState(
     val ioMode: String? = null,     // effective read mode reported by the engine (direct / buffered)
     val cpuTempC: Double? = null,   // SoC/CPU temperature (°C), sampled while generating (battery fallback)
     val sessionSig: String? = null, // signature of the loaded session (AppSettings.sessionSignature)
+    // How the loaded model can honour "Thinking off", reported once at BMOE_READY: "template" (its
+    // chat template reads the flag), "prefill" (it does not, so the engine closes the reasoning span
+    // in the prompt), or "none" (neither — the model always reasons, and the switch is hidden rather
+    // than left there doing nothing). Null until a session reports it. See docs/telemetry.md.
+    val thinkControl: String? = null,
     val transcript: List<ChatTurn> = emptyList(), // committed turns; the in-flight answer is `answer`
     val streaming: Boolean = true,  // is the loaded session using the MoE streamer (vs mmap baseline)?
 ) {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -112,8 +112,10 @@ class RunService : Service() {
         RunBus.update {
             // ioMode is re-sniffed from the new session's stderr, so clear it: it describes the
             // session being replaced, and the sniffer's first-writer-wins guard would keep it.
+            // thinkControl is a property of the model being loaded, so it goes the same way — the
+            // incoming session reports its own at BMOE_READY.
             it.copy(state = EngineState.LOADING, error = null, sessionSig = sig, answer = "", summary = "",
-                transcript = emptyList(), streaming = streaming, ioMode = null)
+                transcript = emptyList(), streaming = streaming, ioMode = null, thinkControl = null)
         }
 
         thread(name = "bmoe-session") { runSession(argv, model, myEpoch, dying) }
@@ -199,7 +201,8 @@ class RunService : Service() {
         val t = line.trim()
         when {
             t.startsWith("BMOE_READY ") -> {
-                RunBus.setState(EngineState.READY)
+                val ctl = Regex(""""think_ctl":"([a-z_]+)"""").find(t)?.groupValues?.get(1)
+                RunBus.update { it.copy(state = EngineState.READY, thinkControl = ctl) }
                 main.post { notify("Model ready") }
                 pending?.let { p -> pending = null; sendGenerate(p) } ?: scheduleIdleUnload()
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**
  * Groups every tunable the engine exposes. Changes are applied to [current] live and
@@ -19,6 +20,12 @@ import androidx.compose.ui.unit.sp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack: () -> Unit) {
+    // Reported by the loaded session at BMOE_READY. "none" means this model reasons no matter what
+    // it is asked, so the Thinking switch is shown disabled with the reason rather than left there
+    // pretending to work (#82). Null = nothing loaded yet, so nothing is claimed either way.
+    val ui by RunBus.state.collectAsStateWithLifecycle()
+    val thinkingLocked = ui.thinkControl == "none"
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -151,10 +158,18 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
             Section("Prompt") {
                 SwitchRow(
                     "Thinking",
-                    "Let a reasoning model think before answering; its reasoning shows in a " +
-                        "collapsible block above the reply. Off tells the model to skip thinking. " +
-                        "No effect on models that don't reason.",
-                    current.thinking,
+                    if (thinkingLocked)
+                        "This model always reasons — it offers no way to turn thinking off, so the " +
+                            "switch is disabled here instead of being ignored silently. Its reasoning " +
+                            "still shows in a collapsible block above the reply."
+                    else
+                        "Let a reasoning model think before answering; its reasoning shows in a " +
+                            "collapsible block above the reply. Off tells the model to skip thinking. " +
+                            "No effect on models that don't reason.",
+                    // Locked reads ON, not OFF: the model reasons on every turn, and that is what
+                    // the switch should be showing whatever the stored preference says.
+                    checked = current.thinking || thinkingLocked,
+                    enabled = !thinkingLocked,
                 ) { onChange(current.copy(thinking = it)) }
             }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,18 @@ target_compile_definitions(bmoe_chat_parse_test PRIVATE
     BMOE_QWEN3_TEMPLATE_PATH="${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates/Qwen3.5-4B.jinja")
 add_test(NAME chat_parse COMMAND bmoe_chat_parse_test)
 
+# Thinking-control tests (issue #82). Drives bmoe::detail::probe_think_control and the prefill
+# against real vendored templates, so it needs no model and runs unconditionally.
+add_executable(bmoe_think_control_test think_control_test.cpp)
+target_link_libraries(bmoe_think_control_test PRIVATE bmoe_core)
+target_include_directories(bmoe_think_control_test PRIVATE ${CMAKE_SOURCE_DIR}/core/src/engine)
+set(_tmpl_dir "${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates")
+target_compile_definitions(bmoe_think_control_test PRIVATE
+    BMOE_TMPL_QWEN3="${_tmpl_dir}/Qwen3.5-4B.jinja"
+    BMOE_TMPL_LFM25="${_tmpl_dir}/LFM2.5-8B-A1B.jinja"
+    BMOE_TMPL_GPTOSS="${_tmpl_dir}/openai-gpt-oss-120b.jinja")
+add_test(NAME think_control COMMAND bmoe_think_control_test)
+
 # validate() unit tests (issue #51 + the pre-existing rules). Pure config, no model — runs
 # unconditionally, and makes good on config.h's "unit-tested" claim.
 add_executable(bmoe_config_test config_test.cpp)

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -15,9 +15,13 @@
 //      that matters: an opened-and-not-closed span is the opposite request, and it is exactly what
 //      asking for an AUTO continuation would silently produce.
 //
-// Nothing here hardcodes a marker for any family. The expected shapes are derived from the
-// thinking-on render of the same template, so a submodule bump that changes a family's markers
-// updates the expectations with it instead of breaking the test.
+// This file does name `<think>`, in the LFM2.5 case only, because a test of a specific template is
+// entitled to state what that template's span looks like. The ENGINE names no marker for any
+// family: everything it emits comes from llama.cpp's handler for the loaded model, and every
+// decision it makes reads model-supplied data (`thinking_start_tag`/`thinking_end_tag`). The
+// gpt-oss expectations below take the harder route and are derived from that template's own
+// thinking-on render, so a submodule bump that changes harmony's channel markers updates them with
+// it instead of breaking the test.
 //
 // Assertions are explicit (not <cassert>) because the Release gates build with NDEBUG, which
 // would compile assert() out.

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -1,0 +1,167 @@
+// Thinking-control tests (issue #82).
+//
+// The bug: turning Thinking off set enable_thinking=false and stopped there. That flag is handed
+// to the model's jinja template, which is free to ignore it — LFM2.5's never reads it — so the
+// prompt came out byte-identical either way and the model reasoned on, with nothing reporting that
+// the setting had been dropped.
+//
+// Two things are asserted here, both against REAL templates from the vendored submodule (paths
+// injected by CMake), with no model:
+//
+//   1. probe_think_control tells the three regimes apart — a template that honours the flag, one
+//      that ignores it but whose handler can have the reasoning span closed for it, and (by
+//      construction) one where neither works.
+//   2. the prefill produces a prompt whose reasoning span is already CLOSED. This is the assertion
+//      that matters: an opened-and-not-closed span is the opposite request, and it is exactly what
+//      asking for an AUTO continuation would silently produce.
+//
+// Nothing here hardcodes a marker for any family. The expected shapes are derived from the
+// thinking-on render of the same template, so a submodule bump that changes a family's markers
+// updates the expectations with it instead of breaking the test.
+//
+// Assertions are explicit (not <cassert>) because the Release gates build with NDEBUG, which
+// would compile assert() out.
+
+#include "thinking_control.h"
+
+#include "chat.h"
+#include "common.h"
+
+#include <cstdio>
+#include <exception>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#if !defined(BMOE_TMPL_QWEN3) || !defined(BMOE_TMPL_LFM25) || !defined(BMOE_TMPL_GPTOSS)
+#error "template paths must be defined by the build"
+#endif
+
+static int failures = 0;
+
+static void expect(const char * name, bool ok, const std::string & detail = {}) {
+    if (ok) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s%s%s\n", name, detail.empty() ? "" : "\n  ", detail.c_str());
+        ++failures;
+    }
+}
+
+static std::string read_file(const char * path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        std::printf("[FAIL] cannot open template: %s\n", path);
+        ++failures;
+        return {};
+    }
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+static common_chat_templates_ptr load(const char * path) {
+    return common_chat_templates_init(/*model*/ nullptr, read_file(path));
+}
+
+// Render one turn the way generate() does, optionally with the reasoning span closed up front.
+static std::string render(const common_chat_templates * tmpls, bool think, bool prefill) {
+    common_chat_msg user;
+    user.role = "user";
+    user.content = "hi";
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = {user};
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
+    inputs.enable_thinking = think;
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_AUTO;
+    if (prefill) bmoe::detail::add_no_think_prefill(inputs);
+
+    return common_chat_templates_apply(const_cast<common_chat_templates *>(tmpls), inputs).prompt;
+}
+
+// The check that the rejected logit-level attempt could not make: is the reasoning span CLOSED?
+//
+// The closing marker is not named here — it is taken from the same template's thinking-on render,
+// which is where the model is left mid-reasoning. A prefilled prompt must contain that marker (the
+// span was closed) and must end at or after it (nothing reopens afterwards).
+static void expect_span_closed(const char * name, const common_chat_templates * tmpls, const char * close_marker) {
+    const std::string prefilled = render(tmpls, /*think*/ false, /*prefill*/ true);
+    const size_t at = prefilled.rfind(close_marker);
+    if (at == std::string::npos) {
+        expect(name, false, "prefilled prompt never closes the reasoning span:\n  " + prefilled);
+        return;
+    }
+    // Only whitespace and the answer-channel header may follow: what must NOT follow is a fresh
+    // opening of the span, which would leave the model reasoning again.
+    const std::string tail = prefilled.substr(at + std::char_traits<char>::length(close_marker));
+    expect(name, tail.find("<think>") == std::string::npos, "span reopens after closing:\n  " + prefilled);
+}
+
+int main() {
+    try {
+        // Qwen3 reads enable_thinking (it renders its own closed <think></think> when false), so the
+        // flag alone is the whole mechanism and the engine must add nothing.
+        {
+            auto t = load(BMOE_TMPL_QWEN3);
+            expect("qwen3: template honours enable_thinking",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Template);
+        }
+
+        // LFM2.5 — the model from issue #82. Its template never mentions enable_thinking, so both
+        // renders are identical; the handler does implement the continuation hook, so the span can
+        // be closed in the prompt.
+        {
+            auto t = load(BMOE_TMPL_LFM25);
+            expect("lfm2.5: flag is inert in the template", render(t.get(), /*think*/ true, /*prefill*/ false) ==
+                                                                render(t.get(), /*think*/ false, /*prefill*/ false));
+            expect("lfm2.5: probed as prefill",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Prefill);
+            expect_span_closed("lfm2.5: prefilled span is closed", t.get(), "</think>");
+        }
+
+        // gpt-oss / harmony. Its template ignores the flag too, and it exposes no thinking tags at
+        // all — a tag-based detector would give up here. Probing the continuation instead sees the
+        // mechanism that does exist: the handler primes the answer channel. This is the case the
+        // engine used to carry as two hardcoded harmony marker strings in the decode path.
+        {
+            auto t = load(BMOE_TMPL_GPTOSS);
+            expect("gpt-oss: probed as prefill",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Prefill);
+
+            const std::string prefilled = render(t.get(), /*think*/ false, /*prefill*/ true);
+            const std::string thinking = render(t.get(), /*think*/ true, /*prefill*/ false);
+            // Derived, not asserted as a constant: whatever channel the plain render leaves the
+            // model in, the prefilled one must have moved past it to a different, later one.
+            expect("gpt-oss: prefill moves past the reasoning channel",
+                   prefilled != thinking && prefilled.size() > thinking.size());
+        }
+
+        // A template with no reasoning of any kind: the flag does nothing and there is no span to
+        // close. The honest answer is None, so a caller can hide the toggle instead of lying.
+        {
+            auto t = common_chat_templates_init(
+                nullptr, "{% for m in messages %}{{ m.role }}: {{ m.content }}\n{% endfor %}assistant:");
+            expect("plain template: reports none",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::None);
+        }
+
+        // A probe that could not run is no evidence the flag is inert: fail open to the
+        // pre-existing behaviour rather than declaring the model uncontrollable.
+        expect("null templates: fails open to template",
+               bmoe::detail::probe_think_control(nullptr) == bmoe::ThinkControl::Template);
+
+        expect("names are stable",
+               std::string(bmoe::think_control_name(bmoe::ThinkControl::Prefill)) == "prefill" &&
+                   std::string(bmoe::think_control_name(bmoe::ThinkControl::None)) == "none" &&
+                   std::string(bmoe::think_control_name(bmoe::ThinkControl::Template)) == "template");
+    } catch (const std::exception & e) {
+        std::printf("[FAIL] unexpected exception: %s\n", e.what());
+        ++failures;
+    }
+
+    std::printf(failures == 0 ? "\nthink control: all checks passed\n" : "\nthink control: %d check(s) failed\n",
+                failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -110,21 +110,25 @@ int main() {
         }
 
         // LFM2.5 — the model from issue #82. Its template never mentions enable_thinking, so both
-        // renders are identical; the handler does implement the continuation hook, so the span can
-        // be closed in the prompt.
+        // renders are identical. The continuation hook does land (the span below really is closed),
+        // but LFM2.5 declares <think>/</think>, so the closed span is only a suggestion to a model
+        // that owns its own reasoning tags — and measured on-device it reasons straight past it,
+        // untagged, into the answer. Reported as uncontrollable rather than made worse.
         {
             auto t = load(BMOE_TMPL_LFM25);
             expect("lfm2.5: flag is inert in the template", render(t.get(), /*think*/ true, /*prefill*/ false) ==
                                                                 render(t.get(), /*think*/ false, /*prefill*/ false));
-            expect("lfm2.5: probed as prefill",
-                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Prefill);
-            expect_span_closed("lfm2.5: prefilled span is closed", t.get(), "</think>");
+            expect("lfm2.5: probed as none (declares its own reasoning tags)",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::None);
+            // The prefill itself is well-formed — this is why "none" is a statement about the
+            // MODEL, not about a mechanism that failed to render.
+            expect_span_closed("lfm2.5: the prefill would close the span correctly", t.get(), "</think>");
         }
 
-        // gpt-oss / harmony. Its template ignores the flag too, and it exposes no thinking tags at
-        // all — a tag-based detector would give up here. Probing the continuation instead sees the
-        // mechanism that does exist: the handler primes the answer channel. This is the case the
-        // engine used to carry as two hardcoded harmony marker strings in the decode path.
+        // gpt-oss / harmony. Its template ignores the flag too, and it declares NO thinking tags:
+        // reasoning is a channel the format separates structurally, so priming past it is not
+        // something the model can decline. This is the case the engine used to carry as two
+        // hardcoded harmony marker strings in the decode path.
         {
             auto t = load(BMOE_TMPL_GPTOSS);
             expect("gpt-oss: probed as prefill",


### PR DESCRIPTION
Closes #82 (pending the on-device check below).

`enable_thinking` is a *request* to the model's chat template, and a template is free to ignore it.
LFM2.5's never reads it, so the rendered prompt was byte-identical with Thinking on and off, the
model reasoned anyway, and nothing said the setting had been dropped.

## What changes

**Detection is measured, not declared.** At `open()` the template is rendered with the flag on and
off and the two prompts compared, then rendered once more with a continuation applied. That answers
the only question that matters — *does this template react?* — for any model, in any language, with
no model names anywhere. `common_chat_templates_support_enable_thinking()` cannot answer it: per
handler it is a hardcoded literal reporting "this model can reason", not "this template reads the
variable".

**Enforcement is llama.cpp's continuation hook.** A synthetic trailing assistant message plus
`continue_final_message` makes upstream's own per-template handler render *that family's* "reasoning
is over" span into the prompt, so the model resumes at the first token of its answer with the
reasoning already behind it. This is exactly what a template that implements the toggle natively
does — Qwen3 renders `<think></think>` for `enable_thinking=false` — and it is the technique the
DeepSeek-R1 community settled on for models whose template lacks the flag. It needs no cooperation
from the template and **no sampler**, so it works on the greedy path the byte-identity gates run on.

The engine writes about 90 lines and spells out no markers of its own.

## The harmony hardcoding is gone

Priming gpt-oss to answer without reasoning used to be a literal `<|start|>assistant` suffix test
plus a literal `<|channel|>final<|message|>` appended in the decode path — the last model-specific
constant in `generate()`. gpt-oss now takes the same generic path as every other family and resumes
at the same point in the prompt (upstream's handler renders an empty analysis turn ahead of it,
which is if anything more harmony-correct). A submodule bump that changes those markers no longer
needs an engine change.

## What is deliberately NOT here

Forcing the reasoning block closed on logits. Measured on-device in the closed #83, it made LFM2.5
strictly worse: the model reopened the block, and once denied twice it abandoned the tags and
reasoned in plain prose straight into the answer — 166 tokens of reasoning moved *out* of a
collapsible block and *into* the reply. Suppression has to land in the prompt, before the model
commits to reasoning, not mid-generation. No output string surgery either, and no invented English
sentence in the engine.

## When the model refuses

Reported, not fought. `BMOE_READY` gains `think_ctl` (`template` | `prefill` | `none`), documented
in `docs/telemetry.md`; the app shows the Thinking switch **disabled with the reason** when a model
reasons no matter what it is asked, instead of offering a control that does nothing.

## Tests

`tests/think_control_test.cpp` — no model needed, runs unconditionally, drives real templates from
the vendored submodule:

| case | asserts |
|---|---|
| Qwen3 | probed as `template` (flag honoured, engine adds nothing) |
| LFM2.5 | flag is inert; probed as `prefill`; **span asserted CLOSED and not reopened** |
| gpt-oss | probed as `prefill`; prefill moves past the reasoning channel |
| plain template | probed as `none` |
| probe fails | falls open to `template`, i.e. pre-existing behaviour |

Expected shapes are derived from each template's own thinking-on render, so a submodule bump that
changes a family's markers updates the expectations with it.

Locally: 7/7 ctest green (byte-identity MoE gates included), clang-format 18 clean, arm64
cross-build clean, app Kotlin compiles. CI still cannot run (Actions billing).

## Still owed before merge — on-device, via the app

Host gates prove the prompt is shaped right; they cannot prove how a model *reacts* to it. That is
exactly the gap that sank #83, so:

- **LFM2.5, Thinking off** — the answer must contain no prose reasoning and no stray markers. This
  is the run that decides the PR. If the model reasons anyway despite the closed span, the honest
  outcome is to classify it `none` and let the UI say so — not to fight it.
- **Qwen3.6** — unchanged behaviour (`template` path, untouched).
- **gpt-oss** — same answer quality as today, since this replaces a currently-working path.
