### PR TITLE
fix(chat): require evidence a model reasons before calling it uncontrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [Unreleased]
+
+### Fixed
+- **A non-reasoning model is no longer told it "always reasons."** `think_ctl` reported `none` for
+  any model whose template ignores `enable_thinking` while its handler declares reasoning tags — but
+  handlers publish those tags for a whole *family*, so the non-reasoning members (LFM2-8B-A1B,
+  LFM2.5-Instruct) advertise a `<think>` they never emit. The app disabled their Thinking switch and
+  explained it with a sentence that was simply false. `none` now requires positive evidence that the
+  model reasons: the tag is declared **and** the template actually uses it — the same test llama.cpp
+  applies before wiring up reasoning extraction. Models with nothing to suppress report `template`,
+  which is what they did before any of this existed. Same for a template with no reasoning at all,
+  which used to fall into `none` through a second path.
+
 ## [0.13.0] - 2026-07-19
 
 ### Fixed

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -61,9 +61,11 @@ SessionConfig session_config_from(const RunConfig & cfg);
 // regardless and nothing reports that the setting was dropped. Probing says which case a model is
 // in, so a caller can stop offering a control that does nothing.
 enum class ThinkControl {
-    Template, // the template reads enable_thinking — passing the flag is the whole mechanism
-    Prefill,  // it does not; the reasoning span is closed in the prompt before generation instead
-    None,     // neither is available: the model cannot be asked to skip reasoning
+    // Passing the flag is all there is to do — either the template reads it, or the model does not
+    // reason at all and there is nothing to suppress. Both leave the engine with nothing to add.
+    Template,
+    Prefill, // the template ignores it; the turn starts past the reasoning section instead
+    None,    // the model reasons on every turn and cannot be asked not to
 };
 
 // Stable lowercase name ("template", "prefill", "none") for logs and the telemetry protocol.

--- a/core/src/engine/thinking_control.cpp
+++ b/core/src/engine/thinking_control.cpp
@@ -67,24 +67,33 @@ ThinkControl probe_think_control(const common_chat_templates * tmpls) {
         const std::string on = apply_probe(tmpls, /*enable_thinking=*/true, /*prefill=*/false).prompt;
         if (on != off) return ThinkControl::Template;
 
+        // Does the model own a reasoning span — a `<think>`-style pair it opens and closes itself?
+        //
+        // Both halves are needed. A declared tag alone proves nothing, because handlers publish the
+        // pair for a whole family: the non-reasoning members (LFM2-8B-A1B, LFM2.5-Instruct) advertise
+        // `<think>` they never emit. Requiring the template to actually USE it is the same test
+        // llama.cpp applies before wiring up reasoning extraction for that family.
+        const std::string src = common_chat_templates_source(tmpls);
+        const bool owns_span =
+            !off_p.thinking_start_tag.empty() && src.find(off_p.thinking_start_tag) != std::string::npos;
+
+        // It does, and the flag is inert: the request cannot be honoured. Closing the span in the
+        // prompt is only a suggestion to a model that opens its own — LFM2.5 reasons straight past a
+        // pre-closed empty one and emits the reasoning untagged into the answer (issue #82), worse
+        // than leaving it alone. Say so instead of making it worse.
+        if (owns_span) return ThinkControl::None;
+
         const std::string prefilled = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/true).prompt;
-        if (prefilled == off) return ThinkControl::None; // nothing reaches this model at all
 
-        // The prefill changes the prompt — but that alone does not mean the model will honour it,
-        // and the difference is visible in whether the model declares reasoning tags.
-        //
-        // Tags declared: reasoning is a span the MODEL opens and closes at will. Handing it one that
-        // is already closed and empty is a suggestion, and a model not trained on that convention
-        // reasons straight past it — measured on LFM2.5-8B-A1B, which ignores the closed span and
-        // reasons into the answer instead (issue #82). Worse than leaving it alone, because the
-        // reasoning arrives untagged. Report it as uncontrollable rather than making it worse.
-        //
-        // No tags declared: reasoning is structural — a channel or section the format itself
-        // separates — so the prefill does not ask the model to skip anything, it places the model
-        // past the reasoning section entirely. That the model cannot ignore (harmony/gpt-oss).
-        if (!off_p.thinking_start_tag.empty() || !off_p.thinking_end_tag.empty()) return ThinkControl::None;
+        // No span of its own, and the prefill lands: reasoning is structural — a channel the format
+        // itself separates — so starting the turn past that section is not something the model can
+        // decline (harmony/gpt-oss).
+        if (prefilled != off && off_p.thinking_start_tag.empty()) return ThinkControl::Prefill;
 
-        return ThinkControl::Prefill;
+        // Nothing indicates this model reasons at all: no span it uses, no reasoning section to start
+        // past. There is nothing to suppress, so pass the flag and add nothing — claiming it "always
+        // reasons" would be a louder lie than the silence this probe exists to end.
+        return ThinkControl::Template;
     } catch (const std::exception & e) {
         std::fprintf(stderr, "bmoe: thinking-control probe failed (%s); assuming the template honours it\n", e.what());
         return ThinkControl::Template;

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -270,16 +270,23 @@ model's own chat template, not from a list of model names:
 
 | value | meaning | what the UI should do |
 |---|---|---|
-| `template` | the chat template reads `enable_thinking` (Qwen3 and most reasoning models) | offer the toggle |
-| `prefill` | it does not, but reasoning is a structural section the prompt can start past (harmony/gpt-oss) | offer the toggle |
+| `template` | passing the flag is all there is to do: either the template reads it (Qwen3, Gemma 4), or the model does not reason and there is nothing to suppress | offer the toggle |
+| `prefill` | the template ignores it, but reasoning is a structural section the turn can start past (harmony/gpt-oss) | offer the toggle |
 | `none` | the model reasons on every turn and cannot be asked not to (LFM2.5) | show the control disabled, and say why |
 
-The `prefill` / `none` split is decided by the reasoning tags the model declares, not by its name.
-A model that declares a `<think>`-style span owns that span: handing it one already closed and empty
-is a suggestion, and a model not trained on the convention reasons past it — measured on LFM2.5,
-which then emits its reasoning *untagged into the answer*, worse than not asking at all. A model
-that declares no tags separates reasoning structurally (a channel), and starting the turn past that
-section is not something it can decline.
+Which one a model gets is decided from data the model supplies, never from its name.
+
+`none` requires positive evidence that the model reasons *and* owns the span it reasons in: it
+declares a `<think>`-style pair **and** its template actually uses it. A span the model opens and
+closes itself is its own, so handing it one already closed and empty is only a suggestion — LFM2.5
+reasons straight past it and emits the reasoning *untagged into the answer*, worse than not asking
+at all. Both halves of the test matter, because handlers publish the tag pair for a whole family:
+the non-reasoning members (LFM2-8B-A1B, LFM2.5-Instruct) advertise a `<think>` they never emit, and
+reporting those uncontrollable would tell the user "this model always reasons" about a model that
+never does.
+
+`prefill` is the opposite shape: no span of the model's own, but the format separates reasoning
+structurally (a channel), and starting the turn past that section is not something it can decline.
 
 `BMOE_DONE` carries the end-of-generation summary (the one-shot mode's `generation:` /
 `moe-stream:` text lines are not emitted in session mode). `n_prompt` is the tokens actually

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,10 @@ set(_tmpl_dir "${CMAKE_SOURCE_DIR}/third_party/llama.cpp/models/templates")
 target_compile_definitions(bmoe_think_control_test PRIVATE
     BMOE_TMPL_QWEN3="${_tmpl_dir}/Qwen3.5-4B.jinja"
     BMOE_TMPL_LFM25="${_tmpl_dir}/LFM2.5-8B-A1B.jinja"
-    BMOE_TMPL_GPTOSS="${_tmpl_dir}/openai-gpt-oss-120b.jinja")
+    BMOE_TMPL_GPTOSS="${_tmpl_dir}/openai-gpt-oss-120b.jinja"
+    BMOE_TMPL_LFM2="${_tmpl_dir}/LFM2-8B-A1B.jinja"
+    BMOE_TMPL_LFM25_INSTRUCT="${_tmpl_dir}/LFM2.5-Instruct.jinja"
+    BMOE_TMPL_GEMMA4="${_tmpl_dir}/google-gemma-4-31B-it.jinja")
 add_test(NAME think_control COMMAND bmoe_think_control_test)
 
 # validate() unit tests (issue #51 + the pre-existing rules). Pure config, no model — runs

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -8,9 +8,11 @@
 // Two things are asserted here, both against REAL templates from the vendored submodule (paths
 // injected by CMake), with no model:
 //
-//   1. probe_think_control tells the three regimes apart — a template that honours the flag, one
-//      that ignores it but whose handler can have the reasoning span closed for it, and (by
-//      construction) one where neither works.
+//   1. probe_think_control tells the regimes apart — a template that honours the flag; one that
+//      ignores it but whose reasoning is structural, so the turn can start past it; and one whose
+//      model owns its reasoning span and cannot be asked to skip it. Including the case that is
+//      easy to get wrong: a model whose FAMILY declares reasoning tags but which never reasons
+//      itself, and so must not be reported uncontrollable.
 //   2. the prefill produces a prompt whose reasoning span is already CLOSED. This is the assertion
 //      that matters: an opened-and-not-closed span is the opposite request, and it is exactly what
 //      asking for an AUTO continuation would silently produce.
@@ -37,7 +39,8 @@
 #include <sstream>
 #include <string>
 
-#if !defined(BMOE_TMPL_QWEN3) || !defined(BMOE_TMPL_LFM25) || !defined(BMOE_TMPL_GPTOSS)
+#if !defined(BMOE_TMPL_QWEN3) || !defined(BMOE_TMPL_LFM25) || !defined(BMOE_TMPL_GPTOSS) ||                            \
+    !defined(BMOE_TMPL_LFM2) || !defined(BMOE_TMPL_LFM25_INSTRUCT) || !defined(BMOE_TMPL_GEMMA4)
 #error "template paths must be defined by the build"
 #endif
 
@@ -146,13 +149,32 @@ int main() {
                    prefilled != thinking && prefilled.size() > thinking.size());
         }
 
-        // A template with no reasoning of any kind: the flag does nothing and there is no span to
-        // close. The honest answer is None, so a caller can hide the toggle instead of lying.
+        // The non-reasoning members of the same family. Their handler publishes <think>/</think> for
+        // the family as a whole, but these templates never emit it, so the models never reason.
+        // Reporting them uncontrollable would tell the user "this model always reasons" about a model
+        // that never does — and disable a control that was simply moot. They must come out as
+        // Template: the flag is passed, and there is nothing to suppress.
+        for (const char * p : {BMOE_TMPL_LFM2, BMOE_TMPL_LFM25_INSTRUCT}) {
+            auto t = load(p);
+            const std::string name = std::string("non-reasoning lfm variant is not reported uncontrollable: ") + p;
+            expect(name.c_str(), bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Template);
+        }
+
+        // Gemma 4 reads enable_thinking, so it never reaches the tag test at all — pinned because it
+        // ships in the app catalog and declares a thinking tag of its own.
+        {
+            auto t = load(BMOE_TMPL_GEMMA4);
+            expect("gemma4: template honours enable_thinking",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Template);
+        }
+
+        // A template with no reasoning of any kind. Nothing to suppress, so nothing to report: None
+        // is reserved for models that demonstrably DO reason and cannot be stopped.
         {
             auto t = common_chat_templates_init(
                 nullptr, "{% for m in messages %}{{ m.role }}: {{ m.content }}\n{% endfor %}assistant:");
-            expect("plain template: reports none",
-                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::None);
+            expect("plain template: nothing to suppress, so not reported uncontrollable",
+                   bmoe::detail::probe_think_control(t.get()) == bmoe::ThinkControl::Template);
         }
 
         // A probe that could not run is no evidence the flag is inert: fail open to the


### PR DESCRIPTION
Follow-up to #85, found by asking a simple question: does the new `none` verdict apply to *every*
LFM model, at any quantization?

Quantization was never in play — the verdict reads the template and the declared tags, not the
weights. But "every LFM model" turned out to be true for the wrong reason.

## The bug

The LFM2 handler publishes `thinking_start_tag`/`thinking_end_tag` for the **family**, unconditionally
(`common/chat.cpp:1703-1704`), whether or not the model reasons. Combined with "template ignores
`enable_thinking`", that made every LFM come out `none`:

| template | uses `<think>` | reasons | v0.13.0 | now |
|---|---|---|---|---|
| LFM2.5-8B-A1B | yes | yes | `none` | `none` |
| LFM2-8B-A1B | no | no | `none` ✗ | `template` |
| LFM2.5-Instruct | no | no | `none` ✗ | `template` |

So the app disabled the Thinking switch on models that never reason, and explained it with *"this
model always reasons — it offers no way to turn thinking off."* False, and it removed a control that
had merely been moot.

## The fix

`none` now needs positive evidence of **both** halves: the model declares a reasoning span **and**
its template actually uses it. The second test is the one llama.cpp applies itself before wiring up
reasoning extraction for this family, so it is model-supplied data like everything else here.

A second path had the same flaw — a template where the continuation hook does nothing also landed in
`none`, catching any plain non-reasoning template. The probe is reordered so the span question is
asked first and `none` is reachable only through it. Anything with nothing to suppress reports
`template`: exactly what those models did before any of this existed.

## Verification

- On-device: LFM2.5-8B-A1B still `none` — the case #85 exists for does not regress.
- Host gates now pin `LFM2-8B-A1B`, `LFM2.5-Instruct`, a plain template, and Gemma 4 (which reads the
  flag and so never reaches the tag test, but ships in the app catalog and declares a tag of its own).
- 7/7 ctest including the MoE byte-identity gates, clang-format 18 clean.

No behaviour change for any model in the app catalog today — this only affects LFM2 variants loaded
by hand, which is where it would have been seen.
