### PR TITLE
fix(cli): honour the documented flag-wins-over-env contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Semantic Versioning.
   which flags were typed and consults that, so passing a flag its default value is still a choice
   the engine honours. Values arriving from the environment are validated exactly as before.
 
+### Removed
+- **The app's unused gguf architecture probe.** `GgufHeader.arch()` was written "to pick the right
+  chat turn format" and never called: `--chatml` already renders the model's *own* template, so the
+  format is chosen by the gguf, not by a name the app reads. Wiring it up would have reintroduced
+  the model-name list the engine's own design note rules out; it and its two private helpers are
+  gone. MoE detection (`isMoe`), the one entry point in use, is untouched.
+
 ## [0.13.1] - 2026-07-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.13.2] - 2026-07-20
+
+### Fixed
+- **An explicitly passed flag now really does beat the environment variable.** `bmoe-cli` documents
+  that a flag always wins over the matching `BMOE_*` override, but it decided "was this flag passed?"
+  by asking whether the field still held its default. So `--cache-mb 0` (cache deliberately off),
+  `--io-threads 4`, `--prefetch 0` and `--n-expert-used 0` were indistinguishable from an untouched
+  config and got overridden anyway — the app passes two of those explicitly. The CLI now records
+  which flags were typed and consults that, so passing a flag its default value is still a choice
+  the engine honours. Values arriving from the environment are validated exactly as before.
+
 ## [0.13.1] - 2026-07-19
 
 ### Fixed

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 
@@ -374,8 +375,13 @@ int main(int argc, char ** argv) {
     std::string io_trace_path;
     bool session_mode = false;
 
+    // Which flags the user actually typed. The env overrides below consult this rather than
+    // comparing against the default, so passing a flag its default value still wins.
+    std::set<std::string> seen;
+
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
+        seen.insert(a);
         auto next = [&](const char * what) -> const char * {
             if (i + 1 >= argc) {
                 std::fprintf(stderr, "missing value for %s\n", what);
@@ -482,13 +488,16 @@ int main(int argc, char ** argv) {
         }
     }
 
-    // Env overrides (flag wins: only apply when the flag left the default).
-    if (cfg.moe.cache_mb == 0 && !cfg.moe.cache_auto) cfg.moe.cache_mb = env_int("BMOE_CACHE_MB", 0);
-    if (cfg.moe.io_threads == 4) cfg.moe.io_threads = env_int("BMOE_IO_THREADS", 4);
-    if (!cfg.progress) cfg.progress = env_int("BMOE_PROGRESS", 0) != 0;
-    if (!cfg.moe.overlap) cfg.moe.overlap = env_int("BMOE_OVERLAP", 0) != 0;
-    if (cfg.moe.prefetch_layers == 0) cfg.moe.prefetch_layers = env_int("BMOE_PREFETCH", 0);
-    if (cfg.n_expert_used == 0) cfg.n_expert_used = env_int("BMOE_N_EXPERT_USED", 0);
+    // Env overrides (flag wins: only apply when the flag was not passed). Asking whether the flag
+    // was typed, not whether its value still equals the default, is what makes an explicit
+    // --cache-mb 0 (cache off) or --io-threads 4 stick. The defaults below match config.h, so an
+    // unset variable leaves the field alone.
+    if (!seen.count("--cache-mb")) cfg.moe.cache_mb = env_int("BMOE_CACHE_MB", 0);
+    if (!seen.count("--io-threads")) cfg.moe.io_threads = env_int("BMOE_IO_THREADS", 4);
+    if (!seen.count("--progress")) cfg.progress = env_int("BMOE_PROGRESS", 0) != 0;
+    if (!seen.count("--overlap")) cfg.moe.overlap = env_int("BMOE_OVERLAP", 0) != 0;
+    if (!seen.count("--prefetch")) cfg.moe.prefetch_layers = env_int("BMOE_PREFETCH", 0);
+    if (!seen.count("--n-expert-used")) cfg.n_expert_used = env_int("BMOE_N_EXPERT_USED", 0);
 
     if (cfg.model_path.empty()) {
         print_usage(argv[0]);

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -57,7 +57,10 @@ data class AppSettings(
             "-m", modelPath,
             "-t", threads.toString(),
             "-c", SESSION_CTX.toString(),
-            "--chatml", // apply the model family's chat turn (gemma / chatml)
+            // Render the model's OWN chat template, whichever family it belongs to; the flag name
+            // is historical (ChatML is only llama.cpp's fallback when a gguf ships no template).
+            // Nothing here selects a format, so it is correct for every model in the catalog.
+            "--chatml",
             "--session",
         )
         // Active-expert (top-k) override is a load-time kv_override, valid with or without

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/GgufHeader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/GgufHeader.kt
@@ -50,42 +50,6 @@ object GgufHeader {
         runCatching { f.inputStream().buffered().use { parseIsMoe(Counting(it)) } }
             .getOrElse { substringFallback(f) }
 
-    /**
-     * The gguf `general.architecture` string (e.g. "gemma4", "qwen3moe"), or null if it can't
-     * be read. Used to pick the right chat turn format and to gate arch-specific prompt switches.
-     * Cheap: this key is normally the first KV, so only a few hundred bytes are read.
-     */
-    fun arch(f: File): String? =
-        runCatching { f.inputStream().buffered().use { parseArch(Counting(it)) } }.getOrNull()
-
-    private fun parseArch(s: Counting): String? {
-        readMagicAndVersion(s)
-        s.u64() // tensor count
-        val kvCount = s.u64()
-        if (kvCount < 0) return null
-        for (i in 0 until kvCount) {
-            val key = readString(s)
-            val type = s.u32()
-            if (key == "general.architecture" && type == T_STRING) return readString(s)
-            skipValue(s, type)
-            if (s.pos > MAX_HEADER_BYTES) return null
-        }
-        return null
-    }
-
-    // Read and validate the "GGUF" magic and version (v2+); throws on anything else.
-    private fun readMagicAndVersion(s: Counting) {
-        val magic = ByteArray(4)
-        s.readFully(magic)
-        if (magic[0].toInt() != 'G'.code || magic[1].toInt() != 'G'.code ||
-            magic[2].toInt() != 'U'.code || magic[3].toInt() != 'F'.code
-        ) {
-            throw IllegalArgumentException("not a gguf file")
-        }
-        val version = s.u32()
-        if (version < 2) throw IllegalArgumentException("unsupported gguf version $version")
-    }
-
     private fun parseIsMoe(s: Counting): Boolean {
         val magic = ByteArray(4)
         s.readFully(magic)


### PR DESCRIPTION
Two cleanups found by a file-by-file audit of `main`. Neither touches the streaming path.

## An explicit flag now really does beat the environment variable

`bmoe-cli` documents, twice, that a flag always wins over the matching `BMOE_*` override. It
decided whether a flag had been passed by asking whether the field still held its default —
a different question for any flag whose default is a value someone might deliberately pass:

| invocation | before | after |
|---|---|---|
| `BMOE_IO_THREADS=8 --io-threads 4` | 8 | **4** |
| `BMOE_CACHE_MB=2000 --cache-mb 0` (cache off) | 2000 | **0** |
| `BMOE_CACHE_MB=2000` (no flag) | 2000 | 2000 |
| `--io-threads 4` (no env) | 4 | 4 |

`--prefetch 0` and `--n-expert-used 0` had the same shape. The app passes `--io-threads <n>`
on every run and `--cache-mb 0` in its cache-off branch, so it was exposed to this.

The parse loop now records which flags it was given and the overrides consult that set.
Resolution still sits between parsing and `validate()`, so environment-supplied values are
validated exactly as before. The `cache_auto` special case that used to keep `--cache-mb auto`
safe is gone: `auto` and `0` share one spelling, so asking whether that spelling was typed
already covers both.

## The app's unused gguf architecture probe

`GgufHeader.arch()` existed "to pick the right chat turn format" and had zero callers. That
job is not the app's: `--chatml` initialises the chat templates from the model itself, so the
format comes from the gguf that declares it (ChatML is only llama.cpp's fallback for a model
shipping none), and the one arch-conditional decision the UI does act on — whether thinking can
be switched off — is measured by the engine at `open()` and arrives as `think_ctl`.

Wiring it up would have meant selecting behaviour from a model name, which `session.h:56-57`
explicitly rules out. Deleted, along with the two private helpers that only it reached.
`isMoe()` is untouched. The `--chatml` comment said "(gemma / chatml)", which reads as though
the app chooses between them; reworded.

## Verification

- All 7 host gates green, byte-identity included (`chat_parse`, `think_control`,
  `config_validate`, `moe_gates_qwen3moe`, `moe_gates_gemma4` and the two model builders).
- Precedence checked end to end against the tiny gate model, reading `io_threads` and
  `cache_mb` back out of the `# bmoe_metrics` preamble — the table above is measured, except
  the "before" column, which follows from the old guards.
- Kotlin compiles clean, which is also the check that no caller of the deleted function
  survived.
- `clang-format` 18 clean on `cli/main.cpp`.

No version bump and no APK rebuild: there is no user-visible feature here, and no engine path
changed, so nothing is owed an on-device A/B.
