### PR TITLE
test(memory): reclaim-exempt memory for the dense weights — bandwidth gate passes, 2047 MiB cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.13.5] - 2026-07-21
+
+Diagnostics only — no engine, CLI or app behaviour changes, so the Android version is unchanged.
+
+### Added
+- **`bmoe-membench`**: measures read bandwidth of the allocations the dense weights can live in,
+  comparing an anonymous mapping against a locked `AHardwareBuffer` BLOB. It exists to gate an idea
+  rather than to tune one: dma-buf pages are the only allocation an unprivileged Android app can
+  make that reclaim cannot touch, but gralloc decides per allocation whether a buffer is
+  CPU-cacheable, and an uncached mapping would read at or below the flash bandwidth it is meant to
+  save. `--probe-max` reports the largest usable buffer; `--repeat` interleaves the comparison.
+- **Measured: reclaim-exempt memory is full-speed, and capped at 2047 MiB.** A locked BLOB reads
+  within 0.5% of anonymous memory on both CPU clusters and at 4 threads, and the `CPU_READ_OFTEN`
+  hint makes no difference. Allocation reaches the 4 GiB format cap, but `AHardwareBuffer_lock`
+  fails with `EINVAL` at exactly 2^31 bytes, so larger working sets must be split across buffers.
+  The bandwidth gate passes; **whether pinning the dense weights helps remains unmeasured**, and
+  reclaim-exempt memory does not create memory. Data in
+  [docs/bench-data/2026-07-21-pinned-memory/](docs/bench-data/2026-07-21-pinned-memory/findings.md);
+  the lever table in `docs/android-memory.md` now carries the dma-buf row it was missing.
+
+### Fixed
+- `bmoe-membench --probe-max` initially probed allocation only and reported ~2× the usable size,
+  because the lock that turns a BLOB into a CPU pointer fails long before allocation does. It now
+  locks every candidate. Same class of defect as 0.13.3's: a diagnostic returning a confident
+  wrong number rather than an error.
+
 ## [0.13.4] - 2026-07-20
 
 Diagnostics and a recorded negative result — no engine, CLI or app behaviour changes.

--- a/docs/android-memory.md
+++ b/docs/android-memory.md
@@ -143,6 +143,7 @@ steal file cache — we evict our own dense weights when we allocate too fast.
 | Memory Advice API | **deprecated**; only warns, never keeps anything resident |
 | `MAP_POPULATE` | prefaults, does **not** pin. Load speed only |
 | **`MADV_COLD` / `MADV_PAGEOUT`** (5.4+) | **the one real lever** — unprivileged. Can't stop reclaim, but *chooses its victims*: volunteer your own cold tail so kswapd finds cheap targets and you cut direct-reclaim stalls |
+| **dma-buf via `AHardwareBuffer`** | **open, and the only allocation here that reclaim cannot touch** — those pages stay pinned because a device may DMA from them at any time, and no capability is needed. Reads at full anonymous-memory speed (measured 1.00×, [2026-07-21](bench-data/2026-07-21-pinned-memory/findings.md)). Capped at **2047 MiB per buffer**: `AHardwareBuffer_lock` fails with `EINVAL` at 2^31 bytes even though allocation reaches the 4 GiB format cap. **Untested against real pressure** — see below |
 
 **lmkd never reclaims — it only kills — and here it is silent by design.** It early-returns while
 `SwapFree >= swap_free_low_percentage` (10%) of total; we sit at 70–79%. **The 12 GB swap is exactly
@@ -156,6 +157,34 @@ to raise it. **Android has no equivalent of either.** No on-device runtime surve
 MediaPipe/LiteRT, ONNX Runtime, ExecuTorch) pins weights on Android or publishes a "stay under X% of
 RAM" rule; llama.cpp's `--mlock` fails here for the reason above, and ExecuTorch explicitly maps
 Android to `NoMlock`.
+
+## The dma-buf exception, and what it does not solve
+
+Everything above is about memory the kernel is *allowed* to take. There is one allocation it is not:
+a **dma-buf**, whose pages are pinned for the lifetime of the buffer because a device may DMA from
+them at any moment. An app reaches one through `AHardwareBuffer` with format `BLOB` — no capability,
+no root, and it sidesteps `RLIMIT_MEMLOCK` entirely, since it is not `mlock` at all.
+
+Measured properties on the test device ([data](bench-data/2026-07-21-pinned-memory/findings.md)):
+
+| property | value |
+|---|---|
+| read bandwidth vs anonymous memory | **1.00×** — 30.4 GiB/s and 45.2 GiB/s on the two clusters, 59.0 at 4 threads, all matching anon within 0.5% |
+| `CPU_READ_OFTEN` vs `CPU_READ_RARELY` | no difference; the hint does not have to be coaxed |
+| max usable size | **2047 MiB per buffer** — `AHardwareBuffer_lock` returns `EINVAL` at 2^31 bytes, a signed-32-bit boundary, though allocation reaches the 4 GiB format cap |
+| allocation cost | ~7–11 GiB/s, i.e. a few hundred ms once, at load |
+
+That the bandwidth is ordinary is the load-bearing result, because it was the plausible way for the
+idea to be dead on arrival: gralloc chooses per allocation whether a buffer is CPU-cacheable, and an
+uncached mapping would read at or below flash bandwidth — making pinned weights slower than
+refaulting them.
+
+**None of that is an argument that pinning the dense weights helps.** Reclaim-exempt memory does not
+create memory: under a >RAM model, RAM the dense weights no longer yield has to come from the expert
+cache or from the page cache feeding the streaming path. That is the same trade that refuted the
+bulk restore (below) and the per-layer LFU cap. And these measurements never put the device under
+the pressure a >RAM decode creates, so "the kernel cannot reclaim it" remains an inference from how
+dma-buf works rather than something observed here. The lever is **open, and unproven**.
 
 ## Why restoring reclaimed pages cannot win
 

--- a/docs/bench-data/2026-07-21-pinned-memory/findings.md
+++ b/docs/bench-data/2026-07-21-pinned-memory/findings.md
@@ -1,0 +1,83 @@
+# Reclaim-exempt memory for the dense weights — bandwidth gate PASSES (2026-07-21)
+
+**Verdict: a locked `AHardwareBuffer` BLOB reads at exactly anonymous-memory speed, so the one
+allocation Android will not reclaim is not disqualified by bandwidth. This clears a gate; it does
+not show a win. Whether pinning the dense weights makes the engine faster is still unmeasured.**
+
+`docs/android-memory.md` lists every lever for keeping the dense weights resident and finds all of
+them closed. The table had one omission: **dma-buf**, whose pages are exempt from reclaim by
+construction because a device may DMA from them at any time, and which an unprivileged app can
+allocate through `AHardwareBuffer`. The reason to check bandwidth before building anything is that
+gralloc decides per allocation whether a buffer is CPU-cacheable — the kernel even ships a dedicated
+uncached system heap — and uncached memory would read at or below the flash bandwidth it is meant to
+save, making pinned dense weights *worse* than refaulting them. That asymmetry is what made this a
+gate rather than a preference. Raw output in [`membench-runs.log`](membench-runs.log).
+
+## Result: the two allocations are indistinguishable
+
+Interleaved, CPU-pinned, `--mib 512`, best MiB/s per row:
+
+| placement | ahwb | anon | ratio |
+|---|---|---|---|
+| cpu2 (policy0), 1 thread | 30392 / 30399 / 30310 | 30423 / 30394 / 30438 | **1.00** |
+| cpu6 (policy6), 1 thread | 45065 / 45175 / 45176 | 45219 / 45183 / 45278 | **1.00** |
+| all cores, 4 threads, 1 GiB | 59016 / 58960 | 58902 / 59024 | **1.00** |
+
+Every pair agrees within 0.5%, which is inside this tool's run-to-run spread. For scale, the flash
+this would displace serves ~1815–1980 MiB/s (`iobench-ceiling.md`): pinned memory reads **15–30×
+faster than the storage path**, exactly as ordinary memory does.
+
+`--usage rarely` produces the same numbers as `--usage often`. Either gralloc ignores the CPU-read
+hint for BLOB, or both map cacheable; either way the mapping does not have to be coaxed.
+
+## The binding constraint is size, and it is not where the docs point
+
+Two different ceilings, and the lower one is undocumented:
+
+- **Allocation** succeeds up to 4095 MiB — the cap implied by `AHardwareBuffer_Desc::width` being
+  32-bit, which for BLOB *is* the byte count.
+- **`AHardwareBuffer_lock`**, which is what turns the buffer into a usable CPU pointer, refuses at
+  exactly 2048 MiB with `EINVAL` while 2047 MiB succeeds. A boundary landing precisely on 2^31 is a
+  signed-32-bit type in the lock path, not memory exhaustion.
+
+So the usable unit is **2047 MiB**, and any larger working set must be split across several buffers.
+That is not an obstacle for this engine — `dense_weights` already allocates per tensor — but it is a
+hard constraint on any design that assumed one buffer, and it is invisible to a probe that only
+allocates. The first version of `--probe-max` did exactly that and reported double the usable size;
+it now locks every candidate.
+
+Allocation cost scales linearly at roughly 7–11 GiB/s (512 MiB ≈ 36–72 ms, 1792 MiB ≈ 222 ms), so a
+multi-GiB dense set would pay a few hundred ms once at load.
+
+## Methodology: the first run was wrong, and how
+
+The first, un-pinned run reported **ahwb = 0.67× anon** — a clean, plausible, completely false
+result. Swapping the mode order inverted it. Every reading in the session is either ~45400 or
+~30400 MiB/s regardless of mode: those are the device's two CPU clusters, and the scheduler's choice
+of core moves this number 1.5×, far more than the allocator does. Notably the faster cluster is the
+one running at the *lower* clock (1.86 GHz vs 2.27 GHz under the vendor cap) — wider cores, so
+frequency alone would have mispredicted the direction too.
+
+`--repeat` (interleaved rounds) and `taskset` were added in response. The general lesson matches the
+one already recorded for tok/s benchmarking: **a single A-then-B pass ranks two conditions that were
+never controlled for.**
+
+## What this does NOT show
+
+- **That pinning helps.** Reclaim-exempt memory does not create memory. Under a >RAM model the RAM
+  the dense weights stop yielding must come out of the expert cache or the page cache that feeds the
+  streaming path, and the same reasoning already refuted the rewarm attempt (PR #28) and the
+  per-layer LFU cap. The plausible failure mode is not "it doesn't work" but "`dense_resident_frac`
+  goes to 1.0 and tok/s falls".
+- **That it survives memory pressure the way the theory says.** These runs allocate and read; none
+  of them put the device under the pressure that a >RAM decode creates, so "the kernel cannot
+  reclaim it" is still an inference from how dma-buf works, not a measurement.
+- **That it is portable.** One device, one gralloc. The 2 GiB lock boundary in particular is a
+  driver-side property and may differ elsewhere.
+
+## Next step
+
+An in-app A/B of a `--dense-weights ahwb` mode against `--dense-weights anon`, on the same protocol
+as the other engine-level tests, with `dense_resident_frac` and majflt/token read alongside tok/s.
+Prior expectation stays where it was before this measurement: the two best-argued memory experiments
+in this repo's history both measured negative, and this one has the same shape.

--- a/docs/bench-data/2026-07-21-pinned-memory/membench-runs.log
+++ b/docs/bench-data/2026-07-21-pinned-memory/membench-runs.log
@@ -1,0 +1,112 @@
+bmoe-membench, Android arm64 (NDK 29, API 29), test device: 8 cores in two clusters
+(policy0 = cpu0-5, cpuinfo_max 3321600 kHz, vendor-capped to 2265600 during the run;
+ policy6 = cpu6-7, cpuinfo_max 3801600 kHz, vendor-capped to 1862400 during the run).
+11.4 GB RAM. Thermal Status 0 before and after every run; scaling_max_freq unchanged
+across the session, so no clock drift confound.
+
+App force-stopped, no stray bmoe processes, before the first run:
+  MemTotal 11366276 kB  MemFree 381300 kB  MemAvailable 3857500 kB  SwapFree 8980756 kB
+
+
+=== 1. First run, UNPINNED — the misleading one, kept as the methodology lesson ===
+
+$ bmoe-membench --mib 512 --seconds 3 --threads 1
+mode       best_MiB/s   mean_MiB/s   alloc_ms   passes  note
+anon          45410.4      45000.0        0.0      264  reclaimable baseline
+ahwb          30373.7      28425.6      131.9      167  pinned dma-buf
+ahwb / anon = 0.67x
+
+Swapping the order inverts the result, which is what exposes it as core placement:
+
+$ bmoe-membench --mib 512 --seconds 3 --threads 1 --modes ahwb   (then --modes anon)
+round 1:  ahwb 44966.9    anon 30098.0
+round 2:  ahwb 30377.4    anon 45404.3
+
+Every reading is either ~45400 or ~30400 regardless of mode: the two values are the two
+CPU clusters, not the two allocators.
+
+
+=== 2. Pinned single-thread, interleaved x3 — the real comparison ===
+
+$ taskset 04 bmoe-membench --mib 512 --seconds 2 --threads 1 --modes <one mode>
+   (cpu2, policy0)
+  r1  ahwb          30392.2      28554.5       55.6      112
+  r1  anon          30422.6      28645.9        0.0      112
+  r2  ahwb          30398.6      28384.7       60.7      111
+  r2  anon          30393.8      27572.0        0.0      108
+  r3  ahwb          30309.6      28668.5       57.2      113
+  r3  anon          30437.7      28636.9        0.0      112
+
+$ taskset 40 bmoe-membench --mib 512 --seconds 2 --threads 1 --modes <one mode>
+   (cpu6, policy6)
+  r1  ahwb          45065.3      44715.8       56.8      175
+  r1  anon          45219.1      44867.3        0.0      176
+  r2  ahwb          45174.6      44821.0       56.3      176
+  r2  anon          45183.3      44812.3        0.0      176
+  r3  ahwb          45175.9      44797.4       58.3      175
+  r3  anon          45277.6      44959.4        0.0      176
+
+
+=== 3. Cacheability hint: 'rarely' vs 'often' — no difference ===
+
+$ taskset 40 bmoe-membench --mib 512 --seconds 2 --threads 1 --repeat 2 --usage rarely --modes ahwb,anon
+ rep mode       best_MiB/s   mean_MiB/s   alloc_ms   passes
+   1 ahwb          45261.8      44933.6       55.4      176
+   1 anon          45214.3      44898.0        0.0      176
+   2 ahwb          45214.1      44946.1       35.9      176
+   2 anon          45265.3      44934.6        0.0      176
+ahwb / anon = 1.00x
+
+
+=== 4. Multi-threaded, all cores — the matmul-representative row ===
+
+$ bmoe-membench --mib 1024 --seconds 2 --threads 4 --repeat 2 --modes ahwb,anon
+ rep mode       best_MiB/s   mean_MiB/s   alloc_ms   passes
+   1 ahwb          59015.7      58438.0      150.3      115
+   1 anon          58902.1      58461.2        0.0      115
+   2 ahwb          58960.3      58324.7       91.0      114
+   2 anon          59023.9      58424.8        0.0      115
+ahwb / anon = 1.00x
+
+
+=== 5. Size ceiling ===
+
+Allocation-only probe (the first, incomplete version of --probe-max) reached the format cap:
+  64 / 128 / 256 / 512 / 1024 / 2048 / 4095 MiB  -- all allocate
+
+But lock fails where allocate succeeds:
+
+$ taskset 40 bmoe-membench --mib 2048 --seconds 2 --threads 1 --repeat 2 --modes ahwb,anon
+   1 ahwb                -            -      153.7        -  AHardwareBuffer_lock failed (rc=-22)
+   1 anon          45049.8      44441.5        0.0       44
+   2 ahwb                -            -      374.5        -  AHardwareBuffer_lock failed (rc=-22)
+   2 anon          45000.0      44424.2        0.0       44
+
+Manual sweep of the lock boundary (1 s rows, cpu6):
+    768 MiB : ahwb 45102.5   alloc  72.2 ms
+   1024 MiB : ahwb 45116.9   alloc  96.9 ms
+   1280 MiB : ahwb 45026.4   alloc 160.5 ms
+   1536 MiB : ahwb 45008.7   alloc 197.5 ms
+   1792 MiB : ahwb 44889.1   alloc 222.2 ms
+   2047 MiB : ahwb 45068.0   alloc 218.7 ms   <- last size that locks
+   2048 MiB : lock fails, EINVAL                <- 2^31 bytes
+
+$ bmoe-membench --probe-max          (corrected: locks every candidate)
+probing the largest lockable BLOB (32-bit width caps this at 4096 MiB)
+      64 MiB  ok
+     128 MiB  ok
+     256 MiB  ok
+     512 MiB  ok
+    1024 MiB  ok
+    2048 MiB  FAILED
+  max lockable ~2047 MiB (allocation alone reaches the 4096 MiB format cap)
+  larger working sets must be split across several buffers
+
+
+=== Host reference (x86-64 laptop, dual-channel DDR4) — sanity check that the read
+    kernel reaches DRAM speed and is not measuring cache ===
+
+$ bmoe-membench --mib 512 --seconds 2 --threads 1
+anon          16077.7      12796.4        0.0       50
+$ bmoe-membench --mib 512 --seconds 2 --threads 4
+anon          36289.7      33315.1        0.0      131

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,6 +57,18 @@ committed route traces, predicting a token's experts from the run's hottest list
 of the time on gpt-oss against 17.9 % for the previous token's routing. But note what the same
 session found about *spending* memory work to exploit it — see the expert-cache theme below.
 
+Keeping the dense weights resident once they are in has no lever in
+[android-memory.md](android-memory.md) — except one, found on 2026-07-21: a **dma-buf allocated
+through `AHardwareBuffer`** is exempt from reclaim by construction and needs no privilege. Its
+bandwidth gate passes cleanly (1.00× against anonymous memory; usable in 2047 MiB units, an
+`AHardwareBuffer_lock` boundary at 2^31 bytes —
+[bench-data/2026-07-21-pinned-memory/](bench-data/2026-07-21-pinned-memory/findings.md)). What is
+**not** established is that pinning helps: reclaim-exempt memory does not create memory, so under a
+>RAM model the RAM the dense weights stop yielding comes out of the expert cache or the page cache
+feeding the stream — the trade that already refuted the bulk restore and the per-layer LFU cap. The
+open question is a `--dense-weights ahwb` mode measured in-app against `anon`, with
+`dense_resident_frac` and majflt/token read next to tok/s.
+
 ## Expert cache policy — closed, negatively
 
 Whether a smarter eviction policy could raise throughput is **answered, and the answer is no**

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,3 +10,15 @@ target_include_directories(bmoe-iobench PRIVATE ${CMAKE_SOURCE_DIR}/core/src/io)
 target_compile_features(bmoe-iobench PRIVATE cxx_std_17)
 find_package(Threads REQUIRED)
 target_link_libraries(bmoe-iobench PRIVATE Threads::Threads)
+
+# Memory-side counterpart: bandwidth of the allocations the dense weights can live in. It links
+# nothing at all beyond the stdlib — the question is about the allocator and the memory it returns,
+# not about any bmoe code — so it also builds on the host, where the `anon` row still runs and the
+# `ahwb` row reports itself unavailable.
+add_executable(bmoe-membench membench.cpp)
+target_compile_features(bmoe-membench PRIVATE cxx_std_17)
+target_link_libraries(bmoe-membench PRIVATE Threads::Threads)
+if(ANDROID)
+    # AHardwareBuffer_* live in libandroid.so.
+    target_link_libraries(bmoe-membench PRIVATE android)
+endif()

--- a/tools/membench.cpp
+++ b/tools/membench.cpp
@@ -26,6 +26,12 @@
 // the ratio between the two rows is the whole result. An absolute number alone would be worthless,
 // since it would fold in the device's clocks and thermal state.
 //
+// One warning learned from the first run of this tool: on a big.LITTLE phone the result is dominated
+// by WHICH CORE the scheduler picked, not by the allocator. The two clusters here read at 30 and
+// 45 GB/s, so an un-pinned anon-then-ahwb pass produced a confident 0.67x that was pure placement and
+// inverted when the modes were swapped. Interleave with `--repeat`, and pin with `taskset <mask>`
+// before believing any difference smaller than the gap between clusters.
+//
 // Secondary output: `--probe-max` reports the largest BLOB the driver will actually hand over. No
 // limit is documented — the NDK only says allocation may fail on driver constraints — and the dense
 // working set is multiple GiB, so "does it even fit" has to be measured too. Note the format's own
@@ -238,13 +244,15 @@ void free_ahwb() {
     g_ahwb = nullptr;
 }
 
-// Largest BLOB the driver will actually allocate: double until it refuses, then binary-search the
-// gap. Allocation only — no lock, no touch — so this reports what the allocator promises, which is
-// an upper bound on what is usable. It is deliberately separate from the bandwidth rows: a size that
-// allocates but is unusably slow is not a size that helps.
+// Largest BLOB that is actually USABLE: allocation alone is not the ceiling that matters, because
+// the buffer is worthless until `AHardwareBuffer_lock` hands back a CPU pointer — and the two limits
+// are not the same. On the device this was written for, allocation succeeds to the 4 GiB format cap
+// while lock refuses anything at or above 2 GiB with EINVAL, a signed-32-bit boundary inside the
+// lock path. Probing allocation only would therefore report double the size the caller can use, so
+// the probe locks every candidate and reports both ceilings.
 void probe_max() {
     const uint64_t cap = 0xFFFFFFFFULL; // 32-bit BLOB width
-    auto can_alloc = [](uint64_t bytes) -> bool {
+    auto try_size = [](uint64_t bytes, bool with_lock) -> bool {
         if (bytes > 0xFFFFFFFFULL) return false;
         AHardwareBuffer_Desc d{};
         d.width = (uint32_t) bytes;
@@ -254,11 +262,18 @@ void probe_max() {
         d.usage = AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN | AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN;
         AHardwareBuffer * b = nullptr;
         if (AHardwareBuffer_allocate(&d, &b) != 0 || !b) return false;
+        bool ok = true;
+        if (with_lock) {
+            void * p = nullptr;
+            ok = (AHardwareBuffer_lock(b, d.usage, -1, nullptr, &p) == 0 && p != nullptr);
+            if (ok) AHardwareBuffer_unlock(b, nullptr);
+        }
         AHardwareBuffer_release(b);
-        return true;
+        return ok;
     };
+    auto can_alloc = [&](uint64_t bytes) { return try_size(bytes, true); };
 
-    std::printf("probing the largest allocatable BLOB (32-bit width caps this at 4096 MiB)\n");
+    std::printf("probing the largest lockable BLOB (32-bit width caps this at 4096 MiB)\n");
     uint64_t good = 0, bad = 0;
     for (uint64_t mib = 64; mib * 1024 * 1024 <= cap; mib *= 2) {
         const uint64_t bytes = mib * 1024 * 1024;
@@ -273,18 +288,33 @@ void probe_max() {
         }
     }
     if (bad == 0) {
-        std::printf("  every probed size allocated; ceiling is the 4 GiB format cap, not the driver\n\n");
-        return;
+        // Doubling stops at 2048 MiB because 4096 MiB does not fit the 32-bit width. Claiming the
+        // format cap without trying it would be asserting the very thing being probed, so ask for
+        // the largest representable BLOB explicitly.
+        if (can_alloc(cap)) {
+            std::printf("  %6llu MiB  ok\n", (unsigned long long) (cap / (1024 * 1024)));
+            std::printf("  the largest representable BLOB locked; the ceiling is the 32-bit format\n"
+                        "  cap, not the driver\n\n");
+            return;
+        }
+        std::printf("  %6llu MiB  FAILED\n", (unsigned long long) (cap / (1024 * 1024)));
+        good = 2048ULL * 1024 * 1024;
+        bad = cap;
     }
-    // 16 MiB is fine enough: the decision this informs is "does several GiB fit", not the exact byte.
-    while (bad - good > 16ULL * 1024 * 1024) {
+    // Refine to 1 MiB. Coarser would be enough to answer "do several GiB fit", but a ceiling that
+    // lands exactly on a power of two is evidence about *why* it is there — a driver running out of
+    // memory stops at an arbitrary size, an integer type stops at 2^31 — and that changes whether
+    // chunking around it is safe.
+    while (bad - good > 1024ULL * 1024) {
         const uint64_t mid = good + (bad - good) / 2;
         if (can_alloc(mid))
             good = mid;
         else
             bad = mid;
     }
-    std::printf("  max allocatable ~%llu MiB\n\n", (unsigned long long) (good / (1024 * 1024)));
+    std::printf("  max lockable ~%llu MiB (allocation alone reaches %s)\n", (unsigned long long) (good / (1024 * 1024)),
+                try_size(cap, false) ? "the 4096 MiB format cap" : "no further");
+    std::printf("  larger working sets must be split across several buffers\n\n");
 }
 #endif // BMOE_HAVE_AHWB
 
@@ -293,7 +323,11 @@ void usage(const char * a0) {
                  "usage: %s [--mib N] [--modes anon,ahwb] [--seconds S] [--threads N]\n"
                  "  --mib       buffer size, default 512 (must exceed the last-level cache, or the\n"
                  "              read loop measures cache instead of DRAM)\n"
-                 "  --modes     comma list of anon,ahwb (default both; ahwb is Android-only)\n"
+                 "  --modes     comma list of anon,ahwb, run IN THE ORDER GIVEN (default both;\n"
+                 "              ahwb is Android-only)\n"
+                 "  --repeat    N interleaved rounds of the mode list, default 1. Use it: core\n"
+                 "              placement moves this number more than the allocator does, so a\n"
+                 "              single round can rank two placements and call it a result.\n"
                  "  --threads   readers running concurrently, default 1. Single-thread separates\n"
                  "              cached from uncached most clearly; the multi-thread row is the one\n"
                  "              comparable to a matmul, which reads from every compute thread.\n"
@@ -310,6 +344,7 @@ int main(int argc, char ** argv) {
     std::string modes = "anon,ahwb";
     double seconds = 3.0;
     int threads = 1;
+    int repeat = 1;
     bool read_often = true;
     bool probe = false;
 
@@ -330,6 +365,8 @@ int main(int argc, char ** argv) {
             seconds = std::atof(next("--seconds"));
         else if (a == "--threads")
             threads = std::atoi(next("--threads"));
+        else if (a == "--repeat")
+            repeat = std::atoi(next("--repeat"));
         else if (a == "--usage")
             read_often = std::string(next("--usage")) != "rarely";
         else if (a == "--probe-max")
@@ -339,7 +376,7 @@ int main(int argc, char ** argv) {
             return 2;
         }
     }
-    if (mib == 0 || threads < 1) {
+    if (mib == 0 || threads < 1 || repeat < 1) {
         usage(argv[0]);
         return 2;
     }
@@ -355,42 +392,68 @@ int main(int argc, char ** argv) {
     }
 
     const size_t bytes = mib * 1024 * 1024;
-    std::printf("buffer %zu MiB, %.1f s per mode, %d reader thread(s), cpu-read hint '%s'\n\n", mib, seconds, threads,
-                read_often ? "often" : "rarely");
-    std::printf("%-8s %12s %12s %10s %8s  %s\n", "mode", "best_MiB/s", "mean_MiB/s", "alloc_ms", "passes", "note");
-
-    double anon_best = 0.0, ahwb_best = 0.0;
-    const bool want_anon = modes.find("anon") != std::string::npos;
-    const bool want_ahwb = modes.find("ahwb") != std::string::npos;
-
-    if (want_anon) {
-        Alloc a = alloc_anon(bytes);
-        if (!a.base) {
-            std::printf("%-8s %12s %12s %10.1f %8s  %s\n", "anon", "-", "-", a.alloc_ms, "-", "allocation failed");
-        } else {
-            const BwResult r = measure(a.base, bytes, seconds, threads);
-            anon_best = r.best_mibs;
-            std::printf("%-8s %12.1f %12.1f %10.1f %8d  %s\n", "anon", r.best_mibs, r.mean_mibs, a.alloc_ms, r.passes,
-                        "reclaimable baseline");
-            free_anon(a.base, bytes);
+    std::vector<std::string> order;
+    for (size_t p = 0; p < modes.size();) {
+        const size_t c = modes.find(',', p);
+        std::string tok = modes.substr(p, c == std::string::npos ? std::string::npos : c - p);
+        if (tok == "anon" || tok == "ahwb")
+            order.push_back(tok);
+        else if (!tok.empty()) {
+            std::fprintf(stderr, "unknown mode '%s'\n", tok.c_str());
+            return 2;
         }
+        if (c == std::string::npos) break;
+        p = c + 1;
+    }
+    if (order.empty()) {
+        usage(argv[0]);
+        return 2;
     }
 
-    if (want_ahwb) {
+    std::printf("buffer %zu MiB, %.1f s per mode, %d reader thread(s), %d repeat(s), cpu-read hint '%s'\n\n", mib,
+                seconds, threads, repeat, read_often ? "often" : "rarely");
+    std::printf("%4s %-8s %12s %12s %10s %8s  %s\n", "rep", "mode", "best_MiB/s", "mean_MiB/s", "alloc_ms", "passes",
+                "note");
+
+    double anon_best = 0.0, ahwb_best = 0.0;
+    // Modes run in the order given and are re-run `repeat` times, so an A/B can be interleaved
+    // within one invocation. That is not a convenience: bandwidth here is dominated by which core
+    // the scheduler picked, so a single anon-then-ahwb pass compares two placements as readily as
+    // two allocators. Interleave, and pin with `taskset` when the numbers still disagree.
+    for (int rep = 1; rep <= repeat; ++rep) {
+        for (const std::string & m : order) {
+            if (m == "anon") {
+                Alloc a = alloc_anon(bytes);
+                if (!a.base) {
+                    std::printf("%4d %-8s %12s %12s %10.1f %8s  %s\n", rep, "anon", "-", "-", a.alloc_ms, "-",
+                                "allocation failed");
+                    continue;
+                }
+                const BwResult r = measure(a.base, bytes, seconds, threads);
+                anon_best = std::max(anon_best, r.best_mibs);
+                std::printf("%4d %-8s %12.1f %12.1f %10.1f %8d  %s\n", rep, "anon", r.best_mibs, r.mean_mibs,
+                            a.alloc_ms, r.passes, "reclaimable baseline");
+                free_anon(a.base, bytes);
+            } else {
 #if BMOE_HAVE_AHWB
-        Alloc a = alloc_ahwb(bytes, read_often);
-        if (!a.base) {
-            std::printf("%-8s %12s %12s %10.1f %8s  %s\n", "ahwb", "-", "-", a.alloc_ms, "-", a.note.c_str());
-        } else {
-            const BwResult r = measure(a.base, bytes, seconds, threads);
-            ahwb_best = r.best_mibs;
-            std::printf("%-8s %12.1f %12.1f %10.1f %8d  %s\n", "ahwb", r.best_mibs, r.mean_mibs, a.alloc_ms, r.passes,
-                        "pinned dma-buf");
-            free_ahwb();
-        }
+                Alloc a = alloc_ahwb(bytes, read_often);
+                if (!a.base) {
+                    std::printf("%4d %-8s %12s %12s %10.1f %8s  %s\n", rep, "ahwb", "-", "-", a.alloc_ms, "-",
+                                a.note.c_str());
+                    continue;
+                }
+                const BwResult r = measure(a.base, bytes, seconds, threads);
+                ahwb_best = std::max(ahwb_best, r.best_mibs);
+                std::printf("%4d %-8s %12.1f %12.1f %10.1f %8d  %s\n", rep, "ahwb", r.best_mibs, r.mean_mibs,
+                            a.alloc_ms, r.passes, "pinned dma-buf");
+                free_ahwb();
 #else
-        std::printf("%-8s %12s %12s %10s %8s  %s\n", "ahwb", "-", "-", "-", "-", "not an Android build");
+                std::printf("%4d %-8s %12s %12s %10s %8s  %s\n", rep, "ahwb", "-", "-", "-", "-",
+                            "not an Android build");
 #endif
+            }
+            std::fflush(stdout);
+        }
     }
 
     if (anon_best > 0.0 && ahwb_best > 0.0) {

--- a/tools/membench.cpp
+++ b/tools/membench.cpp
@@ -1,0 +1,409 @@
+// bmoe-membench — can dense weights live in memory the kernel is not allowed to reclaim?
+//
+// The dense (non-expert) weights are the one part of the model that must stay resident: they are
+// touched for every token, and when Android's kswapd evicts them the engine refaults them off flash
+// on the next token. `mlock` cannot defend them — the vendor caps RLIMIT_MEMLOCK at 64 KiB, which is
+// why `--lock-dense` was abandoned. The one allocation an unprivileged app CAN make that the kernel
+// will not reclaim is a dma-buf: those pages stay pinned for the lifetime of the buffer because a
+// device may DMA from them at any time. Userspace reaches dma-buf through AHardwareBuffer.
+//
+// That would be pointless if the pinned pages were slow to read, and they might be: gralloc decides
+// per-allocation whether a buffer is CPU-cacheable, and uncached memory loses the cache line, the
+// hardware prefetcher and most of the memory-level parallelism. A dense matmul streams weights, so
+// it is fully exposed to that. This tool answers the only question that gates the whole idea:
+//
+//     is a locked AHardwareBuffer BLOB readable at cached-DRAM speed, or at uncached speed?
+//
+// The two outcomes are an order of magnitude apart, so the measurement does not need to be careful —
+// it needs to be unambiguous. Interpretation, on a device whose flash serves 1.3-2.5 GB/s:
+//
+//   ~10+ GB/s   cacheable. Indistinguishable from ordinary anonymous memory; pinning is viable and
+//               the next step is the in-app A/B against `--dense-weights anon`.
+//   ~1 GB/s or  uncached. At or below the flash bandwidth this is meant to save, so pinned dense
+//   below      weights would be SLOWER than refaulting them — the idea is dead, not merely weaker.
+//
+// `anon` is the baseline on purpose: it is the allocation `--dense-weights anon` already makes, so
+// the ratio between the two rows is the whole result. An absolute number alone would be worthless,
+// since it would fold in the device's clocks and thermal state.
+//
+// Secondary output: `--probe-max` reports the largest BLOB the driver will actually hand over. No
+// limit is documented — the NDK only says allocation may fail on driver constraints — and the dense
+// working set is multiple GiB, so "does it even fit" has to be measured too. Note the format's own
+// ceiling: AHardwareBuffer_Desc::width is 32-bit and for BLOB it IS the byte count, so 4 GiB - 1 is
+// the hard cap regardless of what the driver would allow.
+//
+// Android-only for the `ahwb` mode; the `anon` mode runs anywhere, which keeps the tool buildable
+// and testable on the host. Nothing here links the engine or llama.cpp.
+//
+//   bmoe-membench [--mib N] [--modes anon,ahwb] [--seconds S] [--threads N]
+//                 [--usage often|rarely] [--probe-max]
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(__ANDROID__)
+#include <android/hardware_buffer.h>
+#define BMOE_HAVE_AHWB 1
+#else
+#define BMOE_HAVE_AHWB 0
+#endif
+
+#if defined(_WIN32)
+#include <malloc.h>
+#else
+#include <sys/mman.h>
+#endif
+
+namespace {
+
+using clock_t_ = std::chrono::steady_clock;
+
+// Sequential read of an 8-byte-aligned range, accumulating so the loads cannot be dead-coded. Four
+// independent accumulators keep several loads in flight per iteration: on cacheable memory that is
+// what lets the core reach DRAM bandwidth, and on uncached memory it is exactly what stops working —
+// which is the difference this tool is built to expose, so the kernel must be written to benefit
+// from it rather than serialised by hand.
+uint64_t read_range(const uint8_t * base, size_t bytes) {
+    const uint64_t * q = reinterpret_cast<const uint64_t *>(base);
+    const size_t n = bytes / sizeof(uint64_t);
+    uint64_t a0 = 0, a1 = 0, a2 = 0, a3 = 0;
+    size_t i = 0;
+    for (; i + 4 <= n; i += 4) {
+        a0 += q[i];
+        a1 += q[i + 1];
+        a2 += q[i + 2];
+        a3 += q[i + 3];
+    }
+    for (; i < n; ++i)
+        a0 += q[i];
+    return a0 + a1 + a2 + a3;
+}
+
+// Writes a non-zero pattern over the whole buffer. Not optional: a fresh anonymous mapping is all
+// copy-on-write references to the shared zero page, so reading it without faulting pages in first
+// would measure one cached page instead of DRAM.
+void fill_range(uint8_t * base, size_t bytes, uint64_t seed) {
+    uint64_t * q = reinterpret_cast<uint64_t *>(base);
+    const size_t n = bytes / sizeof(uint64_t);
+    for (size_t i = 0; i < n; ++i)
+        q[i] = seed + i * 1099511628211ULL;
+}
+
+void parallel_over(uint8_t * base, size_t bytes, int threads, bool write, std::atomic<uint64_t> * sink) {
+    if (threads <= 1) {
+        if (write)
+            fill_range(base, bytes, 0x9E3779B97F4A7C15ULL);
+        else
+            sink->fetch_add(read_range(base, bytes), std::memory_order_relaxed);
+        return;
+    }
+    // Split on a 64-byte boundary so no two threads share a cache line at the seam.
+    const size_t chunk = ((bytes / (size_t) threads) + 63) & ~(size_t) 63;
+    std::vector<std::thread> th;
+    th.reserve((size_t) threads);
+    for (int t = 0; t < threads; ++t) {
+        const size_t off = chunk * (size_t) t;
+        if (off >= bytes) break;
+        const size_t len = std::min(chunk, bytes - off);
+        th.emplace_back([=]() {
+            if (write)
+                fill_range(base + off, len, 0x9E3779B97F4A7C15ULL + off);
+            else
+                sink->fetch_add(read_range(base + off, len), std::memory_order_relaxed);
+        });
+    }
+    for (auto & t : th)
+        t.join();
+}
+
+// One measured row: fill once, then read the buffer end to end repeatedly until the time budget is
+// spent. Best-pass is the headline because it is the least contaminated by scheduler noise and by
+// whatever else the device decided to run; the mean is printed alongside so a large gap between the
+// two is visible rather than hidden.
+struct BwResult {
+    double best_mibs = 0.0;
+    double mean_mibs = 0.0;
+    int passes = 0;
+};
+
+BwResult measure(uint8_t * base, size_t bytes, double seconds, int threads) {
+    std::atomic<uint64_t> sink{0};
+    parallel_over(base, bytes, threads, true, &sink);
+
+    BwResult r;
+    const double mib = (double) bytes / (1024.0 * 1024.0);
+    const auto t_end = clock_t_::now() + std::chrono::milliseconds((long long) (seconds * 1000.0));
+    double total_s = 0.0;
+    while (clock_t_::now() < t_end) {
+        const auto t0 = clock_t_::now();
+        parallel_over(base, bytes, threads, false, &sink);
+        const double s = std::chrono::duration<double>(clock_t_::now() - t0).count();
+        if (s <= 0.0) continue;
+        total_s += s;
+        r.passes++;
+        r.best_mibs = std::max(r.best_mibs, mib / s);
+    }
+    if (total_s > 0.0) r.mean_mibs = mib * (double) r.passes / total_s;
+    // Keep the accumulated sum observable so the read loop cannot be optimised away entirely.
+    if (sink.load() == 0x1234567890ABCDEFULL) std::fprintf(stderr, "(checksum coincidence)\n");
+    return r;
+}
+
+// --- allocators -------------------------------------------------------------------
+// Each returns a base pointer or nullptr, and records how long the allocation itself took: a pinned
+// multi-GiB allocation may be slow to service even when it succeeds, and that cost would be paid at
+// model load, so it belongs in the report.
+
+struct Alloc {
+    uint8_t * base = nullptr;
+    double alloc_ms = 0.0;
+    std::string note;
+};
+
+Alloc alloc_anon(size_t bytes) {
+    Alloc a;
+    const auto t0 = clock_t_::now();
+#if defined(_WIN32)
+    a.base = (uint8_t *) _aligned_malloc(bytes, 4096);
+#else
+    void * p = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    a.base = (p == MAP_FAILED) ? nullptr : (uint8_t *) p;
+#endif
+    a.alloc_ms = std::chrono::duration<double, std::milli>(clock_t_::now() - t0).count();
+    return a;
+}
+
+void free_anon(uint8_t * p, size_t bytes) {
+    if (!p) return;
+#if defined(_WIN32)
+    (void) bytes;
+    _aligned_free(p);
+#else
+    munmap(p, bytes);
+#endif
+}
+
+#if BMOE_HAVE_AHWB
+AHardwareBuffer * g_ahwb = nullptr;
+
+// BLOB is the "just N bytes" format: width carries the byte count and height must be 1. The usage
+// flags are the whole experiment — CPU_READ_OFTEN is the request for a cacheable mapping, and
+// whether gralloc honours it is exactly what is unknown.
+Alloc alloc_ahwb(size_t bytes, bool read_often) {
+    Alloc a;
+    if (bytes > 0xFFFFFFFFULL) {
+        a.note = "exceeds the 32-bit BLOB width cap (4 GiB)";
+        return a;
+    }
+    AHardwareBuffer_Desc d{};
+    d.width = (uint32_t) bytes;
+    d.height = 1;
+    d.layers = 1;
+    d.format = AHARDWAREBUFFER_FORMAT_BLOB;
+    d.usage = (read_often ? AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN : AHARDWAREBUFFER_USAGE_CPU_READ_RARELY) |
+              AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN;
+
+    const auto t0 = clock_t_::now();
+    AHardwareBuffer * buf = nullptr;
+    const int rc = AHardwareBuffer_allocate(&d, &buf);
+    if (rc != 0 || !buf) {
+        a.alloc_ms = std::chrono::duration<double, std::milli>(clock_t_::now() - t0).count();
+        a.note = "AHardwareBuffer_allocate failed (rc=" + std::to_string(rc) + ")";
+        return a;
+    }
+    void * p = nullptr;
+    const int lrc = AHardwareBuffer_lock(buf, d.usage, -1, nullptr, &p);
+    a.alloc_ms = std::chrono::duration<double, std::milli>(clock_t_::now() - t0).count();
+    if (lrc != 0 || !p) {
+        AHardwareBuffer_release(buf);
+        a.note = "AHardwareBuffer_lock failed (rc=" + std::to_string(lrc) + ")";
+        return a;
+    }
+    g_ahwb = buf;
+    a.base = (uint8_t *) p;
+    return a;
+}
+
+void free_ahwb() {
+    if (!g_ahwb) return;
+    AHardwareBuffer_unlock(g_ahwb, nullptr);
+    AHardwareBuffer_release(g_ahwb);
+    g_ahwb = nullptr;
+}
+
+// Largest BLOB the driver will actually allocate: double until it refuses, then binary-search the
+// gap. Allocation only — no lock, no touch — so this reports what the allocator promises, which is
+// an upper bound on what is usable. It is deliberately separate from the bandwidth rows: a size that
+// allocates but is unusably slow is not a size that helps.
+void probe_max() {
+    const uint64_t cap = 0xFFFFFFFFULL; // 32-bit BLOB width
+    auto can_alloc = [](uint64_t bytes) -> bool {
+        if (bytes > 0xFFFFFFFFULL) return false;
+        AHardwareBuffer_Desc d{};
+        d.width = (uint32_t) bytes;
+        d.height = 1;
+        d.layers = 1;
+        d.format = AHARDWAREBUFFER_FORMAT_BLOB;
+        d.usage = AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN | AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN;
+        AHardwareBuffer * b = nullptr;
+        if (AHardwareBuffer_allocate(&d, &b) != 0 || !b) return false;
+        AHardwareBuffer_release(b);
+        return true;
+    };
+
+    std::printf("probing the largest allocatable BLOB (32-bit width caps this at 4096 MiB)\n");
+    uint64_t good = 0, bad = 0;
+    for (uint64_t mib = 64; mib * 1024 * 1024 <= cap; mib *= 2) {
+        const uint64_t bytes = mib * 1024 * 1024;
+        const bool ok = can_alloc(bytes);
+        std::printf("  %6llu MiB  %s\n", (unsigned long long) mib, ok ? "ok" : "FAILED");
+        std::fflush(stdout);
+        if (ok) {
+            good = bytes;
+        } else {
+            bad = bytes;
+            break;
+        }
+    }
+    if (bad == 0) {
+        std::printf("  every probed size allocated; ceiling is the 4 GiB format cap, not the driver\n\n");
+        return;
+    }
+    // 16 MiB is fine enough: the decision this informs is "does several GiB fit", not the exact byte.
+    while (bad - good > 16ULL * 1024 * 1024) {
+        const uint64_t mid = good + (bad - good) / 2;
+        if (can_alloc(mid))
+            good = mid;
+        else
+            bad = mid;
+    }
+    std::printf("  max allocatable ~%llu MiB\n\n", (unsigned long long) (good / (1024 * 1024)));
+}
+#endif // BMOE_HAVE_AHWB
+
+void usage(const char * a0) {
+    std::fprintf(stderr,
+                 "usage: %s [--mib N] [--modes anon,ahwb] [--seconds S] [--threads N]\n"
+                 "  --mib       buffer size, default 512 (must exceed the last-level cache, or the\n"
+                 "              read loop measures cache instead of DRAM)\n"
+                 "  --modes     comma list of anon,ahwb (default both; ahwb is Android-only)\n"
+                 "  --threads   readers running concurrently, default 1. Single-thread separates\n"
+                 "              cached from uncached most clearly; the multi-thread row is the one\n"
+                 "              comparable to a matmul, which reads from every compute thread.\n"
+                 "  --usage     often|rarely (default often) — the CPU-read hint given to gralloc.\n"
+                 "              If both give the same bandwidth, the hint is being ignored.\n"
+                 "  --probe-max report the largest allocatable BLOB, then exit\n",
+                 a0);
+}
+
+} // namespace
+
+int main(int argc, char ** argv) {
+    size_t mib = 512;
+    std::string modes = "anon,ahwb";
+    double seconds = 3.0;
+    int threads = 1;
+    bool read_often = true;
+    bool probe = false;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        auto next = [&](const char * what) -> const char * {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "%s needs a value\n", what);
+                std::exit(2);
+            }
+            return argv[++i];
+        };
+        if (a == "--mib")
+            mib = (size_t) std::atoll(next("--mib"));
+        else if (a == "--modes")
+            modes = next("--modes");
+        else if (a == "--seconds")
+            seconds = std::atof(next("--seconds"));
+        else if (a == "--threads")
+            threads = std::atoi(next("--threads"));
+        else if (a == "--usage")
+            read_often = std::string(next("--usage")) != "rarely";
+        else if (a == "--probe-max")
+            probe = true;
+        else {
+            usage(argv[0]);
+            return 2;
+        }
+    }
+    if (mib == 0 || threads < 1) {
+        usage(argv[0]);
+        return 2;
+    }
+
+    if (probe) {
+#if BMOE_HAVE_AHWB
+        probe_max();
+        return 0;
+#else
+        std::fprintf(stderr, "--probe-max needs AHardwareBuffer (Android build)\n");
+        return 2;
+#endif
+    }
+
+    const size_t bytes = mib * 1024 * 1024;
+    std::printf("buffer %zu MiB, %.1f s per mode, %d reader thread(s), cpu-read hint '%s'\n\n", mib, seconds, threads,
+                read_often ? "often" : "rarely");
+    std::printf("%-8s %12s %12s %10s %8s  %s\n", "mode", "best_MiB/s", "mean_MiB/s", "alloc_ms", "passes", "note");
+
+    double anon_best = 0.0, ahwb_best = 0.0;
+    const bool want_anon = modes.find("anon") != std::string::npos;
+    const bool want_ahwb = modes.find("ahwb") != std::string::npos;
+
+    if (want_anon) {
+        Alloc a = alloc_anon(bytes);
+        if (!a.base) {
+            std::printf("%-8s %12s %12s %10.1f %8s  %s\n", "anon", "-", "-", a.alloc_ms, "-", "allocation failed");
+        } else {
+            const BwResult r = measure(a.base, bytes, seconds, threads);
+            anon_best = r.best_mibs;
+            std::printf("%-8s %12.1f %12.1f %10.1f %8d  %s\n", "anon", r.best_mibs, r.mean_mibs, a.alloc_ms, r.passes,
+                        "reclaimable baseline");
+            free_anon(a.base, bytes);
+        }
+    }
+
+    if (want_ahwb) {
+#if BMOE_HAVE_AHWB
+        Alloc a = alloc_ahwb(bytes, read_often);
+        if (!a.base) {
+            std::printf("%-8s %12s %12s %10.1f %8s  %s\n", "ahwb", "-", "-", a.alloc_ms, "-", a.note.c_str());
+        } else {
+            const BwResult r = measure(a.base, bytes, seconds, threads);
+            ahwb_best = r.best_mibs;
+            std::printf("%-8s %12.1f %12.1f %10.1f %8d  %s\n", "ahwb", r.best_mibs, r.mean_mibs, a.alloc_ms, r.passes,
+                        "pinned dma-buf");
+            free_ahwb();
+        }
+#else
+        std::printf("%-8s %12s %12s %10s %8s  %s\n", "ahwb", "-", "-", "-", "-", "not an Android build");
+#endif
+    }
+
+    if (anon_best > 0.0 && ahwb_best > 0.0) {
+        const double ratio = ahwb_best / anon_best;
+        std::printf("\nahwb / anon = %.2fx — ", ratio);
+        // The verdict thresholds are wide because the two outcomes are an order of magnitude apart;
+        // anything in between is a real result that needs a human, not a rounding decision.
+        if (ratio >= 0.7)
+            std::printf("cacheable. Pinning is viable; next step is the in-app A/B.\n");
+        else if (ratio >= 0.2)
+            std::printf("degraded but not uncached. Weigh against the refault cost before building.\n");
+        else
+            std::printf("uncached. Pinned dense weights would read slower than the flash they replace.\n");
+    }
+    return 0;
+}


### PR DESCRIPTION
## Why

`docs/android-memory.md` lists every lever for keeping the dense weights resident and finds all of
them closed: `RLIMIT_MEMLOCK` is 64 KiB (vendor-set, hard), the cgroup knobs are v2-only, MGLRU is
disabled at runtime, and `MADV_COLD` only redirects reclaim instead of preventing it. The table had
one conspicuous omission — **dma-buf**. Those pages are exempt from reclaim by construction, because
a device may DMA from them at any time, and an unprivileged app can allocate one through
`AHardwareBuffer`. If the dense weights lived there, kswapd could not take them.

That is only worth building if the pinned pages are fast to read, and they might not have been:
gralloc decides per allocation whether a buffer is CPU-cacheable, and the kernel even ships a
dedicated uncached system heap. Uncached memory loses the cache line, the hardware prefetcher and
most memory-level parallelism — and a dense matmul streams weights, so it would pay that in full.
Against flash measured at ~1815–1980 MiB/s, uncached pinned weights would read **slower than
refaulting them off storage**. So the design question was settled by one measurement, and this PR
is that measurement.

## Result: the gate passes

A locked `AHardwareBuffer` BLOB is indistinguishable from anonymous memory. Interleaved, CPU-pinned,
best MiB/s per row:

| placement | ahwb | anon | ratio |
|---|---|---|---|
| cpu2 (policy0), 1 thread | 30392 / 30399 / 30310 | 30423 / 30394 / 30438 | **1.00** |
| cpu6 (policy6), 1 thread | 45065 / 45175 / 45176 | 45219 / 45183 / 45278 | **1.00** |
| all cores, 4 threads, 1 GiB | 59016 / 58960 | 58902 / 59024 | **1.00** |

Every pair agrees within 0.5%. `--usage rarely` matches `--usage often`, so the mapping does not
have to be coaxed into being cacheable. Allocation costs ~7–11 GiB/s, a few hundred ms once at load.

## The binding constraint is size, and it is not where the docs point

Two ceilings, and the lower one is undocumented:

- **Allocation** succeeds to 4095 MiB — the cap implied by `AHardwareBuffer_Desc::width` being
  32-bit, which for BLOB *is* the byte count.
- **`AHardwareBuffer_lock`**, which is what yields a usable CPU pointer, refuses at exactly 2048 MiB
  with `EINVAL` while 2047 MiB succeeds. A boundary landing precisely on 2^31 is a signed-32-bit
  type in the lock path, not memory exhaustion.

Usable unit: **2047 MiB**. Larger working sets must span several buffers — fine here, since
`dense_weights` already allocates per tensor, but fatal to any design assuming one buffer.

## What this does NOT show

**That pinning helps.** Reclaim-exempt memory does not create memory: under a >RAM model the RAM the
dense weights stop yielding has to come out of the expert cache or the page cache feeding the
stream — the same trade that refuted the bulk restore (#28) and the per-layer LFU cap. The plausible
failure mode is not "it doesn't work" but "`dense_resident_frac` goes to 1.0 and tok/s falls".

Nor did any run here put the device under the pressure a >RAM decode creates, so reclaim-exemption
itself is still an inference from how dma-buf works rather than something observed. And it is one
device, one gralloc — the 2 GiB lock boundary especially is a driver-side property.

Recorded as an **open, unproven lever**. Next step is a `--dense-weights ahwb` mode measured in-app
against `anon`, with `dense_resident_frac` and majflt/token read next to tok/s.

## Two tool fixes, both found by using it

- `--probe-max` probed allocation only and reported ~2× the usable size, since lock fails long
  before allocation does. It now locks every candidate, and refines to 1 MiB so a ceiling sitting on
  a power of two is visible as evidence about its cause. Same class of defect as 0.13.3's.
- `--modes` ran anon first whatever order was asked for, and a single pass ranked CPU clusters
  rather than allocators: **the first un-pinned run reported a clean, plausible, completely false
  0.67×**, which inverted when the modes were swapped. Core placement moves this number 1.5× — and
  the faster cluster is the one at the *lower* clock, so frequency would have mispredicted the
  direction too. Modes now run in the order given, `--repeat` interleaves them, and the header says
  to pin with `taskset`.

## Scope

Diagnostics only. No engine, CLI or app behaviour changes; the Android version is unchanged. Nothing
decides to use pinned memory — this PR establishes that the option exists and what it costs.

## Changes

- `tools/membench.cpp`, `tools/CMakeLists.txt` — the tool
- `docs/bench-data/2026-07-21-pinned-memory/` — findings + raw runs
- `docs/android-memory.md` — the dma-buf row its lever table was missing, plus a section on what it
  does and does not solve
- `docs/roadmap.md` — the open question, under the dense-weights theme
- `CHANGELOG.md` — `[0.13.5]`

## Verification

- [x] Builds for Android arm64 (NDK 29, API 29) and for the Windows host
- [x] Host sanity check — the read kernel reaches DRAM speed (16.1k MiB/s 1 thread, 36.3k at 4), so
      it is measuring DRAM and not cache
- [x] On-device: app force-stopped, no stray processes, Thermal Status 0 and `scaling_max_freq`
      unchanged before and after, so no clock-drift confound
- [x] `clang-format` 18 clean
- [ ] CI — Actions remains blocked on billing; verified locally
