### PR TITLE
feat(moe): measure how predictable expert routing is, then act on it — and refute it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,10 @@ Semantic Versioning.
   a dedicated worker at an L+2 horizon (the probe's stale-2 column prices that staleness per
   model). Throughput verdict OPEN pending thermally matched A/B pairs — the first day's
   comparisons were invalidated by silent thermal capping (see docs/expert-prediction.md, which
-  also records the one matched pair measured: speculation on 8 io lanes loses −28%).
+  also records the one matched pair measured: speculation on 8 io lanes loses −28%). The example
+  app exposes it as an experimental toggle in the Streaming section (off by default, mutually
+  exclusive with the temporal-prefetch setting, spec-max rungs 0/1/2/4) so the matched pairs can
+  be run from the app itself.
 
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,29 +21,6 @@ Semantic Versioning.
   reservation pushing an already-tight system into reclaim — nearly 6 000 major faults per token,
   none of them the workload's fault.
 
-### Fixed
-- A stray `%` in the `--dense-weights` help text was read by `printf` as a conversion specifier, so
-  that line printed garbage and read past the argument list.
-- `scripts/build-android.ps1` now judges `cmake` by its exit code instead of by whether it wrote to
-  stderr, so it works under Windows PowerShell 5.1 and not only under `pwsh` (the NDK toolchain
-  prints progress to stderr, which 5.1 turns into a terminating error).
-
-## [0.15.1] - 2026-07-23
-
-### Added
-- **A warning when cache-aware dropping meets a narrow routing.** The threshold is a fraction of the
-  uniform share `1/top-k`, so `--drop-cold-experts 0.75` means "skip below 9.4% of the routing" at
-  top-k 8 — where every number in 0.15.0 was measured — but "below 18.8%" at top-k 4 and "below
-  37.5%" at top-k 2, where a miss discards the whole minority expert. The engine now says so once at
-  load when the effective top-k is 4 or fewer, quoting the real share for the model in hand, and the
-  app shows the same caveat inline under the setting. **gpt-oss is the case this exists for**: it
-  routes 4 of 128, and the app default is 75%, so 0.15.0 shipped that combination with nothing
-  saying it was outside the measured range.
-  It warns rather than clamping: the engine cannot know whether the trade is acceptable for a given
-  model, and silently adjusting a number the caller chose would be worse than a loud caveat.
-- `BMOE_READY` gains `n_expert_used`, the effective routing width after any override (0 on a non-MoE
-  model), so a UI can interpret the setting at all; `Session::n_expert_used()` exposes the same to
-  embedders. Additive — older consumers ignore it.
 - **`--predict-log` — measure how predictable the routing is, without acting on it.** For every
   decoded token the engine ranks each layer's experts a layer early, by running the **next** layer's
   router matrix on the **current** layer's gate input — the residual stream barely moves between
@@ -87,6 +64,29 @@ Semantic Versioning.
   mutually exclusive with the temporal-prefetch setting, spec-max rungs 0/1/2/4 defaulting to 0 =
   retention-only, the only rung the matched pairs did not refute).
 
+### Fixed
+- A stray `%` in the `--dense-weights` help text was read by `printf` as a conversion specifier, so
+  that line printed garbage and read past the argument list.
+- `scripts/build-android.ps1` now judges `cmake` by its exit code instead of by whether it wrote to
+  stderr, so it works under Windows PowerShell 5.1 and not only under `pwsh` (the NDK toolchain
+  prints progress to stderr, which 5.1 turns into a terminating error).
+
+## [0.15.1] - 2026-07-23
+
+### Added
+- **A warning when cache-aware dropping meets a narrow routing.** The threshold is a fraction of the
+  uniform share `1/top-k`, so `--drop-cold-experts 0.75` means "skip below 9.4% of the routing" at
+  top-k 8 — where every number in 0.15.0 was measured — but "below 18.8%" at top-k 4 and "below
+  37.5%" at top-k 2, where a miss discards the whole minority expert. The engine now says so once at
+  load when the effective top-k is 4 or fewer, quoting the real share for the model in hand, and the
+  app shows the same caveat inline under the setting. **gpt-oss is the case this exists for**: it
+  routes 4 of 128, and the app default is 75%, so 0.15.0 shipped that combination with nothing
+  saying it was outside the measured range.
+  It warns rather than clamping: the engine cannot know whether the trade is acceptable for a given
+  model, and silently adjusting a number the caller chose would be worse than a loud caveat.
+- `BMOE_READY` gains `n_expert_used`, the effective routing width after any override (0 on a non-MoE
+  model), so a UI can interpret the setting at all; `Session::n_expert_used()` exposes the same to
+  embedders. Additive — older consumers ignore it.
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the
   GSM8K result recorded in the same section. Corrected in place.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,15 @@ Semantic Versioning.
   reading them ahead spends the I/O the policy exists to save). Mutually exclusive with
   `--prefetch`; needs the LRU cache; byte-identical like the temporal prefetch (gate `G10`), with
   the same documented exception under dropping, where a correct guess un-drops an expert and buys
-  quality rather than speed. Off by default, pending an on-device A/B.
+  quality rather than speed. Off by default. `--predict-spec-max N` bounds how much flash the
+  prediction may spend per layer (0 = retention-only: predicted residents are LRU-protected via the
+  new `IExpertSource::retain`, and nothing is read ahead). Rebuilt once already around its measured
+  costs — native-F16 GEMV on aarch64 (~40× over a per-element exported-function conversion),
+  barrier-less gate-input capture guarded by a sampled self-validating watchdog, prediction GEMV on
+  a dedicated worker at an L+2 horizon (the probe's stale-2 column prices that staleness per
+  model). Throughput verdict OPEN pending thermally matched A/B pairs — the first day's
+  comparisons were invalidated by silent thermal capping (see docs/expert-prediction.md, which
+  also records the one matched pair measured: speculation on 8 io lanes loses −28%).
 
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,24 @@ Semantic Versioning.
 - `BMOE_READY` gains `n_expert_used`, the effective routing width after any override (0 on a non-MoE
   model), so a UI can interpret the setting at all; `Session::n_expert_used()` exposes the same to
   embedders. Additive — older consumers ignore it.
+- **`--predict-log` — measure how predictable the routing is, without acting on it.** For every
+  decoded token the engine ranks each layer's experts a layer early, by running the **next** layer's
+  router matrix on the **current** layer's gate input — the residual stream barely moves between
+  layers, so the stale input ranks nearly as the real one will. It reports what fraction of each
+  routing that would have had in flight, scored against the previous-token bet
+  [`--prefetch`](docs/prefetch.md) already makes, per layer and in aggregate. Training-free and
+  model-unchanged: the router matrix is a dense weight already resident, and the prediction is one
+  GEMV.
+  Alongside both it prints a **zero-staleness control** — the same row read, GEMV and ranking on the
+  layer's own matrix — which must reproduce the routing llama.cpp computes from those same tensors.
+  A control below 100% means the probe is wrong, or the architecture does not select by raw-logit
+  ranking; either way it caps what the measurement could show, and the CLI says so rather than
+  letting the gap be blamed on staleness. The byte-identity gates cover both halves (`G9`).
+  Diagnostics only: nothing it computes reaches the loading path, so a probed run reads exactly the
+  bytes an unprobed one does — but it costs a barrier and two GEMVs per layer, so it is not a
+  benchmark run. Requires `--moe-stream`. See
+  [docs/expert-prediction.md](docs/expert-prediction.md), which also states why a *good* score still
+  would not imply a faster decode on a flash that is already saturated.
 
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,12 +78,14 @@ Semantic Versioning.
   costs — native-F16 GEMV on aarch64 (~40× over a per-element exported-function conversion),
   barrier-less gate-input capture guarded by a sampled self-validating watchdog, prediction GEMV on
   a dedicated worker at an L+2 horizon (the probe's stale-2 column prices that staleness per
-  model). Throughput verdict OPEN pending thermally matched A/B pairs — the first day's
-  comparisons were invalidated by silent thermal capping (see docs/expert-prediction.md, which
-  also records the one matched pair measured: speculation on 8 io lanes loses −28%). The example
-  app exposes it as an experimental toggle in the Streaming section (off by default, mutually
-  exclusive with the temporal-prefetch setting, spec-max rungs 0/1/2/4) so the matched pairs can
-  be run from the app itself.
+  model). Throughput verdict, from thermally matched pairs (the first day's comparisons were
+  invalidated by silent thermal capping): **read-ahead loses** — −21% in the shipping drop+pinned
+  configuration at spec-max 2 and −28% on 8 io lanes, each with hit rate up and most speculations
+  useful, because the flash has no spare bandwidth to spend; **retention is hit-rate-neutral** at
+  a 3000 MiB cache, as the offline replay bound predicted (see docs/expert-prediction.md). The
+  example app exposes it as an experimental toggle in the Streaming section (off by default,
+  mutually exclusive with the temporal-prefetch setting, spec-max rungs 0/1/2/4 defaulting to 0 =
+  retention-only, the only rung the matched pairs did not refute).
 
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,17 @@ Semantic Versioning.
   benchmark run. Requires `--moe-stream`. See
   [docs/expert-prediction.md](docs/expert-prediction.md), which also states why a *good* score still
   would not imply a faster decode on a flash that is already saturated.
+- **`--predict-prefetch` — speculate on that prediction instead of the previous token.** Feeds the
+  stale-gate ranking into the same speculative read path as `--prefetch` (same cache buffers,
+  accounting and summary line, tagged `[stale-gate]`), replacing a ~43%-accurate predictor with a
+  ~89%-accurate one measured on the same run. Issued after the current layer's load rather than at
+  prediction time — every load path starts by quiescing speculation, so an early queue would be
+  cancelled before a lane picked it up. Drop-aware: with `--drop-cold-experts` armed, predicted
+  experts below the drop threshold are not speculated (if they miss they would be dropped unread —
+  reading them ahead spends the I/O the policy exists to save). Mutually exclusive with
+  `--prefetch`; needs the LRU cache; byte-identical like the temporal prefetch (gate `G10`), with
+  the same documented exception under dropping, where a correct guess un-drops an expert and buys
+  quality rather than speed. Off by default, pending an on-device A/B.
 
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -383,10 +383,14 @@ static void print_usage(const char * argv0) {
         "                          input), scored against the previous-token bet --prefetch makes.\n"
         "                          Changes nothing that is read; costs a barrier and a GEMV per\n"
         "                          layer, so a probed run is not a benchmark run.\n"
+        "      --predict-prefetch  act on that prediction: speculatively read the next layer's\n"
+        "                          predicted experts on the idle lanes (needs the cache; excludes\n"
+        "                          --prefetch). Drop-aware: with --drop-cold-experts armed, experts\n"
+        "                          predicted below the drop threshold are not speculated.\n"
         "      --list-archs        print supported MoE architectures and exit\n"
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
-        "BMOE_N_EXPERT_USED, BMOE_PREDICT_LOG\n",
+        "BMOE_N_EXPERT_USED, BMOE_PREDICT_LOG, BMOE_PREDICT_PREFETCH\n",
         argv0, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
 }
 
@@ -563,6 +567,8 @@ int main(int argc, char ** argv) {
             cfg.moe.drop_prefill = true;
         else if (a == "--predict-log")
             cfg.moe.predict_log = true;
+        else if (a == "--predict-prefetch")
+            cfg.moe.predict_prefetch = true;
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)
@@ -589,6 +595,7 @@ int main(int argc, char ** argv) {
     if (!seen.count("--prefetch")) cfg.moe.prefetch_layers = env_int("BMOE_PREFETCH", 0);
     if (!seen.count("--n-expert-used")) cfg.n_expert_used = env_int("BMOE_N_EXPERT_USED", 0);
     if (!seen.count("--predict-log")) cfg.moe.predict_log = env_int("BMOE_PREDICT_LOG", 0) != 0;
+    if (!seen.count("--predict-prefetch")) cfg.moe.predict_prefetch = env_int("BMOE_PREDICT_PREFETCH", 0) != 0;
 
     if (cfg.model_path.empty()) {
         print_usage(argv[0]);
@@ -704,10 +711,11 @@ int main(int argc, char ** argv) {
         if (cfg.moe.overlap)
             std::printf("moe-overlap: stall %.3f s/token (flash reads overlapped with FFN compute)\n",
                         s.moe_stall_s_per_token);
-        if (cfg.moe.prefetch_layers > 0)
-            std::printf("moe-prefetch: %.1f MiB speculative, %lld/%lld experts useful (%.0f%%)\n", s.moe_spec_read_mib,
-                        s.moe_spec_useful, s.moe_spec_experts,
-                        s.moe_spec_experts > 0 ? 100.0 * s.moe_spec_useful / s.moe_spec_experts : 0.0);
+        if (cfg.moe.prefetch_layers > 0 || cfg.moe.predict_prefetch)
+            std::printf("moe-prefetch: %.1f MiB speculative, %lld/%lld experts useful (%.0f%%)%s\n",
+                        s.moe_spec_read_mib, s.moe_spec_useful, s.moe_spec_experts,
+                        s.moe_spec_experts > 0 ? 100.0 * s.moe_spec_useful / s.moe_spec_experts : 0.0,
+                        cfg.moe.predict_prefetch ? " [stale-gate]" : "");
         // How hard the policy actually bit. The flag sets a threshold, not a drop rate: what gets
         // discarded depends on what the cache held, so this is the only honest report of the trade
         // a given run made.

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -378,11 +378,71 @@ static void print_usage(const char * argv0) {
         "                          it changes the output, and not reproducibly. Off by default.\n"
         "      --drop-no-renorm    do not rescale the surviving weights after a drop (A/B)\n"
         "      --drop-in-prefill   drop during prefill too (off: the cold cache makes it expensive)\n"
+        "      --predict-log       diagnostics: measure how much of each layer's routing could be\n"
+        "                          known a layer early (the next layer's gate run on this layer's\n"
+        "                          input), scored against the previous-token bet --prefetch makes.\n"
+        "                          Changes nothing that is read; costs a barrier and a GEMV per\n"
+        "                          layer, so a probed run is not a benchmark run.\n"
         "      --list-archs        print supported MoE architectures and exit\n"
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
-        "BMOE_N_EXPERT_USED\n",
+        "BMOE_N_EXPERT_USED, BMOE_PREDICT_LOG\n",
         argv0, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
+}
+
+// The prediction probe's report (see MoeStreamConfig::predict_log).
+//
+// Read the two predictors against the CONTROL rather than against 100%: the control ranks the same
+// way with no staleness at all, so it is the ceiling this measurement can show on this model, and
+// any gap below it is the ranking's approximation rather than the prediction's difficulty.
+//
+// The per-layer table is the substantive half. An aggregate flatters a prefetch: what a prefetch
+// costs is set by the layers it gets wrong, and the first layers of a MoE model are reliably the
+// worst — their routing scores sit close together, so a slightly stale input reorders them.
+static void print_predict_report(const RunSummary & s) {
+    const PredictorStats & st = s.predict_stale;
+    const PredictorStats & pv = s.predict_prev;
+    const PredictorStats & sf = s.predict_self;
+    std::printf("moe-predict: stale-gate %.1f%% of routed slots (%.1f%% whole routings) | prev-token %.1f%% (%.1f%%)"
+                " | fresh-gate control %.1f%% (%.1f%%)\n",
+                100.0 * st.hit_frac(), 100.0 * st.exact_frac(), 100.0 * pv.hit_frac(), 100.0 * pv.exact_frac(),
+                100.0 * sf.hit_frac(), 100.0 * sf.exact_frac());
+    // Per predictor, because their denominators genuinely differ: the stale one cannot speak for
+    // layer 0 (nothing precedes it) nor for the first token of a run, and quoting one row count for
+    // all three would misread those structural gaps as agreement.
+    std::printf("moe-predict: scored — stale-gate %lld routings/%lld slots, prev-token %lld/%lld, control %lld/%lld;"
+                " %lld routings the stale-gate could not rank\n",
+                st.rows, st.slots, pv.rows, pv.slots, sf.rows, sf.slots, s.predict_unscored);
+    // Say it rather than let the reader assume staleness cost what the ranking did.
+    if (sf.rows > 0 && sf.hit_frac() < 0.999)
+        std::printf("moe-predict: the control is below 100%%, so this model's expert selection is not raw-logit\n"
+                    "             ranking (an added selection bias, or group-limited routing). The stale-gate\n"
+                    "             figure understates the method by about the control's own gap.\n");
+
+    const size_t n = s.predict_stale_by_layer.size();
+    if (n == 0) return;
+    // A predictor with no routings at this layer prints "-", never 0.0. Layer 0 is the case that
+    // matters: nothing precedes it, so the stale gate structurally cannot reach it — a limit of the
+    // method, not a layer it predicts badly, and a table that showed 0.0% there would say the
+    // opposite. (It is also the gap trained per-layer predictors exist to close.)
+    auto pct = [](const PredictorStats & p, char * buf, size_t n_buf) -> const char * {
+        if (p.rows == 0) {
+            std::snprintf(buf, n_buf, "%6s", "-");
+            return buf;
+        }
+        std::snprintf(buf, n_buf, "%6.1f", 100.0 * p.hit_frac());
+        return buf;
+    };
+    std::printf("  layer   stale    prev   ctrl   routings\n");
+    for (size_t il = 0; il < n; ++il) {
+        const PredictorStats & a = s.predict_stale_by_layer[il];
+        const PredictorStats b = il < s.predict_prev_by_layer.size() ? s.predict_prev_by_layer[il] : PredictorStats{};
+        const PredictorStats c = il < s.predict_self_by_layer.size() ? s.predict_self_by_layer[il] : PredictorStats{};
+        if (a.rows == 0 && b.rows == 0 && c.rows == 0) continue; // a dense layer routes nothing
+        char ba[16], bb[16], bc[16];
+        std::printf("  %5d  %s  %s %s     %6lld\n", (int) il, pct(a, ba, sizeof ba), pct(b, bb, sizeof bb),
+                    pct(c, bc, sizeof bc), a.rows);
+    }
 }
 
 int main(int argc, char ** argv) {
@@ -501,6 +561,8 @@ int main(int argc, char ** argv) {
             cfg.moe.drop_renorm = false;
         else if (a == "--drop-in-prefill")
             cfg.moe.drop_prefill = true;
+        else if (a == "--predict-log")
+            cfg.moe.predict_log = true;
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)
@@ -526,6 +588,7 @@ int main(int argc, char ** argv) {
     if (!seen.count("--overlap")) cfg.moe.overlap = env_int("BMOE_OVERLAP", 0) != 0;
     if (!seen.count("--prefetch")) cfg.moe.prefetch_layers = env_int("BMOE_PREFETCH", 0);
     if (!seen.count("--n-expert-used")) cfg.n_expert_used = env_int("BMOE_N_EXPERT_USED", 0);
+    if (!seen.count("--predict-log")) cfg.moe.predict_log = env_int("BMOE_PREDICT_LOG", 0) != 0;
 
     if (cfg.model_path.empty()) {
         print_usage(argv[0]);
@@ -653,6 +716,7 @@ int main(int argc, char ** argv) {
                         s.experts_dropped, s.experts_routed,
                         s.experts_routed > 0 ? 100.0 * s.experts_dropped / s.experts_routed : 0.0,
                         (double) cfg.moe.drop_cold_frac);
+        if (cfg.moe.predict_log) print_predict_report(s);
     }
     return 0;
 }

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -411,6 +411,10 @@ static void print_predict_report(const RunSummary & s) {
                 " | fresh-gate control %.1f%% (%.1f%%)\n",
                 100.0 * st.hit_frac(), 100.0 * st.exact_frac(), 100.0 * pv.hit_frac(), 100.0 * pv.exact_frac(),
                 100.0 * sf.hit_frac(), 100.0 * sf.exact_frac());
+    // The two-layer horizon, aggregate only: the staleness --predict-prefetch actually runs at.
+    if (s.predict_stale2.rows > 0)
+        std::printf("moe-predict: stale-2 (two layers early) %.1f%% of routed slots (%.1f%% whole routings)\n",
+                    100.0 * s.predict_stale2.hit_frac(), 100.0 * s.predict_stale2.exact_frac());
     // Per predictor, because their denominators genuinely differ: the stale one cannot speak for
     // layer 0 (nothing precedes it) nor for the first token of a run, and quoting one row count for
     // all three would misread those structural gaps as agreement.

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -383,10 +383,12 @@ static void print_usage(const char * argv0) {
         "                          input), scored against the previous-token bet --prefetch makes.\n"
         "                          Changes nothing that is read; costs a barrier and a GEMV per\n"
         "                          layer, so a probed run is not a benchmark run.\n"
-        "      --predict-prefetch  act on that prediction: speculatively read the next layer's\n"
-        "                          predicted experts on the idle lanes (needs the cache; excludes\n"
-        "                          --prefetch). Drop-aware: with --drop-cold-experts armed, experts\n"
+        "      --predict-prefetch  act on that prediction: speculatively read predicted expert\n"
+        "                          misses on the idle lanes and LRU-protect predicted residents\n"
+        "                          (needs the cache; excludes --prefetch). Drop-aware: experts\n"
         "                          predicted below the drop threshold are not speculated.\n"
+        "      --predict-spec-max N  speculated predicted misses per layer [0..8] (default 2;\n"
+        "                          0 = retention only, the prediction spends no flash at all)\n"
         "      --list-archs        print supported MoE architectures and exit\n"
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
@@ -573,6 +575,8 @@ int main(int argc, char ** argv) {
             cfg.moe.predict_log = true;
         else if (a == "--predict-prefetch")
             cfg.moe.predict_prefetch = true;
+        else if (a == "--predict-spec-max")
+            cfg.moe.predict_spec_max = std::atoi(next("--predict-spec-max"));
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -123,6 +123,19 @@ struct MoeStreamConfig {
     // compute-bound, so there is little to win.
     bool drop_prefill = false;
 
+    // Diagnostics: measure how predictable the routing is, without acting on it. For every decoded
+    // token the engine ranks each layer's experts a layer early — running the NEXT layer's gate
+    // matrix on the CURRENT layer's gate input, which the residual stream keeps nearly unchanged —
+    // and reports what fraction of the routing that would have had in flight. Scored alongside it:
+    // the previous-token bet --prefetch already makes, and a zero-staleness control that says how
+    // much of any gap is the ranking's own approximation rather than the staleness.
+    //
+    // Nothing it computes reaches the loading path: a probed run reads exactly the bytes an
+    // unprobed one does. It is not free, though — one isolated node and one gate GEMV per MoE layer
+    // per token, on the eval thread — so a probed run is not a benchmark run. Requires streaming.
+    // See docs/expert-prediction.md.
+    bool predict_log = false;
+
     // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
     // thread, before returning. This defeats the latency-hiding purpose (the reads no longer
     // overlap compute) but makes speculative integration deterministic, so the byte-identity

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -136,6 +136,26 @@ struct MoeStreamConfig {
     // See docs/expert-prediction.md.
     bool predict_log = false;
 
+    // Predictive prefetch: act on the stale-gate prediction instead of just logging it. While
+    // layer l computes, the NEXT layer's router matrix is run on l's gate input (the same one
+    // GEMV predict_log measures) and the predicted experts are handed to the same speculative
+    // read path --prefetch uses — same cache buffers, same accounting, same settle. Two things
+    // separate it from the temporal prefetch it replaces:
+    //   - the prediction is about THIS token (measured ~89% of routed slots on a 128-expert
+    //     model, vs ~43% for the previous-token bet), so far fewer speculated bytes are wasted;
+    //   - it is drop-aware: with drop_cold_frac armed, predicted experts whose predicted routing
+    //     weight falls below the drop threshold are not prefetched — if they miss they would be
+    //     dropped unread anyway, so reading them ahead would spend the exact I/O the drop policy
+    //     exists to save.
+    // Decode only. Needs the LRU cache (speculative slices land in the per-layer cache buffers)
+    // and is mutually exclusive with prefetch_layers — one speculative predictor at a time, or
+    // the lanes fill with two guesses about the same future. Costs one gate GEMV per MoE layer
+    // per token on the eval thread. Byte-identity: like --prefetch, it only warms the cache, so
+    // output is unchanged — except under drop_cold_frac, where residency is an input to the
+    // routing policy and a correct guess un-drops an expert (same caveat as --prefetch, see
+    // docs/expert-dropping.md).
+    bool predict_prefetch = false;
+
     // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
     // thread, before returning. This defeats the latency-hiding purpose (the reads no longer
     // overlap compute) but makes speculative integration deterministic, so the byte-identity

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -156,6 +156,13 @@ struct MoeStreamConfig {
     // docs/expert-dropping.md).
     bool predict_prefetch = false;
 
+    // How many predicted MISSES per layer the predictive prefetch may speculate. The rest of the
+    // prediction still works at any value: predicted experts already resident are retained
+    // (LRU-protected) whatever this says, because that costs zero bytes. 0 is the retention-only
+    // mode — the prediction spends no flash at all and only protects; the measured sweet spot for
+    // speculation, if any, is small (the stall a prefetch can remove is head-of-line only).
+    int predict_spec_max = 2;
+
     // Test/debug only: complete each prefetch's speculative reads synchronously, on the eval
     // thread, before returning. This defeats the latency-hiding purpose (the reads no longer
     // overlap compute) but makes speculative integration deterministic, so the byte-identity

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -34,6 +34,15 @@ public:
     // changes what load_layer produces. Default: no-op (a source without a speculative path).
     virtual void prefetch(int /*il*/, const int32_t * /*ids*/, int /*n_ids*/) {}
 
+    // Mark layer `il`'s already-resident `ids` as recently valuable, so an eviction pass prefers
+    // other entries. The retention half of a prediction: an expert the next layer will very likely
+    // route is worth keeping even if it has not been touched for a while, and protecting it costs
+    // zero bytes — unlike prefetching it, which pays flash for the same insurance. Ids not resident
+    // are ignored (retaining what is absent would mean reading it, which is prefetch's job).
+    // Advisory and eval-thread only, like every other LRU mutation. Default: no cache, nothing to
+    // retain.
+    virtual void retain(int /*il*/, const int32_t * /*ids*/, int /*n_ids*/) {}
+
     // ── route-trace support (diagnostics only; see bmoe/route_trace.h) ──────────────────
     // These let a tracer describe what a routing COST without changing what it does. All three
     // are eval-thread only, and meaningful only between the routing node and load_layer().

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -169,6 +169,7 @@ struct RunInfo {
     bool o_direct = false;
     bool overlap = false;
     int prefetch_layers = 0;
+    bool predict_prefetch = false;      // stale-gate predictive prefetch (see MoeStreamConfig)
     std::string dense_weights = "anon"; // dense (non-expert) policy: "mmap" | "warm" | "anon"
     float drop_cold_frac = 0.0f;        // cache-aware expert dropping threshold (0 = off)
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -6,8 +6,11 @@
 // as CSV for benchmarking. The engine itself makes no formatting decisions.
 #pragma once
 
+#include "bmoe/predict_stats.h"
+
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace bmoe {
 
@@ -125,6 +128,20 @@ struct RunSummary {
     double moe_spec_read_mib = 0.0;
     long long moe_spec_experts = 0;
     long long moe_spec_useful = 0;
+
+    // Expert-prediction accuracy (all zero unless MoeStreamConfig::predict_log). `predict_stale` is
+    // the next layer's routing ranked a layer early, `predict_prev` the previous token's routing —
+    // the bet --prefetch already makes — and `predict_self` a zero-staleness control that bounds
+    // what the ranking could show at best on this architecture. The *_by_layer vectors carry the
+    // same statistic per layer, which is where the interesting shape is: the first layers of a
+    // model route far less predictably than the rest, so an aggregate alone hides the case a
+    // prefetch would most need to get right.
+    //
+    // Unlike the drop counters these are NOT per-generation deltas: they accumulate over the whole
+    // session, because an accuracy estimate wants every sample it can get.
+    PredictorStats predict_stale, predict_prev, predict_self;
+    std::vector<PredictorStats> predict_stale_by_layer, predict_prev_by_layer, predict_self_by_layer;
+    long long predict_unscored = 0; // routings the stale-gate probe could not rank (see RouterHook)
 };
 
 // What this run IS: the model and the configuration every row below it was produced under.

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -139,7 +139,9 @@ struct RunSummary {
     //
     // Unlike the drop counters these are NOT per-generation deltas: they accumulate over the whole
     // session, because an accuracy estimate wants every sample it can get.
-    PredictorStats predict_stale, predict_prev, predict_self;
+    // predict_stale2 is the same predictor two layers early — the staleness the ASYNC prefetch
+    // actually runs at — reported in aggregate only.
+    PredictorStats predict_stale, predict_stale2, predict_prev, predict_self;
     std::vector<PredictorStats> predict_stale_by_layer, predict_prev_by_layer, predict_self_by_layer;
     long long predict_unscored = 0; // routings the stale-gate probe could not rank (see RouterHook)
 };

--- a/core/include/bmoe/predict_stats.h
+++ b/core/include/bmoe/predict_stats.h
@@ -1,0 +1,29 @@
+// Expert-prediction accuracy counters.
+//
+// A prefetch is only worth its bandwidth if it guesses right, and on a device whose flash is
+// already saturated a wrong guess is not free — it displaces a read that was needed. So before
+// any predictor is wired into the loading path, it gets measured here: how much of a routing it
+// would have had in flight, on this model, with these prompts.
+//
+// The unit is the SLOT, not the routing: a top-8 routing offers eight chances to be right, and a
+// predictor that gets six of them turns six reads into hits. `exact` (the whole set predicted)
+// is reported alongside because the literature splits on which one it quotes — set-overlap
+// ratios and exact-match rates are not comparable, and a paper's headline number is usually the
+// first while a system's usable number is closer to the second.
+#pragma once
+
+namespace bmoe {
+
+struct PredictorStats {
+    long long rows = 0;  // routings scored (one per MoE layer per decoded token)
+    long long slots = 0; // sum of top-k over those routings: the denominator for `hits`
+    long long hits = 0;  // predicted experts the router did select
+    long long exact = 0; // routings whose ENTIRE top-k set was predicted
+
+    // Fraction of routed experts the predictor would have had in flight, in [0, 1].
+    double hit_frac() const { return slots > 0 ? (double) hits / (double) slots : 0.0; }
+    // Fraction of routings needing no on-demand read at all, in [0, 1].
+    double exact_frac() const { return rows > 0 ? (double) exact / (double) rows : 0.0; }
+};
+
+} // namespace bmoe

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -58,6 +58,14 @@ ValidationResult validate(const RunConfig & cfg) {
         return fail("moe.overlap requires moe.enabled");
     }
 
+    // The probe rides on the routing nodes the streamer already isolates. Off the streaming path
+    // there is nothing for it to attach to — and nothing to learn either: routing does not depend
+    // on how the weights got into memory, so a dense run would only reproduce the same numbers
+    // more slowly.
+    if (cfg.moe.predict_log && !cfg.moe.enabled) {
+        return fail("moe.predict_log requires moe.enabled");
+    }
+
     if (cfg.moe.enabled) {
         const MoeStreamConfig & m = cfg.moe;
         if (m.io_threads < 1 || m.io_threads > MoeStreamConfig::io_threads_max) {

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -110,6 +110,9 @@ ValidationResult validate(const RunConfig & cfg) {
                         "speculative reads land in the per-layer cache buffers, which do not exist "
                         "with the cache off.");
         }
+        if (m.predict_spec_max < 0 || m.predict_spec_max > 8) {
+            return fail("moe.predict_spec_max must be in [0, 8] (0 = retention only, no speculation)");
+        }
         if (m.predict_prefetch && m.prefetch_layers > 0) {
             return fail("moe.predict_prefetch and moe.prefetch_layers are mutually exclusive: they "
                         "are two predictors for the same speculative read lanes, and running both "

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -65,6 +65,9 @@ ValidationResult validate(const RunConfig & cfg) {
     if (cfg.moe.predict_log && !cfg.moe.enabled) {
         return fail("moe.predict_log requires moe.enabled");
     }
+    if (cfg.moe.predict_prefetch && !cfg.moe.enabled) {
+        return fail("moe.predict_prefetch requires moe.enabled");
+    }
 
     if (cfg.moe.enabled) {
         const MoeStreamConfig & m = cfg.moe;
@@ -101,6 +104,16 @@ ValidationResult validate(const RunConfig & cfg) {
             return fail("moe.prefetch_layers requires the LRU cache (cache_mb > 0 or cache_auto): "
                         "speculative reads land in the per-layer cache buffers, which do not exist "
                         "with the cache off.");
+        }
+        if (m.predict_prefetch && !cache_on) {
+            return fail("moe.predict_prefetch requires the LRU cache (cache_mb > 0 or cache_auto): "
+                        "speculative reads land in the per-layer cache buffers, which do not exist "
+                        "with the cache off.");
+        }
+        if (m.predict_prefetch && m.prefetch_layers > 0) {
+            return fail("moe.predict_prefetch and moe.prefetch_layers are mutually exclusive: they "
+                        "are two predictors for the same speculative read lanes, and running both "
+                        "doubles the speculated bytes for the same future.");
         }
         if (m.drop_cold_frac > 0.0f && !cache_on) {
             return fail("moe.drop_cold_frac requires the LRU cache (cache_mb > 0 or cache_auto): with the "

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -376,7 +376,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.hook->set_prefetch_layers(cfg.moe.prefetch_layers);
     im.hook->set_drop_policy(cfg.moe.drop_cold_frac, cfg.moe.drop_renorm, cfg.moe.drop_prefill);
     im.hook->set_predict_log(cfg.moe.predict_log);
-    im.hook->set_predict_prefetch(cfg.moe.predict_prefetch);
+    im.hook->set_predict_prefetch(cfg.moe.predict_prefetch, cfg.moe.predict_spec_max);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -376,6 +376,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.hook->set_prefetch_layers(cfg.moe.prefetch_layers);
     im.hook->set_drop_policy(cfg.moe.drop_cold_frac, cfg.moe.drop_renorm, cfg.moe.drop_prefill);
     im.hook->set_predict_log(cfg.moe.predict_log);
+    im.hook->set_predict_prefetch(cfg.moe.predict_prefetch);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
@@ -570,6 +571,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.o_direct = cfg.moe.enabled && cfg.moe.o_direct;
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
+        ri.predict_prefetch = cfg.moe.enabled && cfg.moe.predict_prefetch;
         ri.drop_cold_frac = cfg.moe.enabled ? cfg.moe.drop_cold_frac : 0.0f;
         // The CSV keeps the two familiar flags, derived from the resolved dense-weights policy.
         ri.dense_weights = cfg.moe.dense_weights == DenseWeightsMode::Mmap        ? "mmap"

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -982,6 +982,7 @@ RunResult Session::generate(const GenerateRequest & req,
         // Session totals, not a per-generation delta: these are an accuracy estimate, and every
         // turn's routings are equally valid samples of it. See RunSummary.
         s.predict_stale = im.hook->predict_stale();
+        s.predict_stale2 = im.hook->predict_stale2();
         s.predict_prev = im.hook->predict_prev();
         s.predict_self = im.hook->predict_self();
         s.predict_stale_by_layer = im.hook->predict_stale_by_layer();

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -375,6 +375,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.hook = std::make_unique<RouterHook>(recipe ? *recipe : MoeRecipe{}, im.n_layer);
     im.hook->set_prefetch_layers(cfg.moe.prefetch_layers);
     im.hook->set_drop_policy(cfg.moe.drop_cold_frac, cfg.moe.drop_renorm, cfg.moe.drop_prefill);
+    im.hook->set_predict_log(cfg.moe.predict_log);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
@@ -975,6 +976,17 @@ RunResult Session::generate(const GenerateRequest & req,
     }
     s.experts_routed = im.hook->experts_routed() - prev_routed;
     s.experts_dropped = im.hook->experts_dropped() - prev_dropped;
+    if (moe.predict_log) {
+        // Session totals, not a per-generation delta: these are an accuracy estimate, and every
+        // turn's routings are equally valid samples of it. See RunSummary.
+        s.predict_stale = im.hook->predict_stale();
+        s.predict_prev = im.hook->predict_prev();
+        s.predict_self = im.hook->predict_self();
+        s.predict_stale_by_layer = im.hook->predict_stale_by_layer();
+        s.predict_prev_by_layer = im.hook->predict_prev_by_layer();
+        s.predict_self_by_layer = im.hook->predict_self_by_layer();
+        s.predict_unscored = im.hook->predict_unscored();
+    }
     if (sink) sink->on_summary(s);
 
     {

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -23,9 +23,11 @@ public:
                      r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx);
         std::fprintf(f_,
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d force_cache=%d "
-                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d dense_weights=%s drop_cold_frac=%.4g\n",
+                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d predict_prefetch=%d dense_weights=%s "
+                     "drop_cold_frac=%.4g\n",
                      r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.force_cache, r.io_threads, r.o_direct,
-                     r.overlap, r.prefetch_layers, r.dense_weights.c_str(), (double) r.drop_cold_frac);
+                     r.overlap, r.prefetch_layers, r.predict_prefetch, r.dense_weights.c_str(),
+                     (double) r.drop_cold_frac);
         write_header();
     }
 

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -537,6 +537,22 @@ void ExpertStreamSource::evict_tail() {
 }
 
 // ── route-trace support: describe what a routing costs, without changing it ─────────
+// Move already-resident predicted entries to the MRU end so eviction takes something else first.
+// Deliberately NOT a cache hit: chits_ counts lookups the routing actually served, and a
+// prediction is not a routing — inflating the hit rate from here would corrupt the one metric
+// every cache decision in this project is argued from. Eval-thread only (LRU mutation).
+void ExpertStreamSource::retain(int il, const int32_t * ids, int n_ids) {
+    if (!active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids) return;
+    for (int i = 0; i < n_ids; ++i) {
+        const int e = ids[i];
+        if (e < 0 || e >= n_expert_) continue;
+        const int32_t id = il * n_expert_ + e;
+        if (!cvalid_[id]) continue; // absent: keeping it is prefetch's job, not retention's
+        lru_unlink(id);
+        lru_push_front(id);
+    }
+}
+
 void ExpertStreamSource::settle_spec() {
     // Only the LRU path speculates, so mirror load_layer's own guard. Running the quiesce here
     // makes the one inside the load_layer that follows a cheap no-op: nothing left queued, and

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -72,6 +72,7 @@ public:
     // IExpertSource
     bool load_layer(int il, const int32_t * ids, int n_ids) override;
     void prefetch(int il, const int32_t * ids, int n_ids) override;
+    void retain(int il, const int32_t * ids, int n_ids) override;
     void settle_spec() override;
     void query_residency(int il, const int32_t * ids, int n_ids, uint8_t * out) const override;
     uint64_t expert_bytes(int il) const override;

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -218,7 +218,8 @@ void RouterHook::set_predict_log(bool on) {
     predict_reset();
 }
 
-void RouterHook::set_predict_prefetch(bool on) {
+void RouterHook::set_predict_prefetch(bool on, int spec_max) {
+    pred_spec_max_ = spec_max >= 0 ? spec_max : 0;
     predict_prefetch_ = on;
     predict_reset();
     if (on && !pred_worker_.joinable()) pred_worker_ = std::thread([this] { predict_worker_main(); });
@@ -280,7 +281,7 @@ void RouterHook::predict_worker_main() {
         PredictResult r;
         r.seq = job.seq;
         r.nl = job.nl;
-        build_spec_lists(scores, job.nu, job.drop_frac, job.resident, r.spec, r.keep);
+        build_spec_lists(scores, job.nu, job.drop_frac, job.spec_max, job.resident, r.spec, r.keep);
         r.ready = true;
         std::lock_guard<std::mutex> lk(pred_mtx_);
         pred_result_ = std::move(r);
@@ -457,7 +458,7 @@ void RouterHook::predict_at_logits(ggml_tensor * t, int il) {
 // own pin of the top-weighted expert.
 //
 // The split by residency is the cost model in one line: an absent predicted expert is worth AT
-// MOST predict_spec_max flash reads (head-of-line stall is all a prefetch can remove — the tail is
+// MOST spec_max flash reads (head-of-line stall is all a prefetch can remove — the tail is
 // already hidden behind the expert matmul, and speculating a full top-8 was measured to read 33%
 // more flash per token and to triple major faults against a full cache); a RESIDENT predicted
 // expert costs nothing to keep and is merely retained, protecting it from an eviction that would
@@ -465,6 +466,7 @@ void RouterHook::predict_at_logits(ggml_tensor * t, int il) {
 void RouterHook::build_spec_lists(const std::vector<float> & scores,
                                   int nu,
                                   float drop_frac,
+                                  int spec_max,
                                   const std::vector<uint8_t> & resident,
                                   std::vector<int32_t> & spec,
                                   std::vector<int32_t> & keep) {
@@ -489,7 +491,7 @@ void RouterHook::build_spec_lists(const std::vector<float> & scores,
         const int32_t e = pred[k];
         if (e >= 0 && (size_t) e < resident.size() && resident[(size_t) e] != route_miss)
             keep.push_back(e);
-        else if ((int) spec.size() < predict_spec_max)
+        else if ((int) spec.size() < spec_max)
             spec.push_back(e);
     }
 }
@@ -552,6 +554,7 @@ void RouterHook::predict_at_topk(ggml_tensor * t, int il, int nu, int nt) {
         pred_job_.nl = nl;
         pred_job_.nu = nu;
         pred_job_.drop_frac = drop_frac_;
+        pred_job_.spec_max = pred_spec_max_;
         pred_job_.gate = wn;
         pred_job_.row = pred_row_;
         pred_job_.resident = pred_res_;

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -221,19 +221,70 @@ void RouterHook::set_predict_log(bool on) {
 void RouterHook::set_predict_prefetch(bool on) {
     predict_prefetch_ = on;
     predict_reset();
+    if (on && !pred_worker_.joinable()) pred_worker_ = std::thread([this] { predict_worker_main(); });
+    if (!on) predict_worker_stop();
+}
+
+RouterHook::~RouterHook() {
+    predict_worker_stop();
+}
+
+void RouterHook::predict_worker_stop() {
+    if (!pred_worker_.joinable()) return;
+    {
+        std::lock_guard<std::mutex> lk(pred_mtx_);
+        pred_stop_ = true;
+    }
+    pred_cv_.notify_all();
+    pred_worker_.join();
+    pred_stop_ = false;
 }
 
 void RouterHook::predict_reset() {
     const int n = n_layer_ > 0 ? n_layer_ : 0;
     gate_w_.assign(n, nullptr);
+    h_t_.assign(n, nullptr);
     pred_stale_.assign(n, std::vector<int32_t>{});
+    pred_stale2_.assign(n, std::vector<int32_t>{});
     pred_self_.assign(n, std::vector<int32_t>{});
     ps_stale_.assign(n, PredictorStats{});
     ps_prev_.assign(n, PredictorStats{});
     ps_self_.assign(n, PredictorStats{});
-    agg_stale_ = agg_prev_ = agg_self_ = PredictorStats{};
+    agg_stale_ = agg_stale2_ = agg_prev_ = agg_self_ = PredictorStats{};
     predict_unscored_ = 0;
     nu_hint_ = 0;
+    wd_slots_ = wd_hits_ = wd_rout_ = 0;
+    wd_tripped_ = false;
+    std::lock_guard<std::mutex> lk(pred_mtx_);
+    pred_job_pending_ = false;
+    pred_result_ = PredictResult{};
+}
+
+static bool gate_scores(const ggml_tensor * w, const std::vector<float> & h, std::vector<float> & out);
+
+// The prediction worker: everything it touches is either job-local or a read-only weight leaf, so
+// it needs no coordination with the graph, the source, or the LRU — the eval thread snapshots its
+// inputs and consumes its outputs, and this thread only computes.
+void RouterHook::predict_worker_main() {
+    for (;;) {
+        PredictJob job;
+        {
+            std::unique_lock<std::mutex> lk(pred_mtx_);
+            pred_cv_.wait(lk, [&] { return pred_stop_ || pred_job_pending_; });
+            if (pred_stop_) return;
+            job = std::move(pred_job_);
+            pred_job_pending_ = false;
+        }
+        std::vector<float> scores;
+        if (!job.gate || !gate_scores(job.gate, job.row, scores)) continue;
+        PredictResult r;
+        r.seq = job.seq;
+        r.nl = job.nl;
+        build_spec_lists(scores, job.nu, job.drop_frac, job.resident, r.spec, r.keep);
+        r.ready = true;
+        std::lock_guard<std::mutex> lk(pred_mtx_);
+        pred_result_ = std::move(r);
+    }
 }
 
 // Copy one token's row out of a 2-D activation as float, honouring the strides (the row may be a
@@ -260,6 +311,12 @@ static bool row_to_float(const ggml_tensor * t, int j, std::vector<float> & out)
 // The router's own arithmetic: one score per expert, from a gate matrix [n_embd, n_expert] and a
 // gate input row. This is the whole prediction — the same GEMV the graph will do a layer later,
 // done early on an input that has not finished changing.
+//
+// The F16 path matters more than it looks. ggml_fp16_to_fp32 is an exported function, not an
+// inlinable conversion, so the obvious loop pays a function call per weight element — 21M calls
+// per token on a 40-layer, 256-expert model, which measured as ~35-45 ms per GEMV pass and
+// dwarfed everything else this feature does. On aarch64 the compiler converts __fp16 natively
+// (one instruction, vectorizable), so that path is used wherever it exists.
 static bool gate_scores(const ggml_tensor * w, const std::vector<float> & h, std::vector<float> & out) {
     const int64_t nd = w->ne[0], ne = w->ne[1];
     if (nd != (int64_t) h.size() || ne <= 0) return false;
@@ -273,9 +330,15 @@ static bool gate_scores(const ggml_tensor * w, const std::vector<float> & h, std
             for (int64_t d = 0; d < nd; ++d)
                 acc += p[d] * h[(size_t) d];
         } else {
+#if defined(__aarch64__)
+            const __fp16 * p = (const __fp16 *) row;
+            for (int64_t d = 0; d < nd; ++d)
+                acc += (float) p[d] * h[(size_t) d];
+#else
             const ggml_fp16_t * p = (const ggml_fp16_t *) row;
             for (int64_t d = 0; d < nd; ++d)
                 acc += ggml_fp16_to_fp32(p[d]) * h[(size_t) d];
+#endif
         }
         out[(size_t) e] = acc;
     }
@@ -372,74 +435,151 @@ void RouterHook::predict_at_logits(ggml_tensor * t, int il) {
 
     // Stale-gate: the NEXT layer's matrix on this layer's input — the prediction under test. Silent
     // on the first token of a run, whose next layer has not been seen yet; score_layer counts those.
-    // Computed here but NOT speculated here: every load path starts by quiescing speculation, and
-    // this layer's own load_layer is only a few tiny nodes away — reads queued now would be
-    // cancelled before a lane picks them up. predict_after_load() issues them once this layer's
-    // load is behind us, which restores the same read-ahead window the temporal prefetch gets.
-    // pred_scores_ still holds this GEMV's full score vector until layer nl's own logits node,
-    // which is what the drop filter reads — keep it the LAST ranking computed here.
     if (nl < n_layer_ && gate_w_[nl] && gate_scores(gate_w_[nl], pred_row_, pred_scores_))
         rank_top_k(pred_scores_, predict_max_k, pred_stale_[nl]);
+
+    // Stale-2: the matrix two layers ahead on the same input — the accuracy the ASYNC prefetch
+    // actually runs at (see predict_at_topk for why its horizon is two). Probe-only bookkeeping;
+    // the aggregate is what prices the extra layer of staleness on a given model.
+    const int n2 = il + 2;
+    if (predict_log_ && n2 < n_layer_) {
+        pred_stale2_[n2].clear();
+        if (gate_w_[n2] && gate_scores(gate_w_[n2], pred_row_, pred_scores_))
+            rank_top_k(pred_scores_, predict_max_k, pred_stale2_[n2]);
+    }
 }
 
-// Speculate on the prediction for layer il+1, called right after layer il's experts were handed to
-// the source — the one moment a queued read has a whole expert-matmul's worth of idle-lane time
-// before the next quiesce, whichever load path (plain topk, deferred drop, or the drop fallback)
-// just ran.
-void RouterHook::predict_after_load(int il) {
-    if (!predict_prefetch_ || batch_phase_ != 1) return;
-    const int nl = il + 1;
-    if (nl <= 0 || nl >= n_layer_ || pred_stale_[nl].empty()) return;
-    predict_issue_prefetch(nl);
+// From one full score vector to the two lists the prefetch acts on. The softmax over the top-nu
+// predicted scores approximates the routing weights the real gate will produce (exact for
+// softmax-gated models, a fair proxy elsewhere); a candidate below the drop threshold is only ever
+// read on demand — if it misses, the policy drops it unread, so speculating it would spend the
+// exact I/O the policy exists to save. The top prediction is always kept, mirroring the policy's
+// own pin of the top-weighted expert.
+//
+// The split by residency is the cost model in one line: an absent predicted expert is worth AT
+// MOST predict_spec_max flash reads (head-of-line stall is all a prefetch can remove — the tail is
+// already hidden behind the expert matmul, and speculating a full top-8 was measured to read 33%
+// more flash per token and to triple major faults against a full cache); a RESIDENT predicted
+// expert costs nothing to keep and is merely retained, protecting it from an eviction that would
+// turn a predicted hit back into a read.
+void RouterHook::build_spec_lists(const std::vector<float> & scores,
+                                  int nu,
+                                  float drop_frac,
+                                  const std::vector<uint8_t> & resident,
+                                  std::vector<int32_t> & spec,
+                                  std::vector<int32_t> & keep) {
+    spec.clear();
+    keep.clear();
+    std::vector<int32_t> pred;
+    rank_top_k(scores, nu, pred);
+    if ((int) pred.size() < nu) return;
+
+    float w[predict_max_k];
+    float mx = scores[(size_t) pred[0]];
+    for (int k = 1; k < nu; ++k)
+        if (scores[(size_t) pred[k]] > mx) mx = scores[(size_t) pred[k]];
+    float sum = 0.0f;
+    for (int k = 0; k < nu; ++k) {
+        w[k] = std::exp(scores[(size_t) pred[k]] - mx);
+        sum += w[k];
+    }
+    const float thr = drop_frac > 0.0f ? drop_frac / (float) nu : 0.0f;
+    for (int k = 0; k < nu; ++k) {
+        if (k != 0 && drop_frac > 0.0f && !(sum > 0.0f && w[k] / sum >= thr)) continue;
+        const int32_t e = pred[k];
+        if (e >= 0 && (size_t) e < resident.size() && resident[(size_t) e] != route_miss)
+            keep.push_back(e);
+        else if ((int) spec.size() < predict_spec_max)
+            spec.push_back(e);
+    }
 }
 
-// Hand the prediction for layer nl to the speculative read path, minus what the drop policy would
-// discard anyway. The filter reasons entirely in predicted quantities: softmax over the predicted
-// top-k's raw scores approximates the routing weights the real gate will produce (exact for
-// softmax-gated models, a fair proxy elsewhere), and a candidate below the drop threshold is only
-// ever read on demand — if it turns out resident it runs for free, if it misses the policy drops
-// it unread. Speculating it would spend the precise I/O the policy exists to save. The top
-// prediction is always kept, mirroring the policy's own pin of the top-weighted expert.
-void RouterHook::predict_issue_prefetch(int nl) {
-    const int nu = nu_hint_;
-    if (!source_ || nu <= 0 || nu > (int) pred_stale_[nl].size()) return; // width unknown yet, or ranked short
+// At the topk of layer il, with the routing ids in hand: sample the watchdog, then submit the
+// prediction job for layer il+2 built from THIS layer's gate input.
+void RouterHook::predict_at_topk(ggml_tensor * t, int il, int nu, int nt) {
+    if (!predict_prefetch_ || wd_tripped_ || batch_phase_ != 1 || !source_) return;
+    if (il < 0 || il >= n_layer_ || nu <= 0 || nu > predict_max_k || nt <= 0) return;
+    ggml_tensor * h = h_t_[il];
+    if (!h || !h->data || h->ne[1] <= 0) return;
+    const int j = (int) h->ne[1] - 1; // the batch's last token
 
-    const std::vector<int32_t> & pred = pred_stale_[nl];
-    spec_ids_.clear();
-    if (drop_frac_ > 0.0f) {
-        // Softmax over the top-nu predicted scores only: the tail's mass is what the real gate's
-        // normalisation also throws away, and nu terms keep the exp() cost trivial.
-        spec_w_.assign((size_t) nu, 0.0f);
-        float mx = pred_scores_[(size_t) pred[0]];
-        for (int k = 1; k < nu; ++k)
-            if (pred_scores_[(size_t) pred[k]] > mx) mx = pred_scores_[(size_t) pred[k]];
-        float sum = 0.0f;
-        for (int k = 0; k < nu; ++k) {
-            spec_w_[(size_t) k] = std::exp(pred_scores_[(size_t) pred[k]] - mx);
-            sum += spec_w_[(size_t) k];
-        }
-        const float thr = drop_frac_ / (float) nu;
+    // Watchdog sample: the layer's OWN gate on the row just read must reproduce the ids the router
+    // just chose. This is the barrier-less read validating itself — if ggml's planner reused the
+    // buffer between the gate matmul and here, or the architecture does not select by raw-logit
+    // ranking, the control collapses and the prefetch disarms instead of speculating on noise.
+    if (++wd_rout_ % wd_interval == 0 && gate_w_[il] && row_to_float(h, j, pred_row_) &&
+        gate_scores(gate_w_[il], pred_row_, pred_scores_)) {
+        std::vector<int32_t> ctrl;
+        rank_top_k(pred_scores_, nu, ctrl);
+        const int32_t * actual = gathered_.data() + (size_t) (nt - 1) * nu;
+        int hits = 0;
         for (int k = 0; k < nu; ++k)
-            if (k == 0 || (sum > 0.0f && spec_w_[(size_t) k] / sum >= thr)) spec_ids_.push_back(pred[k]);
-    } else {
-        spec_ids_.assign(pred.begin(), pred.begin() + nu);
+            for (int32_t p : ctrl)
+                if (p == actual[k]) {
+                    ++hits;
+                    break;
+                }
+        wd_slots_ += nu;
+        wd_hits_ += hits;
+        if (wd_slots_ >= wd_min_slots && (double) wd_hits_ < wd_min_frac * (double) wd_slots_) {
+            wd_tripped_ = true;
+            std::fprintf(stderr,
+                         "bmoe: predict-prefetch disarmed — control at %.1f%% over %lld slots says the "
+                         "barrier-less gate-input read is not trustworthy on this graph\n",
+                         100.0 * wd_hits_ / wd_slots_, wd_slots_);
+            return;
+        }
     }
 
-    // Keep only the top predict_spec_max predicted MISSES. The stall a prefetch can remove is
-    // head-of-line — the per-expert wait on the first slices to land — and the tail is already
-    // hidden by overlapping reads with the expert matmul, so speculating the whole routing buys
-    // little stall while paying for every byte. Measured: speculating all of it read 33% more
-    // flash per token and its vm commits fought a full cache hard enough to triple major faults,
-    // costing far more than the stall it removed. Misses only, because a predicted expert that is
-    // already resident needs nothing and would only burn a slot of the cap.
-    pred_res_.assign(spec_ids_.size(), (uint8_t) 0);
-    source_->query_residency(nl, spec_ids_.data(), (int) spec_ids_.size(), pred_res_.data());
-    size_t w = 0;
-    for (size_t i = 0; i < spec_ids_.size() && w < (size_t) predict_spec_max; ++i)
-        if (pred_res_[i] == route_miss) spec_ids_[w++] = spec_ids_[i];
-    spec_ids_.resize(w);
+    // Submit il+2: copy the row and snapshot residency on this thread (both are cheap and neither
+    // is safe to read from the worker), and let the worker do the arithmetic.
+    const int nl = il + 2;
+    if (nl >= n_layer_) return;
+    const ggml_tensor * wn = gate_w_[nl];
+    if (!wn || !wn->data) return;
+    const int ne = (int) wn->ne[1];
+    if (ne <= 0 || !row_to_float(h, j, pred_row_)) return;
 
-    if (!spec_ids_.empty()) source_->prefetch(nl, spec_ids_.data(), (int) spec_ids_.size());
+    spec_ids_.resize((size_t) ne); // scratch: the identity id list for the residency snapshot
+    for (int e = 0; e < ne; ++e)
+        spec_ids_[(size_t) e] = e;
+    pred_res_.assign((size_t) ne, (uint8_t) 0);
+    source_->query_residency(nl, spec_ids_.data(), ne, pred_res_.data());
+
+    {
+        std::lock_guard<std::mutex> lk(pred_mtx_);
+        pred_job_.seq = ++pred_seq_;
+        pred_job_.nl = nl;
+        pred_job_.nu = nu;
+        pred_job_.drop_frac = drop_frac_;
+        pred_job_.gate = wn;
+        pred_job_.row = pred_row_;
+        pred_job_.resident = pred_res_;
+        pred_job_pending_ = true;
+    }
+    pred_cv_.notify_one();
+}
+
+// Collect and act on a finished prediction, right after layer il's experts were handed to the
+// source — the one moment a queued read has a whole layer's worth of idle-lane time before the
+// next quiesce, whichever load path (plain topk, deferred drop, or the drop fallback) just ran.
+// The result present here targets il+1 (it was submitted one layer back, so the worker had a full
+// layer to make the deadline); one that is not ready is skipped, never waited for.
+void RouterHook::predict_after_load(int il) {
+    if (!predict_prefetch_ || wd_tripped_ || batch_phase_ != 1 || !source_) return;
+    const int nl = il + 1;
+    if (nl <= 0 || nl >= n_layer_) return;
+    PredictResult r;
+    {
+        std::lock_guard<std::mutex> lk(pred_mtx_);
+        if (!pred_result_.ready || pred_result_.nl != nl) return;
+        r = std::move(pred_result_);
+        pred_result_.ready = false;
+    }
+    // Retention first: it is free, and an entry protected before the eviction that a subsequent
+    // prefetch commit might force is protected in time.
+    if (!r.keep.empty()) source_->retain(nl, r.keep.data(), (int) r.keep.size());
+    if (!r.spec.empty()) source_->prefetch(nl, r.spec.data(), (int) r.spec.size());
 }
 
 // At the topk of layer il: compare every predictor with what the router actually chose. Must run
@@ -455,6 +595,14 @@ void RouterHook::score_layer(int il, const int32_t * actual, int nu) {
         score_prediction(pred_stale_[il], actual, nu, ps_stale_[il], agg_stale_);
     if (!pred_self_[il].empty()) score_prediction(pred_self_[il], actual, nu, ps_self_[il], agg_self_);
     if (!prev_ids_[il].empty()) score_prediction(prev_ids_[il], actual, nu, ps_prev_[il], agg_prev_);
+    if (!pred_stale2_[il].empty()) {
+        // Aggregate only: the two-layer horizon exists to price the async prefetch's staleness,
+        // and one number does that; a per-layer table of it would double the report for no call
+        // anyone makes differently.
+        PredictorStats discard;
+        score_prediction(pred_stale2_[il], actual, nu, discard, agg_stale2_);
+        pred_stale2_[il].clear();
+    }
     pred_stale_[il].clear();
     pred_self_[il].clear();
 }
@@ -663,12 +811,19 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     int wl = -1;
     const bool want_weights = trace_on_ || drop_armed();
     const bool is_weights = want_weights && match_weights(t->name, wl);
-    // The gate matmul, asked for only by the prediction probe. Decode-only: prefill has no previous
-    // token to predict from, and it is not the phase a prefetch would be built for. The "-" in the
-    // pattern is what keeps "ffn_moe_logits_biased-<il>" — a different node — from matching.
+    // The gate matmul. The probe ISOLATES it (a barrier per layer — a probed run is not a
+    // benchmark run); the prefetch only wants its source pointers, which the ask pass hands over
+    // for free, so it asks for nothing and validates its barrier-less read with the watchdog
+    // instead. Decode-only either way. The "-" in the pattern is what keeps
+    // "ffn_moe_logits_biased-<il>" — a different node — from matching.
     int gl = -1;
     const bool is_logits =
         predict_on() && source_ && batch_phase_ == 1 && std::sscanf(t->name, "ffn_moe_logits-%d", &gl) == 1 && gl >= 0;
+    if (ask && is_logits && gl < n_layer_) {
+        ggml_tensor * w = t->src[0];
+        if (w && w->op == GGML_OP_NONE && w->data && ggml_is_contiguous(w)) gate_w_[gl] = w;
+        h_t_[gl] = t->src[1];
+    }
     // The compute trace wants every node isolated — or, at layer granularity, only the first
     // node of each layer: the cursor advances on the ask stream (every node passes through
     // here), so one isolation request per layer transition. Layerless names (embeddings, the
@@ -687,7 +842,7 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 }
             }
         }
-        return ctrace_iso || is_topk || is_weights || is_logits;
+        return ctrace_iso || is_topk || is_weights || (is_logits && predict_log_);
     }
 
     // The probe attaches to the gate matmul rather than to the topk node because this is where the
@@ -752,6 +907,11 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         // it a layer before any topk of the predicted layer exists, and reading it here (not from
         // config) keeps an --n-expert-used override honest without another plumbing path.
         if (predict_on() && nu > 0) nu_hint_ = nu;
+
+        // Watchdog sample + submit the il+2 prediction job. Before the load flow on purpose: the
+        // snapshot must precede load_layer, whose staging would otherwise count this layer's own
+        // reads into the residency picture the job carries.
+        predict_at_topk(t, il, nu, nt);
 
         // Open the layer for the drop policy. Deferring the load is only safe once this layer's
         // terminal weight node is known — otherwise there is no callback left to decide in, and the

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -424,6 +424,21 @@ void RouterHook::predict_issue_prefetch(int nl) {
     } else {
         spec_ids_.assign(pred.begin(), pred.begin() + nu);
     }
+
+    // Keep only the top predict_spec_max predicted MISSES. The stall a prefetch can remove is
+    // head-of-line — the per-expert wait on the first slices to land — and the tail is already
+    // hidden by overlapping reads with the expert matmul, so speculating the whole routing buys
+    // little stall while paying for every byte. Measured: speculating all of it read 33% more
+    // flash per token and its vm commits fought a full cache hard enough to triple major faults,
+    // costing far more than the stall it removed. Misses only, because a predicted expert that is
+    // already resident needs nothing and would only burn a slot of the cap.
+    pred_res_.assign(spec_ids_.size(), (uint8_t) 0);
+    source_->query_residency(nl, spec_ids_.data(), (int) spec_ids_.size(), pred_res_.data());
+    size_t w = 0;
+    for (size_t i = 0; i < spec_ids_.size() && w < (size_t) predict_spec_max; ++i)
+        if (pred_res_[i] == route_miss) spec_ids_[w++] = spec_ids_[i];
+    spec_ids_.resize(w);
+
     if (!spec_ids_.empty()) source_->prefetch(nl, spec_ids_.data(), (int) spec_ids_.size());
 }
 

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -203,6 +203,182 @@ void RouterHook::close_drop_layer() {
     D.layer = -1;
 }
 
+// ── expert-prediction accuracy probe ────────────────────────────────────────────────────
+//
+// Observes only: it reads the gate matrix and the gate input, ranks experts from them, and
+// compares the ranking with what the router went on to select. Nothing it computes reaches
+// load_layer, the cache, or the graph, so a probed run routes and reads exactly as an unprobed
+// one — it is only slower.
+
+void RouterHook::set_predict_log(bool on) {
+    predict_log_ = on;
+    const int n = n_layer_ > 0 ? n_layer_ : 0;
+    gate_w_.assign(n, nullptr);
+    pred_stale_.assign(n, std::vector<int32_t>{});
+    pred_self_.assign(n, std::vector<int32_t>{});
+    ps_stale_.assign(n, PredictorStats{});
+    ps_prev_.assign(n, PredictorStats{});
+    ps_self_.assign(n, PredictorStats{});
+    agg_stale_ = agg_prev_ = agg_self_ = PredictorStats{};
+    predict_unscored_ = 0;
+}
+
+// Copy one token's row out of a 2-D activation as float, honouring the strides (the row may be a
+// view). Returns false for a dtype the probe does not read, which is how an unsupported model
+// declines the measurement instead of reporting a wrong one.
+static bool row_to_float(const ggml_tensor * t, int j, std::vector<float> & out) {
+    const int64_t n = t->ne[0];
+    if (n <= 0) return false;
+    const char * row = (const char *) t->data + (size_t) j * t->nb[1];
+    out.assign((size_t) n, 0.0f);
+    if (t->type == GGML_TYPE_F32) {
+        for (int64_t d = 0; d < n; ++d)
+            out[(size_t) d] = *(const float *) (row + (size_t) d * t->nb[0]);
+        return true;
+    }
+    if (t->type == GGML_TYPE_F16) {
+        for (int64_t d = 0; d < n; ++d)
+            out[(size_t) d] = ggml_fp16_to_fp32(*(const ggml_fp16_t *) (row + (size_t) d * t->nb[0]));
+        return true;
+    }
+    return false;
+}
+
+// The router's own arithmetic: one score per expert, from a gate matrix [n_embd, n_expert] and a
+// gate input row. This is the whole prediction — the same GEMV the graph will do a layer later,
+// done early on an input that has not finished changing.
+static bool gate_scores(const ggml_tensor * w, const std::vector<float> & h, std::vector<float> & out) {
+    const int64_t nd = w->ne[0], ne = w->ne[1];
+    if (nd != (int64_t) h.size() || ne <= 0) return false;
+    if (w->type != GGML_TYPE_F32 && w->type != GGML_TYPE_F16) return false;
+    out.assign((size_t) ne, 0.0f);
+    for (int64_t e = 0; e < ne; ++e) {
+        const char * row = (const char *) w->data + (size_t) e * w->nb[1];
+        float acc = 0.0f;
+        if (w->type == GGML_TYPE_F32) {
+            const float * p = (const float *) row;
+            for (int64_t d = 0; d < nd; ++d)
+                acc += p[d] * h[(size_t) d];
+        } else {
+            const ggml_fp16_t * p = (const ggml_fp16_t *) row;
+            for (int64_t d = 0; d < nd; ++d)
+                acc += ggml_fp16_to_fp32(p[d]) * h[(size_t) d];
+        }
+        out[(size_t) e] = acc;
+    }
+    return true;
+}
+
+// Ranking on RAW scores is exact wherever the gating function is monotonic — softmax, sigmoid and
+// sqrt-softplus all are, so the order of the logits is the order of the probabilities the router
+// sorts. It is NOT exact where the architecture adds a per-expert selection bias or masks whole
+// expert groups before the argsort; there the ranking here is an approximation, and the fresh-gate
+// control is what reveals it (it will sit below 100%) instead of the loss being blamed on staleness.
+void RouterHook::rank_top_k(const std::vector<float> & scores, int k, std::vector<int32_t> & out) {
+    const int n = (int) scores.size();
+    const int want = k < n ? k : n;
+    out.clear();
+    if (want <= 0) return;
+    out.reserve((size_t) want);
+    // Partial selection rather than a sort: `want` is at most predict_max_k and n at most a few
+    // hundred, so this is cheaper than ordering the tail nobody reads, and it needs no scratch.
+    for (int i = 0; i < want; ++i) {
+        int best = -1;
+        for (int e = 0; e < n; ++e) {
+            bool used = false;
+            for (int32_t taken : out)
+                if (taken == e) {
+                    used = true;
+                    break;
+                }
+            if (used) continue;
+            if (best < 0 || scores[(size_t) e] > scores[(size_t) best]) best = e; // ties to the lower index
+        }
+        if (best < 0) break;
+        out.push_back((int32_t) best);
+    }
+}
+
+// Score one prediction against one routing. Only the prediction's first k entries count: a
+// prefetch would fetch k experts, so crediting a hit found deeper in the ranking would measure a
+// predictor nobody could build.
+void RouterHook::score_prediction(
+    const std::vector<int32_t> & pred, const int32_t * actual, int k, PredictorStats & layer, PredictorStats & agg) {
+    const int np = (int) pred.size() < k ? (int) pred.size() : k;
+    int hits = 0;
+    for (int i = 0; i < k; ++i)
+        for (int p = 0; p < np; ++p)
+            if (pred[(size_t) p] == actual[i]) {
+                ++hits;
+                break;
+            }
+    const long long exact = hits == k ? 1 : 0;
+    layer.rows += 1;
+    layer.slots += k;
+    layer.hits += hits;
+    layer.exact += exact;
+    agg.rows += 1;
+    agg.slots += k;
+    agg.hits += hits;
+    agg.exact += exact;
+}
+
+// At the gate matmul of layer il: learn its router matrix, rank its own logits (the control), and
+// predict layer il+1 from the input this layer is about to consume.
+void RouterHook::predict_at_logits(ggml_tensor * t, int il) {
+    if (il < 0 || il >= n_layer_) return;
+
+    // The gate matmul's sources are the router matrix and the gate input. Taking the matrix from
+    // the graph instead of looking it up by tensor name is what keeps the probe architecture-neutral
+    // — and it is a weight LEAF, so unlike a graph intermediate the pointer stays valid into the
+    // layers this token has not reached yet, which is exactly what predicting forward needs.
+    ggml_tensor * w = t->src[0];
+    ggml_tensor * h = t->src[1];
+    if (w && w->op == GGML_OP_NONE && w->data && ggml_is_contiguous(w)) gate_w_[il] = w;
+
+    const int nt = (int) t->ne[1];
+    if (nt <= 0) return;
+    const int j = nt - 1; // the batch's last token, the one prev_ids_ also records
+    const int nl = il + 1;
+
+    pred_self_[il].clear();
+    if (nl < n_layer_) pred_stale_[nl].clear();
+
+    // Both rankings below run the same code over the same gate input; only the matrix differs. That
+    // is what makes the control a control — it shares the row read, the GEMV and the ranking with
+    // the prediction under test, so a bug in any of them surfaces as a control below 100% instead
+    // of quietly depressing the number the experiment is about.
+    if (!h || !h->data || !row_to_float(h, j, pred_row_)) return;
+
+    // Fresh-gate control: this layer's own matrix on its own input, with no staleness at all. It has
+    // to reproduce the routing the graph is about to compute from those very two tensors, so it is
+    // also the check that this GEMV agrees with llama.cpp's.
+    if (gate_w_[il] && gate_scores(gate_w_[il], pred_row_, pred_scores_))
+        rank_top_k(pred_scores_, predict_max_k, pred_self_[il]);
+
+    // Stale-gate: the NEXT layer's matrix on this layer's input — the prediction under test. Silent
+    // on the first token of a run, whose next layer has not been seen yet; score_layer counts those.
+    if (nl < n_layer_ && gate_w_[nl] && gate_scores(gate_w_[nl], pred_row_, pred_scores_))
+        rank_top_k(pred_scores_, predict_max_k, pred_stale_[nl]);
+}
+
+// At the topk of layer il: compare every predictor with what the router actually chose. Must run
+// before prev_ids_[il] is overwritten, or the previous-token predictor would be handed the answer.
+void RouterHook::score_layer(int il, const int32_t * actual, int nu) {
+    if (nu <= 0 || nu > predict_max_k) { // a routing wider than the probe ranks; declined, not missed
+        ++predict_unscored_;
+        return;
+    }
+    if (pred_stale_[il].empty())
+        ++predict_unscored_;
+    else
+        score_prediction(pred_stale_[il], actual, nu, ps_stale_[il], agg_stale_);
+    if (!pred_self_[il].empty()) score_prediction(pred_self_[il], actual, nu, ps_self_[il], agg_self_);
+    if (!prev_ids_[il].empty()) score_prediction(prev_ids_[il], actual, nu, ps_prev_[il], agg_prev_);
+    pred_stale_[il].clear();
+    pred_self_[il].clear();
+}
+
 void RouterHook::set_trace(bool on) {
     trace_on_ = on;
     pending_ = PendingLayer{};
@@ -407,6 +583,12 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     int wl = -1;
     const bool want_weights = trace_on_ || drop_armed();
     const bool is_weights = want_weights && match_weights(t->name, wl);
+    // The gate matmul, asked for only by the prediction probe. Decode-only: prefill has no previous
+    // token to predict from, and it is not the phase a prefetch would be built for. The "-" in the
+    // pattern is what keeps "ffn_moe_logits_biased-<il>" — a different node — from matching.
+    int gl = -1;
+    const bool is_logits =
+        predict_log_ && source_ && batch_phase_ == 1 && std::sscanf(t->name, "ffn_moe_logits-%d", &gl) == 1 && gl >= 0;
     // The compute trace wants every node isolated — or, at layer granularity, only the first
     // node of each layer: the cursor advances on the ask stream (every node passes through
     // here), so one isolation request per layer transition. Layerless names (embeddings, the
@@ -425,8 +607,13 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 }
             }
         }
-        return ctrace_iso || is_topk || is_weights;
+        return ctrace_iso || is_topk || is_weights || is_logits;
     }
+
+    // The probe attaches to the gate matmul rather than to the topk node because this is where the
+    // router's own two inputs are reachable: a graph intermediate cannot be found by name later, and
+    // its pointer does not survive to the next graph. It writes nothing the graph will read.
+    if (is_logits) predict_at_logits(t, gl);
 
     // Weights follow their layer's topk, so the pending record is already open; keep the last
     // one offered (match_weights explains why) and let the flush read it. This runs BEFORE the drop
@@ -496,15 +683,27 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         else
             source_->load_layer(il, gathered_.data(), (int) gathered_.size());
 
+        // Score the predictors against the routing the router just produced — before the record
+        // below moves on, or the previous-token predictor would be graded on the answer itself.
+        // The ids gathered above are still the router's own choice: the drop policy edits them at
+        // a later node, so a probed run measures routing, not what the cache left of it.
+        if (predict_log_ && batch_phase_ == 1 && il >= 0 && il < n_layer_ && nt > 0)
+            score_layer(il, gathered_.data() + (size_t) (nt - 1) * nu, nu);
+
         // Temporal prefetch: hint the next K layers with what the PREVIOUS token routed there,
-        // to be read on idle lanes while this layer computes; then record this layer's routing
-        // (the last token's row during prefill) for the next token to predict from.
+        // to be read on idle lanes while this layer computes.
         if (prefetch_layers_ > 0 && il >= 0 && il < n_layer_) {
             for (int k = 1; k <= prefetch_layers_; ++k) {
                 const int tl = il + k;
                 if (tl < n_layer_ && !prev_ids_[tl].empty())
                     source_->prefetch(tl, prev_ids_[tl].data(), (int) prev_ids_[tl].size());
             }
+        }
+
+        // Record this layer's routing (the last token's row during prefill) for the next token to
+        // predict from. Both consumers read it: the prefetch above, and the probe's previous-token
+        // predictor — which is that same bet, scored instead of acted on.
+        if ((prefetch_layers_ > 0 || predict_log_) && il >= 0 && il < n_layer_) {
             std::vector<int32_t> & rec = prev_ids_[il];
             rec.clear();
             const int last = nt - 1;

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -3,6 +3,7 @@
 #include "ggml.h"
 #include "../io/platform_io.h"
 
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <limits>
@@ -180,6 +181,7 @@ void RouterHook::apply_drop(ggml_tensor * wt) {
     if (tracing) pending_.dropped = drop_mask_;
     source_->load_layer(D.layer, drop_ids_.data(), (int) drop_ids_.size());
     D.deferred = false;
+    predict_after_load(D.layer);
 }
 
 // Finish with the layer whose topk we last saw: record which node ended its weight chain, so the
@@ -199,6 +201,7 @@ void RouterHook::close_drop_layer() {
         source_->load_layer(D.layer, drop_ids_.data(), (int) drop_ids_.size());
         if (D.layer < (int) term_node_.size()) term_node_[D.layer].clear();
         D.deferred = false;
+        predict_after_load(D.layer);
     }
     D.layer = -1;
 }
@@ -212,6 +215,15 @@ void RouterHook::close_drop_layer() {
 
 void RouterHook::set_predict_log(bool on) {
     predict_log_ = on;
+    predict_reset();
+}
+
+void RouterHook::set_predict_prefetch(bool on) {
+    predict_prefetch_ = on;
+    predict_reset();
+}
+
+void RouterHook::predict_reset() {
     const int n = n_layer_ > 0 ? n_layer_ : 0;
     gate_w_.assign(n, nullptr);
     pred_stale_.assign(n, std::vector<int32_t>{});
@@ -221,6 +233,7 @@ void RouterHook::set_predict_log(bool on) {
     ps_self_.assign(n, PredictorStats{});
     agg_stale_ = agg_prev_ = agg_self_ = PredictorStats{};
     predict_unscored_ = 0;
+    nu_hint_ = 0;
 }
 
 // Copy one token's row out of a 2-D activation as float, honouring the strides (the row may be a
@@ -352,14 +365,66 @@ void RouterHook::predict_at_logits(ggml_tensor * t, int il) {
 
     // Fresh-gate control: this layer's own matrix on its own input, with no staleness at all. It has
     // to reproduce the routing the graph is about to compute from those very two tensors, so it is
-    // also the check that this GEMV agrees with llama.cpp's.
-    if (gate_w_[il] && gate_scores(gate_w_[il], pred_row_, pred_scores_))
+    // also the check that this GEMV agrees with llama.cpp's. Probe-only — the prefetch has no use
+    // for a prediction of the layer it is already standing in, and skipping it halves the tax.
+    if (predict_log_ && gate_w_[il] && gate_scores(gate_w_[il], pred_row_, pred_scores_))
         rank_top_k(pred_scores_, predict_max_k, pred_self_[il]);
 
     // Stale-gate: the NEXT layer's matrix on this layer's input — the prediction under test. Silent
     // on the first token of a run, whose next layer has not been seen yet; score_layer counts those.
+    // Computed here but NOT speculated here: every load path starts by quiescing speculation, and
+    // this layer's own load_layer is only a few tiny nodes away — reads queued now would be
+    // cancelled before a lane picks them up. predict_after_load() issues them once this layer's
+    // load is behind us, which restores the same read-ahead window the temporal prefetch gets.
+    // pred_scores_ still holds this GEMV's full score vector until layer nl's own logits node,
+    // which is what the drop filter reads — keep it the LAST ranking computed here.
     if (nl < n_layer_ && gate_w_[nl] && gate_scores(gate_w_[nl], pred_row_, pred_scores_))
         rank_top_k(pred_scores_, predict_max_k, pred_stale_[nl]);
+}
+
+// Speculate on the prediction for layer il+1, called right after layer il's experts were handed to
+// the source — the one moment a queued read has a whole expert-matmul's worth of idle-lane time
+// before the next quiesce, whichever load path (plain topk, deferred drop, or the drop fallback)
+// just ran.
+void RouterHook::predict_after_load(int il) {
+    if (!predict_prefetch_ || batch_phase_ != 1) return;
+    const int nl = il + 1;
+    if (nl <= 0 || nl >= n_layer_ || pred_stale_[nl].empty()) return;
+    predict_issue_prefetch(nl);
+}
+
+// Hand the prediction for layer nl to the speculative read path, minus what the drop policy would
+// discard anyway. The filter reasons entirely in predicted quantities: softmax over the predicted
+// top-k's raw scores approximates the routing weights the real gate will produce (exact for
+// softmax-gated models, a fair proxy elsewhere), and a candidate below the drop threshold is only
+// ever read on demand — if it turns out resident it runs for free, if it misses the policy drops
+// it unread. Speculating it would spend the precise I/O the policy exists to save. The top
+// prediction is always kept, mirroring the policy's own pin of the top-weighted expert.
+void RouterHook::predict_issue_prefetch(int nl) {
+    const int nu = nu_hint_;
+    if (!source_ || nu <= 0 || nu > (int) pred_stale_[nl].size()) return; // width unknown yet, or ranked short
+
+    const std::vector<int32_t> & pred = pred_stale_[nl];
+    spec_ids_.clear();
+    if (drop_frac_ > 0.0f) {
+        // Softmax over the top-nu predicted scores only: the tail's mass is what the real gate's
+        // normalisation also throws away, and nu terms keep the exp() cost trivial.
+        spec_w_.assign((size_t) nu, 0.0f);
+        float mx = pred_scores_[(size_t) pred[0]];
+        for (int k = 1; k < nu; ++k)
+            if (pred_scores_[(size_t) pred[k]] > mx) mx = pred_scores_[(size_t) pred[k]];
+        float sum = 0.0f;
+        for (int k = 0; k < nu; ++k) {
+            spec_w_[(size_t) k] = std::exp(pred_scores_[(size_t) pred[k]] - mx);
+            sum += spec_w_[(size_t) k];
+        }
+        const float thr = drop_frac_ / (float) nu;
+        for (int k = 0; k < nu; ++k)
+            if (k == 0 || (sum > 0.0f && spec_w_[(size_t) k] / sum >= thr)) spec_ids_.push_back(pred[k]);
+    } else {
+        spec_ids_.assign(pred.begin(), pred.begin() + nu);
+    }
+    if (!spec_ids_.empty()) source_->prefetch(nl, spec_ids_.data(), (int) spec_ids_.size());
 }
 
 // At the topk of layer il: compare every predictor with what the router actually chose. Must run
@@ -588,7 +653,7 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     // pattern is what keeps "ffn_moe_logits_biased-<il>" — a different node — from matching.
     int gl = -1;
     const bool is_logits =
-        predict_log_ && source_ && batch_phase_ == 1 && std::sscanf(t->name, "ffn_moe_logits-%d", &gl) == 1 && gl >= 0;
+        predict_on() && source_ && batch_phase_ == 1 && std::sscanf(t->name, "ffn_moe_logits-%d", &gl) == 1 && gl >= 0;
     // The compute trace wants every node isolated — or, at layer granularity, only the first
     // node of each layer: the cursor advances on the ask stream (every node passes through
     // here), so one isolation request per layer transition. Layerless names (embeddings, the
@@ -668,6 +733,11 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         // the wrong thing.
         if (drop_frac_ > 0.0f) experts_routed_ += (long long) gathered_.size();
 
+        // The routing width, learned from the node that defines it. The predictive prefetch needs
+        // it a layer before any topk of the predicted layer exists, and reading it here (not from
+        // config) keeps an --n-expert-used override honest without another plumbing path.
+        if (predict_on() && nu > 0) nu_hint_ = nu;
+
         // Open the layer for the drop policy. Deferring the load is only safe once this layer's
         // terminal weight node is known — otherwise there is no callback left to decide in, and the
         // expert matmul would run against slots nothing loaded. First graph of a run: load here.
@@ -678,10 +748,14 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         drop_.ids = t;
         drop_.deferred = defer;
         chain_last_.clear();
-        if (defer)
+        if (defer) {
             drop_ids_ = gathered_;
-        else
+        } else {
             source_->load_layer(il, gathered_.data(), (int) gathered_.size());
+            // Deferred layers speculate from apply_drop instead — after THEIR load, for the same
+            // reason this call sits after the one above: the load's quiesce would cancel it.
+            predict_after_load(il);
+        }
 
         // Score the predictors against the routing the router just produced — before the record
         // below moves on, or the previous-token predictor would be graded on the answer itself.

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -253,7 +253,6 @@ void RouterHook::predict_reset() {
     ps_self_.assign(n, PredictorStats{});
     agg_stale_ = agg_stale2_ = agg_prev_ = agg_self_ = PredictorStats{};
     predict_unscored_ = 0;
-    nu_hint_ = 0;
     wd_slots_ = wd_hits_ = wd_rout_ = 0;
     wd_tripped_ = false;
     std::lock_guard<std::mutex> lk(pred_mtx_);
@@ -905,11 +904,6 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         // experts, and a denominator that skipped them would report the drop rate as a fraction of
         // the wrong thing.
         if (drop_frac_ > 0.0f) experts_routed_ += (long long) gathered_.size();
-
-        // The routing width, learned from the node that defines it. The predictive prefetch needs
-        // it a layer before any topk of the predicted layer exists, and reading it here (not from
-        // config) keeps an --n-expert-used override honest without another plumbing path.
-        if (predict_on() && nu > 0) nu_hint_ = nu;
 
         // Watchdog sample + submit the il+2 prediction job. Before the load flow on purpose: the
         // snapshot must precede load_layer, whose staging would otherwise count this layer's own

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -234,6 +234,13 @@ private:
     int nu_hint_ = 0;
     std::vector<int32_t> spec_ids_; // scratch: the filtered prediction handed to prefetch()
     std::vector<float> spec_w_;     // scratch: softmax over the predicted top-k's raw scores
+    std::vector<uint8_t> pred_res_; // scratch: residency of the prediction being filtered
+
+    // How many predicted misses a layer may speculate. 2 covers the head-of-line stall (the only
+    // stall overlap leaves) at a quarter of the bytes of speculating a full top-8 routing; see
+    // predict_issue_prefetch for the measurement that set it. A candidate for a flag if the A/B
+    // says the mechanism earns one.
+    static constexpr int predict_spec_max = 2;
 
     bool predict_on() const { return predict_log_ || predict_prefetch_; }
     void predict_reset();

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -33,8 +33,11 @@
 #include "expert_stream_source.h"
 
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -46,6 +49,7 @@ namespace bmoe {
 class RouterHook {
 public:
     RouterHook(const MoeRecipe & recipe, int n_layer);
+    ~RouterHook(); // joins the prediction worker, if one was started
 
     // Install as ctx_params.cb_eval / cb_eval_user_data before context creation.
     static bool c_eval(ggml_tensor * t, bool ask, void * user_data);
@@ -133,6 +137,7 @@ public:
     // state is a dtype the probe does not read. It is reported rather than folded into the
     // denominator — a skipped routing is not a wrong guess.
     const PredictorStats & predict_stale() const { return agg_stale_; }
+    const PredictorStats & predict_stale2() const { return agg_stale2_; }
     const PredictorStats & predict_prev() const { return agg_prev_; }
     const PredictorStats & predict_self() const { return agg_self_; }
     const std::vector<PredictorStats> & predict_stale_by_layer() const { return ps_stale_; }
@@ -220,10 +225,11 @@ private:
     bool predict_log_ = false;
     bool predict_prefetch_ = false;
     std::vector<ggml_tensor *> gate_w_;
-    std::vector<std::vector<int32_t>> pred_stale_; // per layer, ranked at the PREVIOUS layer
-    std::vector<std::vector<int32_t>> pred_self_;  // per layer, ranked from its own logits
+    std::vector<std::vector<int32_t>> pred_stale_;  // per layer, ranked one layer early
+    std::vector<std::vector<int32_t>> pred_stale2_; // per layer, ranked TWO layers early (probe only)
+    std::vector<std::vector<int32_t>> pred_self_;   // per layer, ranked from its own logits
     std::vector<PredictorStats> ps_stale_, ps_prev_, ps_self_;
-    PredictorStats agg_stale_, agg_prev_, agg_self_;
+    PredictorStats agg_stale_, agg_stale2_, agg_prev_, agg_self_;
     long long predict_unscored_ = 0;
     std::vector<float> pred_scores_; // scratch: one score per expert
     std::vector<float> pred_row_;    // scratch: one activation row, as float
@@ -233,26 +239,91 @@ private:
     // during which the prefetch stays silent.
     int nu_hint_ = 0;
     std::vector<int32_t> spec_ids_; // scratch: the filtered prediction handed to prefetch()
-    std::vector<float> spec_w_;     // scratch: softmax over the predicted top-k's raw scores
     std::vector<uint8_t> pred_res_; // scratch: residency of the prediction being filtered
 
     // How many predicted misses a layer may speculate. 2 covers the head-of-line stall (the only
     // stall overlap leaves) at a quarter of the bytes of speculating a full top-8 routing; see
-    // predict_issue_prefetch for the measurement that set it. A candidate for a flag if the A/B
-    // says the mechanism earns one.
+    // build_spec_lists for the measurement that set it. A candidate for a flag if the A/B says
+    // the mechanism earns one.
     static constexpr int predict_spec_max = 2;
+
+    // ── the prefetch's own prediction path (no barrier, GEMV off the eval thread) ─────
+    //
+    // The probe pays for its reading with an isolated node per layer; the prefetch cannot afford
+    // that (the barrier alone measured ~20 ms/token) so it reads WITHOUT one: the gate matmul's
+    // source pointers are stashed in the ask pass — which sees every node isolated or not — and
+    // the gate-input row is copied at the topk callback, by which point the graph has certainly
+    // computed it. What is NOT certain is that ggml's memory planner has not reused the buffer in
+    // between; the watchdog below is what turns that risk into a measured quantity.
+    //
+    // The GEMV itself runs on a dedicated worker, and the horizon is TWO layers: h at layer l
+    // ranks layer l+2. One layer ahead cannot work off-thread — the only eval callbacks between a
+    // layer's gate and its own load are microseconds apart, so the result would always miss its
+    // deadline. At l+2 the worker has a whole layer (~ms) for a ~0.5M-MAC job, and the result is
+    // collected at layer l+1's load (predict_after_load), inheriting the same post-load issue
+    // window the temporal prefetch uses. The price is one more layer of staleness; the probe's
+    // stale-2 column is what says how much accuracy that costs on a given model. A result that is
+    // not ready in time is skipped, never waited for.
+    std::vector<ggml_tensor *> h_t_; // per layer, the gate matmul's input, stashed in the ask pass
+
+    struct PredictJob {
+        uint64_t seq = 0;
+        int nl = 0; // layer the prediction is FOR
+        int nu = 0;
+        float drop_frac = 0.0f;
+        const ggml_tensor * gate = nullptr; // layer nl's gate matrix, snapshotted with the job
+        std::vector<float> row;             // the gate-input row, copied on the eval thread
+        std::vector<uint8_t> resident;      // residency bitmap of layer nl, snapshotted on the eval thread
+    };
+    struct PredictResult {
+        uint64_t seq = 0;
+        int nl = -1;
+        std::vector<int32_t> spec; // predicted misses to speculate, confidence-ordered, capped
+        std::vector<int32_t> keep; // predicted residents to retain (LRU-protect)
+        bool ready = false;
+    };
+    std::thread pred_worker_;
+    std::mutex pred_mtx_;
+    std::condition_variable pred_cv_;
+    PredictJob pred_job_;
+    PredictResult pred_result_;
+    bool pred_job_pending_ = false;
+    bool pred_stop_ = false;
+    uint64_t pred_seq_ = 0;
+
+    // Watchdog for the barrier-less read. Every wd_interval routings the freshly-stashed row is
+    // run through the layer's OWN gate and checked against the ids the router actually chose —
+    // the same zero-staleness control the probe uses, sampled instead of continuous. If it drifts
+    // below the threshold the buffer is being reused (or the architecture does not select by
+    // raw-logit ranking) and the prefetch disarms itself, once, out loud. Without this, a planner
+    // change in a future llama.cpp bump would turn the predictor into a silent noise generator.
+    long long wd_slots_ = 0, wd_hits_ = 0, wd_rout_ = 0;
+    bool wd_tripped_ = false;
+    static constexpr int wd_interval = 512;         // routings between samples (~13 tokens at 40 layers)
+    static constexpr double wd_min_frac = 0.98;     // below this, the read is not trustworthy
+    static constexpr long long wd_min_slots = 2048; // do not judge before this many slots
 
     bool predict_on() const { return predict_log_ || predict_prefetch_; }
     void predict_reset();
+    void predict_worker_stop();
+    void predict_worker_main();
 
     // Rank the top `k` of `scores` into `out`, and score a prediction against a routing.
     static void rank_top_k(const std::vector<float> & scores, int k, std::vector<int32_t> & out);
     static void score_prediction(
         const std::vector<int32_t> & pred, const int32_t * actual, int k, PredictorStats & layer, PredictorStats & agg);
+    // From a full score vector: the top-nu ranking, softmax-filtered against the drop threshold,
+    // split into misses to speculate (capped) and residents to retain.
+    static void build_spec_lists(const std::vector<float> & scores,
+                                 int nu,
+                                 float drop_frac,
+                                 const std::vector<uint8_t> & resident,
+                                 std::vector<int32_t> & spec,
+                                 std::vector<int32_t> & keep);
     void predict_at_logits(ggml_tensor * logits, int il);
     void score_layer(int il, const int32_t * actual, int nu);
-    void predict_issue_prefetch(int nl); // filter pred_scores_/pred_stale_[nl] and speculate
-    void predict_after_load(int il);     // issue the il+1 prediction once il's load is behind us
+    void predict_at_topk(ggml_tensor * t, int il, int nu, int nt); // watchdog + job submission
+    void predict_after_load(int il);                               // collect + issue once il's load is behind us
 
     // The probe's maximum prediction width. A routing wider than this would be scored against a
     // truncated prediction and read as a miss it never was, so the probe declines it instead.

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -19,11 +19,17 @@
 // router weighted them, and whether they were already resident. It observes only — the ids
 // handed to load_layer are the same traced or not — but it costs a barrier per weight node,
 // so it stays off unless asked for. See bmoe/route_trace.h.
+//
+// And an optional fourth (set_predict_log): the expert-prediction probe, which asks for each
+// layer's gate matmul so it can rank the NEXT layer's experts before that layer runs, and reports
+// how often the ranking was right. It decides nothing — it exists to price a predictor before one
+// is wired into the loading path. See bmoe/predict_stats.h.
 #pragma once
 
 #include "bmoe/recipe.h"
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
+#include "bmoe/predict_stats.h"
 #include "expert_stream_source.h"
 
 #include <chrono>
@@ -66,6 +72,29 @@ public:
     // experts the previous token used at layers l+1..l+K. 0 (default) disables it.
     void set_prefetch_layers(int k) { prefetch_layers_ = k; }
 
+    // ── expert-prediction accuracy probe (diagnostics; see bmoe/predict_stats.h) ──────
+    // Measures, without changing a byte of what gets loaded, how well the next layer's routing can
+    // be guessed before that layer runs. Three predictors are scored against the routing the
+    // router actually produced:
+    //
+    //   stale-gate  layer l's gate INPUT run through layer l+1's gate matrix. The residual stream
+    //               moves little between layers, so the stale input ranks l+1's experts nearly as
+    //               the real one will — a full layer earlier. Costs one GEMV per layer; needs no
+    //               training and no model change.
+    //   prev-token  what the PREVIOUS token routed at this layer: the predictor --prefetch already
+    //               bets on, scored here so the two are comparable on the same run.
+    //   fresh-gate  the layer's own matrix on its own gate input: the stale predictor with the
+    //               staleness taken out, sharing its every line of code. A control, not a
+    //               predictor — it must reproduce the routing the graph computes from those same
+    //               two tensors, so anything it misses is this probe being wrong (a GEMV that
+    //               disagrees with llama.cpp's, or a selection the architecture does not make by
+    //               raw-logit ranking: an additive bias, group-limited routing). Read the other
+    //               two against it: a fresh-gate below 100% caps what the stale one could show.
+    //
+    // Decode only, last token of the batch. Off by default: it isolates one extra node per MoE
+    // layer and does a per-layer GEMV on the eval thread, so a probed run is not a benchmark run.
+    void set_predict_log(bool on);
+
     // ── route trace (diagnostics; see bmoe/route_trace.h) ────────────────────────────
     // When on, the hook additionally asks for each layer's router-weight node and records one
     // RouteTraceRow per routed expert. Rows buffer in RAM — the callback runs on a compute
@@ -88,6 +117,19 @@ public:
 
     long long experts_routed() const { return experts_routed_; }
     long long experts_dropped() const { return experts_dropped_; }
+
+    // Prediction accuracy, aggregate and per layer (index = layer). Empty/zero unless the probe
+    // was armed. `predict_unscored` counts routings the probe had to skip: the first token, whose
+    // layers have not yet seen the next layer's gate matrix, plus any layer whose gate or hidden
+    // state is a dtype the probe does not read. It is reported rather than folded into the
+    // denominator — a skipped routing is not a wrong guess.
+    const PredictorStats & predict_stale() const { return agg_stale_; }
+    const PredictorStats & predict_prev() const { return agg_prev_; }
+    const PredictorStats & predict_self() const { return agg_self_; }
+    const std::vector<PredictorStats> & predict_stale_by_layer() const { return ps_stale_; }
+    const std::vector<PredictorStats> & predict_prev_by_layer() const { return ps_prev_; }
+    const std::vector<PredictorStats> & predict_self_by_layer() const { return ps_self_; }
+    long long predict_unscored() const { return predict_unscored_; }
 
     // ── compute trace (diagnostics; see bmoe/decode_trace.h) ────────────────────────
     // When on, the hook asks for EVERY node, which makes ggml compute and synchronize each one
@@ -159,6 +201,33 @@ private:
     // during prefill). Empty when prefetch is off or a layer has not been seen yet.
     int prefetch_layers_ = 0;
     std::vector<std::vector<int32_t>> prev_ids_;
+
+    // Prediction probe. All of this is inert unless predict_log_.
+    //
+    // gate_w_ is learned from the graph rather than looked up by name: the gate matmul's first
+    // source IS the router matrix, whatever the architecture calls its tensor. It is a weight LEAF,
+    // so unlike a graph intermediate the pointer stays valid across graphs — which is what lets
+    // layer l predict for layer l+1 using a matrix layer l+1 has not reached yet this token.
+    bool predict_log_ = false;
+    std::vector<ggml_tensor *> gate_w_;
+    std::vector<std::vector<int32_t>> pred_stale_; // per layer, ranked at the PREVIOUS layer
+    std::vector<std::vector<int32_t>> pred_self_;  // per layer, ranked from its own logits
+    std::vector<PredictorStats> ps_stale_, ps_prev_, ps_self_;
+    PredictorStats agg_stale_, agg_prev_, agg_self_;
+    long long predict_unscored_ = 0;
+    std::vector<float> pred_scores_; // scratch: one score per expert
+    std::vector<float> pred_row_;    // scratch: one activation row, as float
+
+    // Rank the top `k` of `scores` into `out`, and score a prediction against a routing.
+    static void rank_top_k(const std::vector<float> & scores, int k, std::vector<int32_t> & out);
+    static void score_prediction(
+        const std::vector<int32_t> & pred, const int32_t * actual, int k, PredictorStats & layer, PredictorStats & agg);
+    void predict_at_logits(ggml_tensor * logits, int il);
+    void score_layer(int il, const int32_t * actual, int nu);
+
+    // The probe's maximum prediction width. A routing wider than this would be scored against a
+    // truncated prediction and read as a miss it never was, so the probe declines it instead.
+    static constexpr int predict_max_k = 32;
 
     // Cache-aware dropping. Inert unless drop_frac_ > 0.
     //

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -95,6 +95,15 @@ public:
     // layer and does a per-layer GEMV on the eval thread, so a probed run is not a benchmark run.
     void set_predict_log(bool on);
 
+    // ── predictive prefetch (see MoeStreamConfig::predict_prefetch) ───────────────────
+    // Act on the stale-gate prediction: hand the predicted next-layer experts to the source's
+    // speculative read path, exactly as the temporal prefetch does with the previous token's ids.
+    // Drop-aware by construction — with the drop policy armed, a predicted expert whose predicted
+    // routing weight sits below the drop threshold is not speculated: if it misses, the policy
+    // would discard it unread, so prefetching it buys nothing and costs the read. Independent of
+    // set_predict_log (the probe adds scoring and the control on top of the same prediction).
+    void set_predict_prefetch(bool on);
+
     // ── route trace (diagnostics; see bmoe/route_trace.h) ────────────────────────────
     // When on, the hook additionally asks for each layer's router-weight node and records one
     // RouteTraceRow per routed expert. Rows buffer in RAM — the callback runs on a compute
@@ -202,13 +211,14 @@ private:
     int prefetch_layers_ = 0;
     std::vector<std::vector<int32_t>> prev_ids_;
 
-    // Prediction probe. All of this is inert unless predict_log_.
+    // Prediction (probe and/or prefetch). All of this is inert unless one of the two is on.
     //
     // gate_w_ is learned from the graph rather than looked up by name: the gate matmul's first
     // source IS the router matrix, whatever the architecture calls its tensor. It is a weight LEAF,
     // so unlike a graph intermediate the pointer stays valid across graphs — which is what lets
     // layer l predict for layer l+1 using a matrix layer l+1 has not reached yet this token.
     bool predict_log_ = false;
+    bool predict_prefetch_ = false;
     std::vector<ggml_tensor *> gate_w_;
     std::vector<std::vector<int32_t>> pred_stale_; // per layer, ranked at the PREVIOUS layer
     std::vector<std::vector<int32_t>> pred_self_;  // per layer, ranked from its own logits
@@ -217,6 +227,16 @@ private:
     long long predict_unscored_ = 0;
     std::vector<float> pred_scores_; // scratch: one score per expert
     std::vector<float> pred_row_;    // scratch: one activation row, as float
+    // How wide a routing actually is, learned from the last topk node seen. The prefetch needs it
+    // BEFORE the predicted layer's topk exists, and reading it off the graph (rather than config)
+    // keeps an --n-expert-used override honest. 0 until the first routing of a run has been seen,
+    // during which the prefetch stays silent.
+    int nu_hint_ = 0;
+    std::vector<int32_t> spec_ids_; // scratch: the filtered prediction handed to prefetch()
+    std::vector<float> spec_w_;     // scratch: softmax over the predicted top-k's raw scores
+
+    bool predict_on() const { return predict_log_ || predict_prefetch_; }
+    void predict_reset();
 
     // Rank the top `k` of `scores` into `out`, and score a prediction against a routing.
     static void rank_top_k(const std::vector<float> & scores, int k, std::vector<int32_t> & out);
@@ -224,6 +244,8 @@ private:
         const std::vector<int32_t> & pred, const int32_t * actual, int k, PredictorStats & layer, PredictorStats & agg);
     void predict_at_logits(ggml_tensor * logits, int il);
     void score_layer(int il, const int32_t * actual, int nu);
+    void predict_issue_prefetch(int nl); // filter pred_scores_/pred_stale_[nl] and speculate
+    void predict_after_load(int il);     // issue the il+1 prediction once il's load is behind us
 
     // The probe's maximum prediction width. A routing wider than this would be scored against a
     // truncated prediction and read as a miss it never was, so the probe declines it instead.

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -106,7 +106,9 @@ public:
     // routing weight sits below the drop threshold is not speculated: if it misses, the policy
     // would discard it unread, so prefetching it buys nothing and costs the read. Independent of
     // set_predict_log (the probe adds scoring and the control on top of the same prediction).
-    void set_predict_prefetch(bool on);
+    // spec_max: how many predicted misses a layer may speculate (0 = retention only). Retention of
+    // predicted residents happens at every value — it costs zero bytes.
+    void set_predict_prefetch(bool on, int spec_max = 2);
 
     // ── route trace (diagnostics; see bmoe/route_trace.h) ────────────────────────────
     // When on, the hook additionally asks for each layer's router-weight node and records one
@@ -240,12 +242,7 @@ private:
     int nu_hint_ = 0;
     std::vector<int32_t> spec_ids_; // scratch: the filtered prediction handed to prefetch()
     std::vector<uint8_t> pred_res_; // scratch: residency of the prediction being filtered
-
-    // How many predicted misses a layer may speculate. 2 covers the head-of-line stall (the only
-    // stall overlap leaves) at a quarter of the bytes of speculating a full top-8 routing; see
-    // build_spec_lists for the measurement that set it. A candidate for a flag if the A/B says
-    // the mechanism earns one.
-    static constexpr int predict_spec_max = 2;
+    int pred_spec_max_ = 2;         // speculated predicted misses per layer (0 = retention only)
 
     // ── the prefetch's own prediction path (no barrier, GEMV off the eval thread) ─────
     //
@@ -271,6 +268,7 @@ private:
         int nl = 0; // layer the prediction is FOR
         int nu = 0;
         float drop_frac = 0.0f;
+        int spec_max = 2;
         const ggml_tensor * gate = nullptr; // layer nl's gate matrix, snapshotted with the job
         std::vector<float> row;             // the gate-input row, copied on the eval thread
         std::vector<uint8_t> resident;      // residency bitmap of layer nl, snapshotted on the eval thread
@@ -317,6 +315,7 @@ private:
     static void build_spec_lists(const std::vector<float> & scores,
                                  int nu,
                                  float drop_frac,
+                                 int spec_max,
                                  const std::vector<uint8_t> & resident,
                                  std::vector<int32_t> & spec,
                                  std::vector<int32_t> & keep);

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -235,14 +235,9 @@ private:
     long long predict_unscored_ = 0;
     std::vector<float> pred_scores_; // scratch: one score per expert
     std::vector<float> pred_row_;    // scratch: one activation row, as float
-    // How wide a routing actually is, learned from the last topk node seen. The prefetch needs it
-    // BEFORE the predicted layer's topk exists, and reading it off the graph (rather than config)
-    // keeps an --n-expert-used override honest. 0 until the first routing of a run has been seen,
-    // during which the prefetch stays silent.
-    int nu_hint_ = 0;
-    std::vector<int32_t> spec_ids_; // scratch: the filtered prediction handed to prefetch()
-    std::vector<uint8_t> pred_res_; // scratch: residency of the prediction being filtered
-    int pred_spec_max_ = 2;         // speculated predicted misses per layer (0 = retention only)
+    std::vector<int32_t> spec_ids_;  // scratch: the filtered prediction handed to prefetch()
+    std::vector<uint8_t> pred_res_;  // scratch: residency of the prediction being filtered
+    int pred_spec_max_ = 2;          // speculated predicted misses per layer (0 = retention only)
 
     // ── the prefetch's own prediction path (no barrier, GEMV off the eval thread) ─────
     //

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ for the idea the project is built on.
 | [cache-sizing.md](cache-sizing.md) | `--cache-mb auto`, the cache ceiling, and dense warm-up. |
 | [prefetch.md](prefetch.md) | `--prefetch K`: the design and why it cannot change output (with the lossy knobs off). |
 | [expert-dropping.md](expert-dropping.md) | `--drop-cold-experts F`: spending quality only where it buys a flash read, and why it is the one setting whose output is not reproducible. |
+| [expert-prediction.md](expert-prediction.md) | `--predict-log`: how much of a routing can be known a layer early, measured against the predictor `--prefetch` already bets on — and why a good score still would not mean a faster decode. |
 | [android-memory.md](android-memory.md) | What reclaims the engine's memory on a phone, which levers exist (almost none), and why the cache hit rate is what the kernel judges you by. |
 | [pressure.md](pressure.md) | Cache policy under memory pressure: why an unaffordable budget starts a reclaim war, why the adaptive governor was retired, and what the fixed `--cache-mb` / `--dense-weights` levers do. |
 

--- a/docs/expert-prediction.md
+++ b/docs/expert-prediction.md
@@ -1,5 +1,34 @@
 # Expert prediction: measuring it before building it
 
+> **Measured, 2026-07-23 — accuracy confirmed, throughput verdict OPEN, and a thermal lesson that
+> invalidated half a day of comparisons.** On device, the stale-gate predictor scores **88.6%** of
+> routed slots on Qwen3-30B (48 layers, top-8 of 128) and **80.7%** on Qwen3.6-35B (top-8 of 256),
+> with the zero-staleness control at exactly **100.0%** on every layer of both — Qwen selects by
+> pure logit ranking, so these numbers need no discount. The previous-token predictor scored 43.3% /
+> 35.4% on the same runs, corroborating the offline route-trace estimates.
+>
+> Acting on the prediction (`--predict-prefetch`) was then measured across the whole cost spectrum
+> against a drop-0.75 + pinned-dense baseline ("B", 6.54 tok/s cool): full-routing speculation
+> **4.02** (−38%: +33% flash bytes, major faults ×3), top-2-miss cap **4.46**, the rebuilt
+> implementation (native-F16 GEMV ~40× faster, no barrier + self-validating watchdog, worker at an
+> L+2 horizon, retention of predicted residents) **5.30**, retention-only (zero extra bytes)
+> **5.44**. Every variant improved its intermediate metrics — hit rate up, stall down to 9-22 ms,
+> 77-86% of speculations useful — while the wall clock stayed behind.
+>
+> **But those deltas are contaminated:** re-running B itself at the end of the day, on a device
+> that had heated through the whole campaign (mid cores silently capped ~8%), gave **3.93 tok/s
+> with byte-for-byte identical I/O, hit rate and drop counts** — the engine is deterministic; the
+> −40% was throttling. Each C variant ran on a progressively hotter device against the cool-morning
+> 6.54, so the pairwise conclusions do not stand. The one thermally matched pair of the day —
+> B-hot 3.93 vs prefetch on EIGHT io lanes 2.83 (−28%, effective flash bandwidth collapsing from
+> 585 to 392 MiB/s) — kills the more-lanes hypothesis specifically, consistent with the measured
+> lane ceiling, but the spec-max 2 and retention-only configurations still owe a matched cool-pair
+> A/B before any verdict. Two structural facts did survive the day: the observer tax was 109
+> ms/token before the rebuild (~35-45 ms per GEMV pass from a per-element exported-function
+> conversion — 21M calls/token — plus ~20 ms of barrier), and retention moved the hit rate by 0.1pp
+> on a 3000 MiB cache, confirming offline replay: at that size, eviction order within a two-layer
+> horizon is irrelevant.
+
 `--predict-log` answers one question and refuses to answer any other: **how much of a layer's
 routing could be known before that layer runs?** It predicts, scores itself against what the router
 actually chose, and prints the result. Nothing it computes reaches the loading path — a probed run

--- a/docs/expert-prediction.md
+++ b/docs/expert-prediction.md
@@ -111,6 +111,11 @@ Two design points matter more than the swap itself:
   is not speculated: if it misses, the policy would drop it unread — prefetching it would spend the
   exact I/O the policy exists to save. The top prediction is always kept, mirroring the policy's own
   pin of the top-weighted expert.
+- **It speculates at most the top 2 predicted misses per layer, not the routing.** The stall a
+  prefetch can remove is head-of-line — the wait on the first missing expert's slices — and overlap
+  already hides the tail behind the expert matmul. Speculating a full top-8 was measured to read 33%
+  more flash per token and to fight a full cache hard enough to triple major faults, costing several
+  times the stall it removed. Predicted experts already resident do not burn a slot of the cap.
 
 Byte-identity is the same contract as the temporal prefetch (gate `G10`): speculation only warms the
 cache, so output is unchanged — except under `--drop-cold-experts`, where residency is an input to

--- a/docs/expert-prediction.md
+++ b/docs/expert-prediction.md
@@ -1,0 +1,108 @@
+# Expert prediction: measuring it before building it
+
+`--predict-log` answers one question and refuses to answer any other: **how much of a layer's
+routing could be known before that layer runs?** It predicts, scores itself against what the router
+actually chose, and prints the result. Nothing it computes reaches the loading path — a probed run
+reads exactly the bytes an unprobed one does, only slower.
+
+It exists because [temporal prefetch](prefetch.md) was built on a predictor nobody had priced. That
+predictor — "the previous token routed these, the next one probably will too" — turned out to be
+right about 38% of the time on Qwen and 18% on gpt-oss, which is not enough to pay for the reads it
+speculates. The lesson was not that prefetch is impossible; it was that a predictor should be
+measured before it is wired into anything.
+
+## The three predictors
+
+All three are scored on the same routings, on the same run, so they are directly comparable.
+
+**stale-gate** is the one under test. Each layer's router is a matrix multiplied by that layer's
+gate input; the input comes from the residual stream, which every layer only nudges. So while layer
+*l* is computing, we take the input *it* is about to consume and multiply it by **layer *l+1*'s**
+router matrix. The ranking that comes out is a guess at what layer *l+1* will select, available a
+full layer early. It needs no training and no change to the model — the matrix is already resident
+(it is a dense weight, not a streamed expert) and the multiply is one GEMV.
+
+This is the mechanism [FATE](https://arxiv.org/html/2502.12224v1) uses, where it scored 78.8% on
+DeepSeek-V2-Lite.
+
+**prev-token** is the incumbent: what this layer routed for the *previous* token — exactly the bet
+`--prefetch` places. Reported here so the new predictor is judged against the one already shipped,
+not against zero.
+
+**ctrl** is not a predictor. It is the stale-gate with the staleness removed: the same row read,
+the same GEMV, the same ranking, but using layer *l*'s **own** matrix on layer *l*'s own input. It
+therefore has to reproduce the selection llama.cpp is about to compute from those very tensors, and
+**it should read 100%**. Anything less is this probe being wrong, not routing being hard:
+
+- a GEMV that disagrees with ggml's (a transposed matrix, a mis-strided row, the wrong token of the
+  batch) collapses it toward chance;
+- an architecture that does not select by raw-logit ranking — one that adds a per-expert selection
+  bias, or masks whole expert groups before the argsort — puts it somewhere below 100%, and by
+  roughly that much the stale-gate number understates the method.
+
+Read the other two against `ctrl`, never against 100%. The CLI says so out loud when it drops.
+
+## Reading the report
+
+```
+moe-predict: stale-gate <pct>% of routed slots (<pct>% whole routings) | prev-token <pct>% (<pct>%) | fresh-gate control <pct>% (<pct>%)
+moe-predict: scored — stale-gate <rows> routings/<slots> slots, prev-token <rows>/<slots>, control <rows>/<slots>; <n> routings the stale-gate could not rank
+  layer   stale    prev   ctrl   routings
+```
+
+The headline figure is **slot overlap**: of the *k* experts a routing selected, how many the
+predictor had named. That is the number a prefetch cares about — each hit is one read turned into a
+hit. The parenthesised figure is **whole routings** predicted exactly, i.e. the fraction of layers
+that would have needed no on-demand read at all. They are far apart, and papers differ on which one
+they quote, so both are printed. FATE's 78.8% is the first kind; the
+[ETH pre-attention work](https://arxiv.org/abs/2511.10676)'s 93–97% is the second.
+
+**The per-layer table is the substantive half.** An aggregate flatters a prefetch, because what a
+prefetch costs is set by the layers it gets *wrong*, and those are not evenly spread: a MoE model's
+first layers route far less predictably than its last, their routing scores sitting close enough
+together that a slightly stale input reorders them. Both published results above report the same
+shape.
+
+A predictor with no routings at a layer prints `-`, never `0.0`.
+
+## What it structurally cannot do
+
+- **Layer 0 is out of reach.** There is no previous layer to borrow an input from, so the stale gate
+  never predicts it — the table shows `-`. This is the method's limit, not a bad score. It is also
+  precisely the gap the ETH work exists to close, by training a small per-layer predictor that reads
+  the layer's own pre-attention state instead. That needs training data and a shipped artifact per
+  model, which is a different project from this one.
+- **The first token of a run is unscored**, because a layer only learns the next layer's matrix once
+  the graph has reached it. Both cases are counted and reported, never folded into the denominator:
+  a routing that was not ranked is not a wrong guess.
+- **Decode only.** During prefill every token's routing is known at once and there is nothing to
+  predict; it is also not the phase a prefetch would be built for.
+- **Routings wider than 32 experts are declined** rather than scored against a truncated ranking.
+
+## Cost, and why it is not a benchmark run
+
+The probe isolates one extra graph node per MoE layer (a barrier, as `--route-trace` costs) and runs
+two GEMVs per layer on the eval thread — the prediction and its control. On a 48-layer model with
+128 experts that is a few tens of millions of scalar multiply-accumulates per token, single
+threaded. Correctness is unaffected and the byte-identity gates cover it (`G9a`), but **do not read
+tok/s off a probed run.**
+
+Requires streaming (`--moe-stream`): the probe attaches to the routing nodes the streamer already
+isolates, and routing does not depend on how the weights reached memory, so a dense run would only
+reproduce the same numbers more slowly.
+
+## The honest caveat about what a good number would mean
+
+A high stale-gate accuracy would say the routing is *knowable* earlier. It would not say that
+knowing it earlier makes decode faster. Those are different claims, and on this engine the second
+one is the doubtful one: when the flash is already saturated — which
+[the decode attribution](benchmarks.md) shows it is on Qwen at top-k 8 — starting a read sooner adds
+no bandwidth, and speculating extra reads spends the bandwidth that was the binding constraint. That
+is why [temporal prefetch](prefetch.md), [layer-LFU caching](benchmarks.md) and the expert sidecar
+all lost despite improving the metric each was designed around.
+
+The use that does *not* spend bandwidth is eviction: knowing what the next layer will ask for is a
+reason not to discard it. That is a cache-policy change, not a prefetch, and offline replay bounds
+the whole class of online cache policies at roughly 5 percentage points over LRU. So even a
+predictor that scores well should be expected to buy little — which is exactly why it gets measured
+here first, at the cost of one flag, rather than built.

--- a/docs/expert-prediction.md
+++ b/docs/expert-prediction.md
@@ -1,7 +1,7 @@
 # Expert prediction: measuring it before building it
 
-> **Measured, 2026-07-23 — accuracy confirmed, throughput verdict OPEN, and a thermal lesson that
-> invalidated half a day of comparisons.** On device, the stale-gate predictor scores **88.6%** of
+> **Measured, 2026-07-23/24 — accuracy confirmed, read-ahead refuted in a matched pair, retention
+> neutral on hit rate, and a thermal lesson that invalidated half a day of comparisons.** On device, the stale-gate predictor scores **88.6%** of
 > routed slots on Qwen3-30B (48 layers, top-8 of 128) and **80.7%** on Qwen3.6-35B (top-8 of 256),
 > with the zero-staleness control at exactly **100.0%** on every layer of both — Qwen selects by
 > pure logit ranking, so these numbers need no discount. The previous-token predictor scored 43.3% /
@@ -28,6 +28,20 @@
 > conversion — 21M calls/token — plus ~20 ms of barrier), and retention moved the hit rate by 0.1pp
 > on a 3000 MiB cache, confirming offline replay: at that size, eviction order within a two-layer
 > horizon is irrelevant.
+>
+> **The 2026-07-24 redo settled most of what stayed open.** A four-cell session (B, retention-only,
+> spec-2, then B again as a drift sentinel) run with fixed 30 s spacing first re-proved the
+> contamination mechanism on purpose — the closing B lost 17% against the opening B (4.77 → 3.96
+> tok/s) with the CPU clusters silently capped from the second cell on — and then yielded the one
+> pair the spacing left genuinely matched: **spec-2 vs the B sentinel, adjacent cells at the same
+> caps and the same battery temperature, 3.14 vs 3.96 tok/s (−21%)**, with hit rate *up* 4.3pp,
+> 79% of speculations useful, and +37% flash bytes per token. Speculation improves every metric it
+> owns and still loses the wall clock; the top-2 read-ahead is refuted in the shipping
+> configuration, by the same mechanism that killed more-lanes — the flash has no spare bandwidth to
+> spend. Retention-only again moved the hit rate by nothing (77.2% vs 77.6%), as the offline replay
+> bound predicted; its own wall-clock cell started inside the deepest throttle window and is not
+> readable, but with zero hit-rate movement there is no mechanism left for it to win by — only the
+> residual gate-GEMV cost to lose by.
 
 `--predict-log` answers one question and refuses to answer any other: **how much of a layer's
 routing could be known before that layer runs?** It predicts, scores itself against what the router

--- a/docs/expert-prediction.md
+++ b/docs/expert-prediction.md
@@ -91,6 +91,35 @@ Requires streaming (`--moe-stream`): the probe attaches to the routing nodes the
 isolates, and routing does not depend on how the weights reached memory, so a dense run would only
 reproduce the same numbers more slowly.
 
+## Acting on it: `--predict-prefetch`
+
+`--predict-log` measures; `--predict-prefetch` bets. It hands the stale-gate prediction for layer
+*l+1* to the same speculative read path [`--prefetch`](prefetch.md) uses — same cache buffers, same
+accounting, same `moe-prefetch:` summary line (tagged `[stale-gate]`) — replacing the previous-token
+predictor with one measured roughly twice as accurate on the same run. Mutually exclusive with
+`--prefetch`, and it needs the LRU cache for the same reason.
+
+Two design points matter more than the swap itself:
+
+- **The speculation is issued after the current layer's load, not when the prediction is made.**
+  Every load path begins by quiescing speculation, and the layer's own load sits a few graph nodes
+  after its gate — reads queued at prediction time would be cancelled before a lane picked them up.
+  Issuing after the load gives a queued read the layer's whole expert-matmul window, the same window
+  the temporal prefetch gets.
+- **It is drop-aware.** With [`--drop-cold-experts`](expert-dropping.md) armed, a predicted expert
+  whose predicted routing weight (softmax over the predicted top-k) falls below the drop threshold
+  is not speculated: if it misses, the policy would drop it unread — prefetching it would spend the
+  exact I/O the policy exists to save. The top prediction is always kept, mirroring the policy's own
+  pin of the top-weighted expert.
+
+Byte-identity is the same contract as the temporal prefetch (gate `G10`): speculation only warms the
+cache, so output is unchanged — except under `--drop-cold-experts`, where residency is an input to
+the routing policy and a correct guess un-drops an expert. That interplay is deliberate: prediction
+spent there buys back quality at the same threshold, not speed.
+
+Cost: one gate GEMV per MoE layer per decoded token on the eval thread (the control GEMV is
+probe-only and skipped here), plus one isolated node per layer.
+
 ## The honest caveat about what a good number would mean
 
 A high stale-gate accuracy would say the routing is *knowable* earlier. It would not say that

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -17,6 +17,10 @@ often and stall on flash (see [benchmarks.md](benchmarks.md)). Temporal prefetch
 > See [bench-data/2026-07-20-cache-replay/iobench-ceiling.md](bench-data/2026-07-20-cache-replay/iobench-ceiling.md)
 > and [bench-data/2026-07-15-route-trace/findings.md](bench-data/2026-07-15-route-trace/findings.md).
 
+> The predictor below can now be measured online, against a stronger one, on any model:
+> [`--predict-log`](expert-prediction.md) scores the previous-token bet alongside running the next
+> layer's router a layer early, and reports both per layer.
+
 ## The bet
 
 MoE routing has strong temporal locality: the experts a token selects at layer *l* overlap

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -19,7 +19,9 @@ often and stall on flash (see [benchmarks.md](benchmarks.md)). Temporal prefetch
 
 > The predictor below can now be measured online, against a stronger one, on any model:
 > [`--predict-log`](expert-prediction.md) scores the previous-token bet alongside running the next
-> layer's router a layer early, and reports both per layer.
+> layer's router a layer early, and reports both per layer. The stronger predictor can also be
+> acted on: [`--predict-prefetch`](expert-prediction.md) feeds it to this same speculative read
+> path (mutually exclusive with `--prefetch`).
 
 ## The bet
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -145,3 +145,19 @@ Routing prediction and speculative expert gating were built and **removed**: the
 trade never paid on-device, and the predictor coupled the streamer to model internals, which cost
 more in modularity than it returned in throughput. The archived measurements are in
 [bench-data/2026-07-12-pr23/](bench-data/2026-07-12-pr23/).
+
+**Reading a routing early is now measured, and it does not buy throughput either.** The question
+was reopened with a predictor that costs no training and no model coupling — run the *next* layer's
+router matrix on the *current* layer's gate input, which `--predict-log` scores against the
+previous-token bet and against a zero-staleness control ([expert-prediction.md](expert-prediction.md)).
+The accuracy is real: **88.6%** of routed slots on Qwen3-30B and **80.7%** on Qwen3.6-35B, against
+43.3% / 35.4% for the incumbent, with the control at exactly 100% on every layer. Acting on it is
+what fails. In thermally matched pairs, reading ahead on that prediction **lost 21%** in the
+shipping drop + pinned-dense configuration with its hit rate *up* 4.3 points and 79% of speculations
+useful — the same mechanism that killed more lanes, coalescing and the sidecar: on a saturated
+flash, a better guess still spends bandwidth that was the binding constraint. The half that spends
+nothing — retaining predicted residents against eviction — moved the hit rate by 0.4 points at a
+3000 MiB cache, inside the ~5-point ceiling the offline replay already put on the whole class.
+`--predict-prefetch` ships off by default, and the app defaults its budget to retention-only. What
+would change the answer is a device where flash is *not* the constraint, or a predictor that reaches
+layer 0 — which needs a trained per-layer artifact, a different project from this one.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -103,7 +103,10 @@ moe-prefetch: <mib> MiB speculative, <useful>/<prefetched> experts useful (<pct>
 
 `<mib>` is the flash read done speculatively this generation (a subset of the total read),
 `<prefetched>` the experts fully read ahead, and `<useful>` how many of those a later routing
-actually hit. See [prefetch.md](prefetch.md).
+actually hit. See [prefetch.md](prefetch.md). With `--predict-prefetch` the same line is emitted
+with a `[stale-gate]` tag — same counters, different predictor (see
+[expert-prediction.md](expert-prediction.md)). The CSV preamble records which was active
+(`prefetch=` / `predict_prefetch=`).
 
 With `--drop-cold-experts F` a `moe-drop:` line is added:
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -115,6 +115,23 @@ The flag fixes a *threshold*, not a rate: how much is actually discarded depends
 held, so this line — not the flag — is what a run traded. See
 [expert-dropping.md](expert-dropping.md).
 
+With `--predict-log` two `moe-predict:` lines and a per-layer table are added:
+
+```
+moe-predict: stale-gate <pct>% of routed slots (<pct>% whole routings) | prev-token <pct>% (<pct>%) | fresh-gate control <pct>% (<pct>%)
+moe-predict: scored — stale-gate <rows> routings/<slots> slots, prev-token <rows>/<slots>, control <rows>/<slots>; <n> routings the stale-gate could not rank
+  layer   stale    prev   ctrl   routings
+```
+
+Three predictors scored against the routing the router actually produced, so they are comparable on
+one run: `stale` runs the next layer's router a layer early, `prev` is the previous-token bet
+`--prefetch` makes, and `ctrl` is the same arithmetic with no staleness — a control that should read
+100%, not a predictor. Read the first two against `ctrl`. Denominators differ per predictor and are
+printed separately, because the stale gate structurally cannot rank layer 0 or the first token; a
+predictor with no routings at a layer prints `-`, never `0.0`. The probe changes nothing that is
+read, but it costs a barrier and two GEMVs per layer, so a probed run is not a benchmark run. See
+[expert-prediction.md](expert-prediction.md).
+
 Under `--overlap` the `moe-stream:` line additionally reports `stall_s/tok=<s>` — the mean
 wall time per token that compute threads waited for expert reads to complete. It is `0` in
 serial mode (where the read wait is already folded into decode time).

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -94,3 +94,10 @@ expert cache at 4000 MiB, 4 I/O lanes and 4 compute threads, decode settles arou
 sweep point from the benchmark protocol, not the app default: the app ships a fixed 2000 MiB
 expert cache. See `../../docs/benchmark-method.md` for the full procedure and the cache/thread
 sweep.
+
+The Streaming section also exposes the **predictive prefetch** (experimental, off by default):
+the engine predicts each layer's experts one layer early and reads ahead / retains what the
+prediction names (`--predict-prefetch`, with "predicted misses to read ahead" mapping to
+`--predict-spec-max`; 0 = retention only). It needs the cache on and replaces the temporal
+prefetch — the two are mutually exclusive. Its throughput is **not yet proven** on device; see
+`../../docs/expert-prediction.md` for the measured state before drawing conclusions from a run.

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -98,6 +98,9 @@ sweep.
 The Streaming section also exposes the **predictive prefetch** (experimental, off by default):
 the engine predicts each layer's experts one layer early and reads ahead / retains what the
 prediction names (`--predict-prefetch`, with "predicted misses to read ahead" mapping to
-`--predict-spec-max`; 0 = retention only). It needs the cache on and replaces the temporal
-prefetch — the two are mutually exclusive. Its throughput is **not yet proven** on device; see
-`../../docs/expert-prediction.md` for the measured state before drawing conclusions from a run.
+`--predict-spec-max`; 0 = retention only, the app default). It needs the cache on and replaces
+the temporal prefetch — the two are mutually exclusive, and they differ only in the predictor:
+temporal bets each layer repeats the previous token's experts (~40% right), predictive asks the
+next layer's own router one layer early (~85% right). A better guess did not buy throughput:
+in thermally matched pairs the read-ahead **lost** (−21% at spec-max 2), because the flash is
+already saturated — see `../../docs/expert-prediction.md` before drawing conclusions from a run.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -40,8 +40,9 @@ data class AppSettings(
     // sessionArgv only emits it when prefetchLayers == 0.
     val predictPrefetch: Boolean = false,
     // How many predicted MISSES per layer it may read ahead (0 = retention only: the prediction
-    // spends no flash and only protects predicted residents from eviction).
-    val predictSpecMax: Int = 2,
+    // spends no flash and only protects predicted residents from eviction). Defaults to 0 because
+    // the matched-pair A/B showed read-ahead losing on a saturated flash (docs/expert-prediction.md).
+    val predictSpecMax: Int = 0,
     // Cache-aware expert dropping, as a PERCENTAGE of the uniform share 1/top-k (0 = off, 100 = the
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
@@ -205,8 +206,9 @@ data class AppSettings(
         // 0 = model default (top-k as trained). 6/4/3/2 trade output quality for tok/s (fewer routed experts).
         val N_EXPERT_CHOICES = intArrayOf(0, 6, 4, 3, 2)
         val PREFETCH_CHOICES = intArrayOf(0, 1, 2, 4)
-        // Speculated predicted misses per layer. 0 = retention only (zero flash spent); 2 is the
-        // engine default; anything above it re-buys the measured full-speculation pathology.
+        // Speculated predicted misses per layer. 0 = retention only (zero flash spent) and the app
+        // default — the matched-pair A/B showed 2 losing −21% on a saturated flash; anything above
+        // it re-buys the measured full-speculation pathology.
         val PREDICT_SPEC_CHOICES = intArrayOf(0, 1, 2, 4)
         // Percent of the uniform share 1/top-k. 100 is the share itself and the useful maximum:
         // above it the threshold could exceed every weight in a routing. The rungs below it are the

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -34,6 +34,14 @@ data class AppSettings(
     val overlap: Boolean = true,        // read the next experts while the current layer computes
     val denseWeights: DenseWeights = DenseWeights.ANON, // dense (non-expert) weight residency policy
     val prefetchLayers: Int = 0,        // temporal prefetch depth K (0 = off); needs the cache
+    // Predictive prefetch (experimental): run the NEXT layer's router on the current layer's
+    // input and speculate/retain on that prediction instead of the previous token's routing.
+    // Needs the cache; the engine rejects it combined with the temporal prefetch above, so
+    // sessionArgv only emits it when prefetchLayers == 0.
+    val predictPrefetch: Boolean = false,
+    // How many predicted MISSES per layer it may read ahead (0 = retention only: the prediction
+    // spends no flash and only protects predicted residents from eviction).
+    val predictSpecMax: Int = 2,
     // Cache-aware expert dropping, as a PERCENTAGE of the uniform share 1/top-k (0 = off, 100 = the
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
@@ -93,6 +101,13 @@ data class AppSettings(
             // Auto sizing is a live LRU cache, so it satisfies the prefetch cache requirement.
             val cacheOn = cacheMb == CACHE_AUTO || cacheMb > 0
             if (prefetchLayers > 0 && cacheOn) a += listOf("--prefetch", prefetchLayers.toString())
+            // Predictive prefetch shares the cache requirement and excludes the temporal one —
+            // two predictors would double-speculate the same future, and the engine refuses the
+            // pair. Temporal wins when both are somehow set; the UI keeps them exclusive anyway.
+            if (predictPrefetch && cacheOn && prefetchLayers == 0) {
+                a += "--predict-prefetch"
+                a += listOf("--predict-spec-max", predictSpecMax.toString())
+            }
             // Cache-aware dropping needs a live cache to ask about residency — with the cache off
             // every expert reads as a miss and the engine rejects the combination outright, so the
             // same cacheOn condition that guards prefetch guards this. The engine takes a fraction
@@ -110,7 +125,7 @@ data class AppSettings(
      */
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, oDirect,
-               overlap, denseWeights, prefetchLayers, dropColdPct)
+               overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -123,6 +138,8 @@ data class AppSettings(
             .putBoolean("overlap", overlap)
             .putString("denseWeights", denseWeights.name)
             .putInt("prefetchLayers", prefetchLayers)
+            .putBoolean("predictPrefetch", predictPrefetch)
+            .putInt("predictSpecMax", predictSpecMax)
             .putInt("dropColdPct", dropColdPct)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
@@ -188,6 +205,9 @@ data class AppSettings(
         // 0 = model default (top-k as trained). 6/4/3/2 trade output quality for tok/s (fewer routed experts).
         val N_EXPERT_CHOICES = intArrayOf(0, 6, 4, 3, 2)
         val PREFETCH_CHOICES = intArrayOf(0, 1, 2, 4)
+        // Speculated predicted misses per layer. 0 = retention only (zero flash spent); 2 is the
+        // engine default; anything above it re-buys the measured full-speculation pathology.
+        val PREDICT_SPEC_CHOICES = intArrayOf(0, 1, 2, 4)
         // Percent of the uniform share 1/top-k. 100 is the share itself and the useful maximum:
         // above it the threshold could exceed every weight in a routing. The rungs below it are the
         // conservative half of the curve, where the replay already beats a top-k cut on both axes.
@@ -220,6 +240,8 @@ data class AppSettings(
                     }
                 },
                 prefetchLayers = p.getInt("prefetchLayers", d.prefetchLayers),
+                predictPrefetch = p.getBoolean("predictPrefetch", d.predictPrefetch),
+                predictSpecMax = p.getInt("predictSpecMax", d.predictSpecMax),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -119,12 +119,40 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 IntSetting(
                     "Temporal prefetch (layers)", AppSettings.PREFETCH_CHOICES, current.prefetchLayers,
                     format = { if (it == 0) "off" else "$it" },
-                    enabled = stream && cacheOn,
+                    // Mutually exclusive with predictive prefetch: two predictors would speculate
+                    // the same future twice, and the engine refuses the pair.
+                    enabled = stream && cacheOn && !current.predictPrefetch,
                 ) { onChange(current.copy(prefetchLayers = it)) }
                 Text(
                     "Experimental. Prefetch the next K layers' likely experts on idle read lanes. Needs the cache on.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                SwitchRow(
+                    "Predictive prefetch (experimental)",
+                    "Predict each layer's experts one layer early by running the next router on the " +
+                        "current activations, then read ahead and keep what the prediction names. " +
+                        "Needs the cache; replaces temporal prefetch.",
+                    current.predictPrefetch, enabled = stream && cacheOn && current.prefetchLayers == 0,
+                ) { onChange(current.copy(predictPrefetch = it)) }
+                if (current.predictPrefetch) {
+                    IntSetting(
+                        "Predicted misses to read ahead", AppSettings.PREDICT_SPEC_CHOICES, current.predictSpecMax,
+                        format = {
+                            when (it) {
+                                0 -> "0 — retention only"
+                                2 -> "2 — default"
+                                else -> "$it"
+                            }
+                        },
+                        enabled = stream && cacheOn,
+                    ) { onChange(current.copy(predictSpecMax = it)) }
+                    Text(
+                        "How much flash the prediction may spend per layer. 0 reads nothing ahead and only " +
+                            "protects predicted experts already in RAM from eviction. Under measurement — " +
+                            "throughput not yet proven; the per-run summary lines are the evidence.",
+                        fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
             Section("Speed / quality") {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -124,14 +124,15 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     enabled = stream && cacheOn && !current.predictPrefetch,
                 ) { onChange(current.copy(prefetchLayers = it)) }
                 Text(
-                    "Experimental. Prefetch the next K layers' likely experts on idle read lanes. Needs the cache on.",
+                    "Experimental. Bets each layer will reuse the experts it picked for the previous " +
+                        "token and reads them ahead on idle lanes — right ~40% of the time. Needs the cache on.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 SwitchRow(
                     "Predictive prefetch (experimental)",
-                    "Predict each layer's experts one layer early by running the next router on the " +
-                        "current activations, then read ahead and keep what the prediction names. " +
-                        "Needs the cache; replaces temporal prefetch.",
+                    "Instead of betting on the previous token, asks the next layer's own router one " +
+                        "layer early — right ~85% of the time. Reads ahead within the budget below and " +
+                        "keeps what the prediction names. Needs the cache; replaces temporal prefetch.",
                     current.predictPrefetch, enabled = stream && cacheOn && current.prefetchLayers == 0,
                 ) { onChange(current.copy(predictPrefetch = it)) }
                 if (current.predictPrefetch) {
@@ -139,8 +140,7 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                         "Predicted misses to read ahead", AppSettings.PREDICT_SPEC_CHOICES, current.predictSpecMax,
                         format = {
                             when (it) {
-                                0 -> "0 — retention only"
-                                2 -> "2 — default"
+                                0 -> "0 — retention only (default)"
                                 else -> "$it"
                             }
                         },
@@ -148,8 +148,8 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     ) { onChange(current.copy(predictSpecMax = it)) }
                     Text(
                         "How much flash the prediction may spend per layer. 0 reads nothing ahead and only " +
-                            "protects predicted experts already in RAM from eviction. Under measurement — " +
-                            "throughput not yet proven; the per-run summary lines are the evidence.",
+                            "protects predicted experts already in RAM from eviction. Measured: reading ahead " +
+                            "lost its matched A/B — the flash has no spare bandwidth — so 0 is the honest default.",
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -31,6 +31,13 @@
 // S3 guards set_cache_budget_mb: evicting a warm cache mid-session must cost only re-reads.
 // G5 guards temporal prefetch: speculatively reading the next layers' experts must only warm the
 // cache — the routed slices a token actually consumes, and thus its output, are unchanged.
+//
+//   G9  streaming + --predict-log == streaming (the prediction probe observes and nothing more),
+//       and its zero-staleness control reproduces the router it measures
+//
+// G9's second half is the probe measuring itself: the control shares every line of code with the
+// prediction under test and differs only in having no staleness, so it must agree with llama.cpp's
+// own routing. A probe that is quietly wrong would otherwise report a plausible number.
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
 #include "bmoe/session.h"
@@ -428,6 +435,61 @@ int main(int argc, char ** argv) {
         return 2;
     }
     fails += check("G8c drop(full strength, top-k=1) == top-k=1 undropped (top expert pinned)", s_k1, s_k1_drop);
+
+    // G9 — the expert-prediction probe observes and nothing more.
+    //
+    // It isolates an extra node per layer and reads the router's inputs, which puts it inside the
+    // most load-bearing callback in the engine. So the first thing to pin down is that it changes
+    // nothing: same prompt, same bytes as the unprobed stream.
+    RunConfig probe = base(model);
+    probe.moe.enabled = true;
+    probe.moe.cache_mb = 0;
+    probe.moe.predict_log = true;
+    std::string s_probe;
+    if (!gen(probe, s_probe, err)) {
+        std::fprintf(stderr, "predict-log run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("G9a predict-log == streaming(cache off) (the probe only observes)", s_s0, s_probe);
+
+    // G9b — and that it measured something rather than reporting an empty run as a clean one.
+    //
+    // The load-bearing assertion is the CONTROL. It ranks experts from the layer's own gate matrix
+    // and its own gate input — the same row read, GEMV and ranking the stale prediction uses, with
+    // only the staleness removed — so it has to reproduce the selection llama.cpp computed from
+    // those exact two tensors. A transposed matrix, a mis-strided row or a wrong token would leave
+    // it near chance while the stale number stayed superficially plausible. It is checked against
+    // 0.99 rather than 1.0 because the probe accumulates in scalar float where ggml does not, so a
+    // routing whose top-k straddles a near-tie may legitimately order two experts differently.
+    {
+        RunResult r = run(probe);
+        const PredictorStats & self = r.summary.predict_self;
+        const PredictorStats & stale = r.summary.predict_stale;
+        const PredictorStats & prev = r.summary.predict_prev;
+        if (!r || self.rows == 0 || stale.rows == 0 || prev.rows == 0) {
+            std::printf("[FAIL] G9b probe scored nothing (self=%lld stale=%lld prev=%lld routings)\n", self.rows,
+                        stale.rows, prev.rows);
+            ++fails;
+        } else if (self.hit_frac() < 0.99) {
+            std::printf("[FAIL] G9b zero-staleness control only %.1f%% — the probe's own gate arithmetic disagrees "
+                        "with the router it is measuring\n",
+                        100.0 * self.hit_frac());
+            ++fails;
+        } else {
+            std::printf("[PASS] G9b control %.1f%% over %lld routings (stale %.1f%%, prev-token %.1f%%)\n",
+                        100.0 * self.hit_frac(), self.rows, 100.0 * stale.hit_frac(), 100.0 * prev.hit_frac());
+        }
+        // The per-layer breakdown is the half of the report conclusions get drawn from, so it must
+        // exist and the three predictors must be indexed the same way — a table where one of them
+        // is shifted or short would compare a layer against a different layer, legibly but wrongly.
+        const size_t nst = r.summary.predict_stale_by_layer.size();
+        if (r && (nst == 0 || r.summary.predict_prev_by_layer.size() != nst ||
+                  r.summary.predict_self_by_layer.size() != nst)) {
+            std::printf("[FAIL] G9b per-layer tables disagree (stale=%d prev=%d self=%d)\n", (int) nst,
+                        (int) r.summary.predict_prev_by_layer.size(), (int) r.summary.predict_self_by_layer.size());
+            ++fails;
+        }
+    }
 
     if (fails == 0) std::printf("\nall MoE byte-identity gates passed\n");
     return fails == 0 ? 0 : 1;

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -38,6 +38,9 @@
 // G9's second half is the probe measuring itself: the control shares every line of code with the
 // prediction under test and differs only in having no staleness, so it must agree with llama.cpp's
 // own routing. A probe that is quietly wrong would otherwise report a plausible number.
+//
+//   G10 streaming + --predict-prefetch == streaming (speculating on the prediction only warms the
+//       cache), and the run must actually have speculated — an inert predictor passes vacuously.
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
 #include "bmoe/session.h"
@@ -488,6 +491,41 @@ int main(int argc, char ** argv) {
             std::printf("[FAIL] G9b per-layer tables disagree (stale=%d prev=%d self=%d)\n", (int) nst,
                         (int) r.summary.predict_prev_by_layer.size(), (int) r.summary.predict_self_by_layer.size());
             ++fails;
+        }
+    }
+
+    // G10 — predictive prefetch is speculation and nothing more.
+    //
+    // Same contract as the temporal prefetch (G5): whatever the predictor speculates, the routed
+    // slices a token consumes — and thus its output — must not change. prefetch-sync completes the
+    // speculative reads deterministically so the integrate-then-hit path is actually exercised on
+    // a fast host, exactly as G5c does; the small forced cache makes hits and evictions both occur.
+    RunConfig ppf = base(model);
+    ppf.moe.enabled = true;
+    ppf.moe.cache_mb = 2;
+    ppf.moe.force_cache = true;
+    ppf.moe.io_threads = 4;
+    ppf.moe.predict_prefetch = true;
+    ppf.moe.prefetch_sync = true;
+    std::string s_ppf;
+    if (!gen(ppf, s_ppf, err)) {
+        std::fprintf(stderr, "predict-prefetch run failed: %s\n", err.c_str());
+        return 2;
+    }
+    fails += check("G10a predict-prefetch(sync) == streaming(cache off)", s_s0, s_ppf);
+    // The identity is only evidence if something was actually speculated: a predictor that never
+    // fired would pass G10a vacuously. spec_experts counts what the speculative path fully read.
+    {
+        RunResult r = run(ppf);
+        if (!r || r.summary.moe_spec_experts <= 0) {
+            std::printf("[FAIL] G10b predict-prefetch speculated nothing (spec_experts=%lld)\n",
+                        r.summary.moe_spec_experts);
+            ++fails;
+        } else {
+            std::printf("[PASS] G10b predict-prefetch speculated %lld experts, %lld useful (%.0f%%)\n",
+                        r.summary.moe_spec_experts, r.summary.moe_spec_useful,
+                        r.summary.moe_spec_experts > 0 ? 100.0 * r.summary.moe_spec_useful / r.summary.moe_spec_experts
+                                                       : 0.0);
         }
     }
 


### PR DESCRIPTION
## Why

[Temporal prefetch](docs/prefetch.md) was built on a predictor nobody had priced. Measured after the
fact over the committed route traces, the previous-token bet is right about **38% on Qwen and 18% on
gpt-oss** — not enough to pay for the reads it speculates. The lesson was not that prefetch is
impossible; it was that a predictor should be measured *before* it is wired into anything.

So this PR does both halves in order: it adds the instrument, measures a much better predictor with
it, acts on that predictor — and then reports that acting on it **loses**, which is why the lever
ships off by default.

## `--predict-log`: the instrument

It ranks each layer's experts a layer early, by running the **next** layer's router matrix on the
**current** layer's gate input. The residual stream barely moves between layers, so the stale input
ranks nearly as the real one will — the mechanism [FATE](https://arxiv.org/html/2502.12224v1)
reports 78.8% for. Training-free and model-unchanged: the router matrix is a dense weight already
resident, and the prediction is one GEMV per layer.

The matrix is **learned from the graph** (the gate matmul's first source) rather than looked up by
tensor name, so no architecture is named anywhere in the path. Being a weight leaf, its pointer
stays valid into layers the current token has not reached — which is what makes predicting forward
possible at all.

Three predictors, scored on the same routings of the same run:

| | what it is |
|---|---|
| `stale` | the next layer's router run a layer early — the one under test |
| `prev` | what the previous token routed here — the bet `--prefetch` already places |
| `ctrl` | the same code with the staleness removed — **a control, not a predictor** |

**The control is the load-bearing part.** It shares every line of code with the prediction under
test and differs only in using the layer's own matrix, so it *must* reproduce the selection
llama.cpp computes from those same two tensors. A transposed matrix, a mis-strided row or the wrong
token of the batch collapses it toward chance while the stale figure would stay superficially
plausible. An architecture that selects by something other than raw-logit ranking (an additive bias,
group-limited routing) puts it below 100%, and by that much the stale figure understates the method
— the CLI says so rather than letting the gap be blamed on staleness.

Per layer as well as aggregate, because an aggregate flatters a prefetch: what a prefetch costs is
set by the layers it gets **wrong**, and a MoE model's first layers route far less predictably than
its last. Denominators are printed per predictor — the stale gate structurally cannot rank layer 0
(nothing precedes it) or the first token of a run, and those are counted as *unscored* rather than
folded in.

## What it measured

On device, against what `--prefetch` already bets on:

| model | stale-gate | prev-token | control |
|---|---|---|---|
| Qwen3-30B-A3B (top-8 of 128) | **88.6%** | 43.3% | 100.0% |
| Qwen3.6-35B-A3B (top-8 of 256) | **80.7%** | 35.4% | 100.0% |

The control at exactly 100% on every layer of both says Qwen selects by pure logit ranking, so
those numbers need no discount. The prev-token column corroborates the offline route-trace
estimates that motivated the whole exercise.

## `--predict-prefetch`: acting on it, and the verdict

The prediction is fed to the same speculative read path `--prefetch` uses (same cache buffers,
accounting and summary line, tagged `[stale-gate]`), with two design points that matter more than
the swap: speculation is **issued after the current layer's load** (every load path begins by
quiescing speculation, so an earlier queue would be cancelled), and it is **drop-aware** — with
`--drop-cold-experts` armed, a predicted expert below the drop threshold is not speculated, because
if it misses the policy would discard it unread. `--predict-spec-max N` bounds how much flash the
prediction may spend per layer; `0` is retention-only, where predicted residents are LRU-protected
(new `IExpertSource::retain`) and nothing is read ahead.

It was then measured across the whole cost spectrum, and **the read-ahead loses**:

- **−21%** against the shipping drop + pinned-dense baseline at `--predict-spec-max 2`, in the one
  thermally matched adjacent pair of the campaign — with hit rate **up** 4.3pp, 79% of speculations
  useful, and +37% flash bytes per token.
- **−28%** on 8 I/O lanes in the other matched pair, effective flash bandwidth collapsing 585 →
  392 MiB/s — consistent with the measured lane ceiling.
- **Retention is hit-rate-neutral** (77.2% vs 77.6% at a 3000 MiB cache), exactly as the offline
  replay bound predicted: within a two-layer horizon, eviction order is irrelevant at that size.

Speculation improved every metric it owns and still lost the wall clock, by the same mechanism that
killed more lanes, coalescing and the expert sidecar: on a saturated flash, a better guess spends
the bandwidth that was the binding constraint. So the flag ships **off by default** and the app
defaults its budget to retention-only.

A method note worth keeping: the first day's comparisons were **invalidated by silent thermal
capping** — re-running the baseline on a heated device reproduced byte-for-byte identical I/O, hit
rate and drop counts at −40% wall clock. Only thermally matched adjacent cells are quoted above;
`docs/expert-prediction.md` records the contaminated numbers too, and why they cannot be read.

Two structural findings survived the campaign and are in the code: the observer tax was 109 ms/token
before the rebuild — ~35-45 ms per GEMV pass from calling `ggml_fp16_to_fp32` per element (21M calls
per token) plus ~20 ms of barrier — and the prefetch's barrier-less gate-input read is guarded by a
sampled **self-validating watchdog** that disarms the predictor out loud if a future llama.cpp
planner change makes the read untrustworthy.

## Cost and scope

- **Byte-identical**: the probe reaches neither `load_layer`, nor the cache, nor the graph (`G9a`);
  the prefetch only warms the cache (`G10a`), with the same documented exception as `--prefetch`
  under `--drop-cold-experts`, where a correct guess un-drops an expert and buys quality, not speed.
- **The probe is not free**: one isolated node and two GEMVs per layer on the eval thread. A probed
  run is **not a benchmark run**; the docs and `--help` both say so.
- Decode only; requires `--moe-stream`. `--predict-prefetch` needs the LRU cache and excludes
  `--prefetch`. Routings wider than 32 experts are declined rather than scored against a truncated
  ranking.

## Verification

- `ctest` — 7/7 pass, including `G9a`/`G9b` (probe inert; control 100.0% over 96 routings) and
  `G10a`/`G10b` (speculation inert; 33 experts actually speculated, so the identity is not vacuous)
  on both tiny models (qwen3moe, gemma4).
- CI format gate (`clang-format` 18) clean.
- On-device measurement is reported above, from thermally matched pairs only.
