### PR TITLE
feat(moe): warn when cache-aware dropping meets a narrow routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ Semantic Versioning.
   collapse, not a subtle cost. Harness, per-question replies and grading rule:
   [docs/bench-data/2026-07-22-drop-quality/](docs/bench-data/2026-07-22-drop-quality/findings.md).
 
+- **A warning when dropping meets a narrow routing.** The threshold is a fraction of the uniform
+  share `1/top-k`, so `0.75` means "below 9.4% of the routing" at top-k 8 but "below 37.5%" at
+  top-k 2 — a regime nothing here has measured. The engine now says so once at load when the
+  effective top-k is 4 or fewer, and the app shows the same caveat inline under the setting. It
+  warns rather than clamping: the engine cannot know whether the trade is acceptable for a given
+  model, and silently adjusting a number the caller chose would be worse than a loud caveat.
+  gpt-oss is the case to watch — it routes 4 of 128.
+- `BMOE_READY` gains `n_expert_used`, the effective routing width after any override (0 on a
+  non-MoE model), so a UI can interpret the setting at all. Additive; older consumers ignore it.
+  `Session::n_expert_used()` exposes the same value to embedders.
+
 ### Changed
 - With the policy armed, `load_layer()` moves from the topk node to the terminal node of the layer's
   weight chain — the decision needs the final router weights. Which node that is depends on the

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -206,9 +206,13 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
     }
     // think_ctl states, once, whether this model can honour a think=false request at all, so a UI
     // can disable its Thinking control instead of leaving one that silently does nothing (#82).
-    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d,\"think_ctl\":\"%s\"}\n",
+    // n_expert_used is the EFFECTIVE routing width, after any override. A UI needs it to say
+    // anything sensible about --drop-cold-experts, whose threshold is a fraction of 1/top-k: the
+    // same percentage trims a tail at 8 and takes half the routing at 2. 0 on a non-MoE model.
+    std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d,\"think_ctl\":\"%s\","
+                "\"n_expert_used\":%d}\n",
                 session->load_seconds(), json_escape(session->arch()).c_str(), session->n_ctx(),
-                bmoe::think_control_name(session->think_control()));
+                bmoe::think_control_name(session->think_control()), session->n_expert_used());
     std::fflush(stdout);
 
     std::mutex mtx;

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -130,6 +130,13 @@ struct MoeStreamConfig {
     // on a fast host. Serial mode only. Never set in production.
     bool prefetch_sync = false;
 
+    // Top-k at or below which drop_cold_frac gets a warning. This is an EVIDENCE boundary, not a
+    // physical one: the policy is measured at top-k 8, where the uniform share is 12.5% and the
+    // threshold trims a long tail. At top-k 4 that share is 25% and at top-k 2 it is 50%, so the
+    // same fraction removes a far larger part of the routing — a different regime, unmeasured.
+    // Nothing in the streaming path reads this; it only decides whether the caller is told.
+    static constexpr int drop_low_topk_warn = 4;
+
     static constexpr int cache_min_mb = 1500; // smallest non-pathological cache (see above)
     static constexpr int io_threads_max = 8;
     static constexpr int prefetch_layers_max = 8;

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -118,6 +118,11 @@ public:
     const std::string & arch() const; // model architecture ("qwen3moe", "gemma4", …)
     int n_ctx() const;
 
+    // Experts this model actually routes per token, after any n_expert_used override — the width a
+    // caller needs to interpret MoeStreamConfig::drop_cold_frac, whose threshold is a fraction of
+    // 1/top-k. 0 when the model is not MoE or the count could not be read.
+    int n_expert_used() const;
+
     // Which thinking-off mechanism this model supports (probed at open()). Report it to the user
     // rather than leaving a Thinking toggle that silently does nothing. Always Template when chat
     // mode is off, where no template is rendered and the question does not arise.

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -188,6 +188,7 @@ struct Session::Impl {
 
     const llama_vocab * vocab = nullptr;
     int n_vocab = 0;
+    int n_expert_used = 0; // effective routing width, after any override (0 = not MoE)
     int n_layer = 0;
     bool chat_on = false;
     common_chat_templates_ptr chat_tmpls;
@@ -255,6 +256,9 @@ const std::string & Session::arch() const {
 }
 int Session::n_ctx() const {
     return impl_->cfg.n_ctx;
+}
+int Session::n_expert_used() const {
+    return impl_->n_expert_used;
 }
 ThinkControl Session::think_control() const {
     return impl_->think_ctl;
@@ -583,6 +587,32 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                 if (ri.n_expert_used <= 0) ri.n_expert_used = mi.n_expert_used;
             }
         }
+    }
+
+    // The effective routing width, resolved once: an override IS the applied width, otherwise the
+    // model's own count. Exposed so a UI can interpret drop_cold_frac, and used by the warning below.
+    im.n_expert_used = cfg.n_expert_used;
+    if (im.n_expert_used <= 0) {
+        const GgufModelInfo & mi = gguf();
+        im.n_expert_used = mi.ok ? mi.n_expert_used : 0;
+    }
+
+    // Cache-aware dropping on a narrow routing: say so once, at load.
+    //
+    // The threshold is a fraction of the uniform share 1/top-k, so what it removes scales with how
+    // wide the routing is. At top-k 8 (where it was measured) it trims a long tail; at top-k 2 the
+    // same fraction can discard the whole minority expert on every miss, which is closer to halving
+    // the routing than to trimming it. The engine has no way to know whether that is acceptable for
+    // a given model, so it states the fact rather than clamping the flag — a silent adjustment
+    // would be worse than a loud caveat.
+    if (cfg.moe.enabled && cfg.moe.drop_cold_frac > 0.0f) {
+        const int k = im.n_expert_used;
+        if (k > 0 && k <= MoeStreamConfig::drop_low_topk_warn)
+            std::fprintf(stderr,
+                         "bmoe: WARNING drop-cold-experts=%.2f with top-k %d — the threshold is %.1f%% of the "
+                         "routing here, against 12.5%% at the top-k 8 this was measured on. Expect it to discard "
+                         "much more, and check output quality on your own task.\n",
+                         (double) cfg.moe.drop_cold_frac, k, 100.0 * cfg.moe.drop_cold_frac / k);
     }
 
     im.load_seconds = secs(t_load0, clock_t_::now());

--- a/docs/expert-dropping.md
+++ b/docs/expert-dropping.md
@@ -98,6 +98,31 @@ prefetch exists for — treat the two as interacting, not composable.
 threshold discards ~42% of the weight mass instead of ~9%. Prefill is compute-bound anyway, so there
 is little to win. `--drop-in-prefill` arms it for experiments.
 
+## Narrow routings are a different regime, and the engine says so
+
+The threshold is a fraction of the uniform share `1/top-k`, so what it removes depends on how wide
+the routing is. At top-k 8 — where all the evidence here was collected — `F = 0.75` means "below
+9.4% of the routing", a tail trim. At top-k 4 the same `F` means "below 18.8%", and at top-k 2 it
+means "below 37.5%", which on a miss discards the entire minority expert. That is closer to halving
+the routing than to trimming it, and nothing in this document measured it.
+
+So the engine warns once at load when dropping is armed on a routing of four experts or fewer:
+
+```
+bmoe: WARNING drop-cold-experts=0.75 with top-k 2 — the threshold is 37.5% of the routing here,
+against 12.5% at the top-k 8 this was measured on. Expect it to discard much more, and check
+output quality on your own task.
+```
+
+It warns rather than clamping or refusing. The engine cannot know whether that trade is acceptable
+for a given model and task, and silently adjusting a number the caller chose would be worse than a
+loud caveat. `MoeStreamConfig::drop_low_topk_warn` is an **evidence** boundary, not a physical one:
+nothing in the streaming path reads it, it only decides whether the caller is told.
+
+The app shows the same warning inline under the setting, computed from the width the loaded model
+reports at `BMOE_READY` — and only once a model is loaded, since guessing would be worse than
+staying quiet. gpt-oss is the case to watch: it routes 4 of 128.
+
 ## The output is no longer reproducible
 
 This is the real novelty, and the reason the flag is off by default and named the way it is.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -279,7 +279,7 @@ Responses (stdout):
 
 ```
 BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>,
-            "think_ctl":"template|prefill|none"}                        # once, after the model loads
+            "think_ctl":"template|prefill|none","n_expert_used":<int>}  # once, after the model loads
 BMOE_BEGIN {"id":<int>}                                                # a generation started
 BMOE_LOAD / BMOE_PROGRESS ...                                          # per token, as above
 BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
@@ -290,6 +290,11 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "token_demand_mib":<float>,"reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
+
+`BMOE_READY`'s `n_expert_used` is the **effective** routing width, after any `--n-expert-used`
+override (`0` on a non-MoE model). A UI needs it to say anything sensible about
+[`--drop-cold-experts`](expert-dropping.md), whose threshold is a fraction of `1/top-k`: the same
+percentage trims a tail at 8 experts and takes half the routing at 2.
 
 `BMOE_READY`'s `think_ctl` states how a `"think":false` request can be honoured on the model that
 was just loaded, so a UI need not offer a control that does nothing. It is decided by rendering the

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -35,6 +35,10 @@ data class UiState(
     // in the prompt), or "none" (neither — the model always reasons, and the switch is hidden rather
     // than left there doing nothing). Null until a session reports it. See docs/telemetry.md.
     val thinkControl: String? = null,
+    // Experts the loaded model routes per token, from BMOE_READY. Null = nothing loaded yet,
+    // 0 = not MoE. Settings needs it because "Drop cold experts" is a fraction of 1/top-k, so the
+    // same percentage means something very different on a narrow routing.
+    val nExpertUsed: Int? = null,
     val transcript: List<ChatTurn> = emptyList(), // committed turns; the in-flight answer is `answer`
     val streaming: Boolean = true,  // is the loaded session using the MoE streamer (vs mmap baseline)?
 ) {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -202,7 +202,8 @@ class RunService : Service() {
         when {
             t.startsWith("BMOE_READY ") -> {
                 val ctl = Regex(""""think_ctl":"([a-z_]+)"""").find(t)?.groupValues?.get(1)
-                RunBus.update { it.copy(state = EngineState.READY, thinkControl = ctl) }
+                val topk = Regex(""""n_expert_used":(\d+)""").find(t)?.groupValues?.get(1)?.toIntOrNull()
+                RunBus.update { it.copy(state = EngineState.READY, thinkControl = ctl, nExpertUsed = topk) }
                 main.post { notify("Model ready") }
                 pending?.let { p -> pending = null; sendGenerate(p) } ?: scheduleIdleUnload()
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -173,6 +173,20 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                         "skipped depends on what the cache happened to hold.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                // The threshold is a share of 1/top-k, so a narrow routing changes what the same
+                // percentage means: 75% is "below 9.4%" at eight experts but "below 18.8%" at four.
+                // Only shown once a model is loaded and reports its width — guessing would be worse
+                // than saying nothing.
+                val topk = ui.nExpertUsed
+                if (current.dropColdPct > 0 && topk != null && topk in 1..4) {
+                    Text(
+                        "⚠ This model routes only $topk experts per token, so ${current.dropColdPct}% here " +
+                            "means \"skip below ${"%.1f".format(current.dropColdPct.toDouble() / topk)}%\" — a much " +
+                            "bigger share of the reply than the 9.4% this setting was measured at (8 experts). " +
+                            "Check the answers, or turn it off for this model.",
+                        fontSize = 12.sp, color = MaterialTheme.colorScheme.error,
+                    )
+                }
             }
 
             Section("Compute") {


### PR DESCRIPTION
`--drop-cold-experts F` sets a threshold at `F × (1/top-k)`, so what it removes scales with how wide the routing is:

| top-k | uniform share | what `F = 0.75` means |
|---|---|---|
| 8 | 12.5% | skip below **9.4%** — a tail trim, and where every number in the docs was measured |
| 4 | 25% | skip below **18.8%** |
| 2 | 50% | skip below **37.5%** — on a miss this discards the entire minority expert |

At top-k 2 that is closer to halving the routing than trimming it, and nothing measured so far covers it.

**The engine now warns once at load** when dropping is armed and the effective top-k is 4 or fewer, quoting the real share for the model in hand:

```
bmoe: WARNING drop-cold-experts=0.75 with top-k 2 — the threshold is 37.5% of the routing here,
against 12.5% at the top-k 8 this was measured on. Expect it to discard much more, and check
output quality on your own task.
```

It **warns rather than clamping or refusing**. The engine cannot know whether that trade is acceptable for a given model and task, and silently adjusting a number the caller chose would be worse than a loud caveat. `MoeStreamConfig::drop_low_topk_warn` is documented as an *evidence* boundary, not a physical one — nothing in the streaming path reads it.

**The app shows the same caveat inline** under the setting, in the error colour, computed from the width the loaded model actually reports rather than assumed — and only once a model is loaded, since guessing would be worse than staying quiet. **gpt-oss is the case this exists for**: it routes 4 of 128, and the app default is 75%.

To make that possible `BMOE_READY` gains `n_expert_used` (effective width after any override, `0` on a non-MoE model) and `Session::n_expert_used()` exposes it to embedders. Additive — older consumers ignore it.

Gates 7/7, app compiles. Verified: warning fires at top-k 2 with the right percentage, silent at `--n-expert-used 8`.