### PR TITLE
fix(tools): make the diagnostics fail instead of reporting a confident wrong number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.13.3] - 2026-07-20
+
+Diagnostics only — no engine, CLI or app behaviour changes, so the Android version is unchanged.
+Both tools ship measurements that are quoted as evidence in `docs/roadmap.md`, and both had a way
+to produce a confident wrong number rather than an error.
+
+### Fixed
+- **`route-replay.py` no longer reports a fabricated ~100 % hit rate when the trace preamble is
+  incomplete.** `cost()` defaulted a layer with no recorded `expert_bytes` to **zero bytes**: such a
+  layer was admitted for free, never counted against the budget and was never evicted. A trace
+  missing its per-layer preamble therefore did not fail — it printed a full, plausible table in
+  which *every* policy scored the same near-perfect number. Measured on a gate-model trace with the
+  preamble stripped: the old code prints `96.9 %` across all six policies; it now exits with the
+  reason and names the layer. The recorded traces behind the published curves all carry complete
+  preambles, so no result in `docs/` changes.
+- **An unknown `--policies` name is rejected instead of silently running LRU.** A typo (`lur`) fell
+  through every branch of `victim()` to the LRU default and was tabulated under its own column
+  header, so the output claimed to compare a policy that never ran.
+- **`bmoe-iobench` asks the OS for its alignment instead of assuming 4096.** Page size is the very
+  variable this tool exists to characterise; on a device with a 16 KiB page the sweep was measuring
+  the wrong alignment. It now uses `pio::vm_page()`, the same source the engine uses.
+- **`bmoe-iobench --slice-kb` is documented in the unit it actually takes.** The usage text said
+  "bytes per read, default 4096" for a value multiplied by 1024 — every figure the tool printed was
+  open to being read off by a factor of 1024. It is KiB, and the default is 4 MiB.
+
 ## [0.13.2] - 2026-07-20
 
 ### Fixed

--- a/scripts/route-replay.py
+++ b/scripts/route-replay.py
@@ -142,7 +142,16 @@ class Sim:
         return il * self.n_expert + e
 
     def cost(self, il):
-        return self.ebytes.get(il, 0)
+        # Never default to 0. A layer that costs nothing is admitted for free, never counts against
+        # the budget and is never evicted -- so a missing preamble does not fail, it reports ~100%
+        # hit at every budget. That is a wrong answer wearing the costume of a good one.
+        try:
+            return self.ebytes[il]
+        except KeyError:
+            raise SystemExit(
+                "route-replay: no expert_bytes for layer %d in the trace preamble; "
+                "the replay cannot size the cache. Re-record the trace with a complete preamble." % il
+            )
 
     # -- eviction victims ---------------------------------------------------------------
     def victim(self, protected, il_cur):
@@ -246,7 +255,11 @@ def main():
     ap = argparse.ArgumentParser(description="replay a route trace through cache policies")
     ap.add_argument("trace")
     ap.add_argument("--budgets", default="", help="MiB, comma separated (default: a sweep)")
-    ap.add_argument("--policies", default=",".join(POLICIES))
+    # choices= would reject the comma-joined default, so the list is validated after the split
+    # below. Silently aliasing an unknown name to LRU under its own column header is the one
+    # failure mode this argument must not have.
+    ap.add_argument("--policies", default=",".join(POLICIES),
+                    help="comma separated, from: %s" % ", ".join(POLICIES))
     ap.add_argument("--validate", type=float, default=None,
                     help="budget MiB whose LRU row must reproduce the recorded hit rate")
     ap.add_argument("--turn", type=int, default=None)
@@ -269,6 +282,10 @@ def main():
     print("T       %.0f MiB touched per token cycle (all layers x top-k, worst case)" % (cycle / MIB))
 
     policies = [p for p in args.policies.split(",") if p]
+    unknown = [p for p in policies if p not in POLICIES]
+    if unknown:
+        raise SystemExit("route-replay: unknown policy %s; known: %s"
+                         % (", ".join(unknown), ", ".join(POLICIES)))
     if args.validate is not None:
         sim = run_one(batches, n_prefill, tr, "lru", args.validate)
         print("\nvalidation @ %.0f MiB: LRU replay = %.1f%% cumulative (%.1f%% decode-only)"

--- a/tools/iobench.cpp
+++ b/tools/iobench.cpp
@@ -60,8 +60,13 @@ struct LaneResult {
 // One lane: random-offset reads of `slice` bytes until the deadline. Offsets are block-aligned and
 // kept a slice away from EOF so every read is a full window (the sub-alignment tail would otherwise
 // take FileReader's buffered fallback and quietly measure the page cache instead of the drive).
-void lane_worker(bmoe::FileReader * r, int lane, size_t slice, size_t align, uint64_t fsize,
-                 clock_t_::time_point deadline, LaneResult * out) {
+void lane_worker(bmoe::FileReader * r,
+                 int lane,
+                 size_t slice,
+                 size_t align,
+                 uint64_t fsize,
+                 clock_t_::time_point deadline,
+                 LaneResult * out) {
     void * dst = bmoe::pio::alloc_aligned(align, slice);
     if (!dst) return;
     const uint64_t span = (fsize > slice * 2) ? (fsize - slice * 2) : 0;
@@ -92,7 +97,8 @@ void load_worker(clock_t_::time_point deadline, std::atomic<bool> * stop) {
     volatile double sink = 0.0;
     double x = 1.000001;
     while (!stop->load(std::memory_order_relaxed) && clock_t_::now() < deadline) {
-        for (int i = 0; i < 4096; ++i) x = x * 1.0000001 + 1e-9;
+        for (int i = 0; i < 4096; ++i)
+            x = x * 1.0000001 + 1e-9;
         sink = sink + x;
         if (x > 1e6) x = 1.000001;
     }
@@ -102,10 +108,12 @@ void load_worker(clock_t_::time_point deadline, std::atomic<bool> * stop) {
 // One row of the sweep: open a reader with `lanes` lanes, run them all for `seconds`, report the
 // aggregate. The reader is opened and closed per row so each row pays its own warm-up and no lane
 // inherits another row's fd state.
-bool run_row(const std::string & path, int lanes, size_t slice, bool direct, double seconds, int load,
-             double * mibs_out) {
+bool run_row(
+    const std::string & path, int lanes, size_t slice, bool direct, double seconds, int load, double * mibs_out) {
     bmoe::FileReader r;
-    const size_t align = 4096;
+    // Ask the OS rather than assuming 4096: alignment is exactly the variable this tool exists to
+    // characterise, so a device with a 16 KiB page must be measured at its own page size, not ours.
+    const size_t align = bmoe::pio::vm_page();
     const size_t bounce_cap = slice + 2 * align; // mirrors what the streamer asks for
     if (!r.open(path, lanes, direct, align, bounce_cap)) {
         std::fprintf(stderr, "open failed (lanes=%d)\n", lanes);
@@ -120,14 +128,17 @@ bool run_row(const std::string & path, int lanes, size_t slice, bool direct, dou
     std::atomic<bool> stop{false};
     std::vector<std::thread> loaders;
     loaders.reserve((size_t) (load > 0 ? load : 0));
-    for (int i = 0; i < load; ++i) loaders.emplace_back(load_worker, deadline, &stop);
+    for (int i = 0; i < load; ++i)
+        loaders.emplace_back(load_worker, deadline, &stop);
 
     for (int i = 0; i < lanes; ++i)
         th.emplace_back(lane_worker, &r, i, slice, align, r.file_size(), deadline, &res[(size_t) i]);
-    for (auto & t : th) t.join();
+    for (auto & t : th)
+        t.join();
     const double wall_s = std::chrono::duration<double>(clock_t_::now() - t0).count();
     stop.store(true); // lanes are done; do not let the load run past the measured window
-    for (auto & t : loaders) t.join();
+    for (auto & t : loaders)
+        t.join();
 
     long long bytes = 0, reads = 0, busy_ns = 0;
     for (const auto & x : res) {
@@ -151,7 +162,7 @@ bool run_row(const std::string & path, int lanes, size_t slice, bool direct, dou
 void usage(const char * a0) {
     std::fprintf(stderr,
                  "usage: %s --model PATH [--lanes 1,2,4,8,16] [--slice-kb N] [--seconds S] [--buffered]\n"
-                 "  --slice-kb      bytes per read, default 4096 (a typical expert projection slice)\n"
+                 "  --slice-kb      KiB per read, default 4096 (= 4 MiB, a typical expert slice)\n"
                  "  --buffered      drop O_DIRECT, to see what the page cache contributes\n"
                  "  --compute-load  N CPU-burning threads alongside the lanes (default 0), to read\n"
                  "                  under the contention the streamer actually faces\n",


### PR DESCRIPTION
Both `scripts/route-replay.py` and `tools/bmoe-iobench` produce numbers that are already quoted as
evidence in `docs/roadmap.md`. Each had a path that returned an answer where it could not support
one. No engine, CLI or app code is touched — the Android version is unchanged.

## The one that matters

`route-replay.py`'s `cost()` defaulted a layer with no recorded `expert_bytes` to **zero bytes**. A
layer that costs nothing is admitted for free, never counts against the budget and is never
evicted — so a trace missing its per-layer preamble did not fail. It printed a full, plausible
table in which *every* policy scored the same near-perfect number.

Reproduced on a real qwen3moe gate-model trace with the `# layer=` lines stripped:

| | belady | lru | lfu | random | layer | layerlfu |
|---|---|---|---|---|---|---|
| before | 96.9 | 96.9 | 96.9 | 96.9 | 96.9 | 96.9 |
| after | *exits, naming the layer and the reason* | | | | | |

The recorded traces behind the published curves all carry complete preambles, so **no result in
`docs/` changes.**

## The other three

- **Unknown `--policies` name silently ran LRU.** A typo (`lur`) fell through every branch of
  `victim()` to the LRU default and was tabulated under its own column header — output claiming to
  compare a policy that never ran. `argparse`'s `choices=` cannot express a comma-joined list, so
  the names are validated after the split.
- **`bmoe-iobench` hardcoded `align = 4096`.** Alignment is the variable the tool exists to
  characterise; on a 16 KiB-page device it measured the wrong one. Now `pio::vm_page()`, the
  engine's own source.
- **`--slice-kb` was documented as "bytes per read, default 4096"** for a value multiplied by 1024.
  Every printed figure was open to being read off by 1024×. It is KiB; the default is 4 MiB.

## Verification

- Replay accepted a real qwen3moe route trace and reproduced the known **LRU cliff** shape (0 %
  below one token cycle, `T = 2 MiB`) — the fix does not perturb correct input.
- `--policies lur` now rejected; stripped preamble now fails loudly (table above).
- `bmoe-iobench` rebuilt with `BMOE_BUILD_TOOLS=ON` and swept — still negotiates **O_DIRECT** at
  the queried page size (`mode = direct`).
- Host gates **7/7**, clang-format 18 clean on the touched file.

## Known follow-up, deliberately not in this PR

`tools/` is outside both CI jobs: nothing sets `BMOE_BUILD_TOOLS=ON`, and the format gate runs
`find core cli tests`. That is how `iobench.cpp` reached `main` unformatted (fixed here). Widening
the CI scope is a separate change to `.github/workflows/ci.yml`.
