### PR TITLE
feat(gpu): --gpu — run the dense half on the GPU, and the measurement that says not to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 /out/
 cmake-build-*/
 
+# OpenCL headers + ICD loader, fetched by scripts/fetch-opencl-android.ps1 for the optional
+# GPU build. Third-party sources we do not vendor: they are a build prerequisite, not our code.
+/third_party/opencl-sdk/
+
 # Models and large artifacts (never commit weights)
 *.gguf
 *.bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Semantic Versioning.
   is reproducible, not because it is recommended. See `docs/gpu-offload.md` and
   `docs/bench-data/2026-07-27-gpu-dense-offload/`, which also records the two wrong verdicts that
   preceded this one and why they were wrong.
+
+  Repeated on a second model (`Qwen3.6-35B-A3B`, Q4_0, with `--drop-cold-experts`) the sign is no
+  longer ambiguous: full offload **−27%**, output head alone **−16 to −21%**, both outside the noise
+  and consistent across a palindrome. The CPU baseline got faster, so the same fixed
+  boundary-crossing cost is now a larger share of a smaller total. Decode belongs to the CPU on this
+  class of device at every placement measured — including holding the routed experts in device
+  memory, which is a separate experiment on a fork-dependent branch and measures 0.22×. The GPU's
+  one unrefuted advantage is batched **prefill** (~2.3×), which is not measured here.
 - **`--ubatch N`: the widest graph computed at once, decoupled from the context.** Compute buffers
   are reserved for the worst-case graph, and the engine had always set `n_ubatch = n_ctx` so that
   any fitting prompt prefills in one pass — which quietly ties resident memory to the context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,17 @@ Semantic Versioning.
   because linking it makes `libOpenCL` a hard load-time dependency: such a binary will not start on
   a device with no OpenCL driver, where the default build runs fine.
 
-  **Measured on a phone: behind the CPU, and not yet settled.** 3.175 tok/s on the CPU against
-  2.752 with the dense path offloaded — a ~15% gap, once `--ubatch` below removed a self-inflicted
-  cost that had made it look like 2.6x. What remains is structural: the dense and expert halves
-  interleave at every layer, so a two-device split crosses the boundary twice per layer (98 graph
-  splits against 1) and each crossing copies an activation. The configuration that would settle it,
-  `--gpu-layers 1` (output head only, 1-2 splits instead of 98), is owed. Output is token-identical
-  throughout, so this is a performance question and never a correctness one. Ships gated and off so
-  the measurement is reproducible, not because it is recommended. See `docs/gpu-offload.md` and
-  `docs/bench-data/2026-07-27-gpu-dense-offload/`.
+  **Measured on a phone: between neutral and mildly negative, and inside the noise.** At a capped
+  ubatch, CPU reads 2.941–3.116 tok/s across cells and full offload reads 2.768; `--gpu-layers 1`
+  (output head only) read 3.029 in one pass and 2.934 in a repeat that reversed its sign. The
+  device's run-to-run variation is ±6%, larger than every effect measured except the full-offload
+  penalty. The GPU does take real work off the CPU — occupancy falls from 88% to 54% — but the dense
+  and expert halves interleave, so a two-device split crosses the boundary twice per layer (96 graph
+  splits against 1) and the boundary tax eats the saving. Output is token-identical throughout, so
+  this is a performance question and never a correctness one. Ships gated and off so the measurement
+  is reproducible, not because it is recommended. See `docs/gpu-offload.md` and
+  `docs/bench-data/2026-07-27-gpu-dense-offload/`, which also records the two wrong verdicts that
+  preceded this one and why they were wrong.
 - **`--ubatch N`: the widest graph computed at once, decoupled from the context.** Compute buffers
   are reserved for the worst-case graph, and the engine had always set `n_ubatch = n_ctx` so that
   any fitting prompt prefills in one pass — which quietly ties resident memory to the context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- **`--gpu`: the dense half of the model can run on a GPU.** The routed experts always stay on the
+  CPU, and structurally must — the streamer rebinds their `->data` to host buffers it refills every
+  token, while a GPU backend copies weights into device memory once at load and never re-reads the
+  pointer. What a GPU *can* take is everything else: embeddings, attention/SSM, norms, `lm_head`.
+  On a MoE that is roughly half the per-token arithmetic, because 100% of the dense weights are used
+  on every token against only `k/n_expert` of the expert weights (Qwen3-30B-A3B: 951 MiB dense
+  against ~1.10 GiB of expert bytes touched). Lossless — placement changes where a matmul runs, not
+  what the model computes — and orthogonal to streaming, so it combines with every existing knob.
+  Also `--gpu-layers N` to offload only the last N layers, and `--gpu-require` to fail rather than
+  fall back, so a benchmark cannot silently compare CPU against CPU.
+
+  Two properties it was built to have. It is **device-agnostic**: availability is probed at load
+  through the ggml backend registry (`core/src/engine/gpu_device.h`), which names no vendor or API,
+  so a build without a GPU backend and a device without a driver take the same clean CPU fallback.
+  And it is **model-agnostic**: the buffer-type override that pins the experts is derived from the
+  architecture recipe (`expert_tensor_pattern()`), so a new MoE family added as a recipe row pins
+  its own experts with nothing else to update.
+
+  Off by default at every level. The OpenCL backend is opt-in at build time (`-DBMOE_OPENCL=ON`)
+  because linking it makes `libOpenCL` a hard load-time dependency: such a binary will not start on
+  a device with no OpenCL driver, where the default build runs fine. See `docs/gpu-offload.md` for
+  the build recipe and, importantly, for what is **not** yet known — this ships gated and measured
+  on nothing; the argument for it is the byte split plus the compute/stall attribution, not a
+  benchmark.
+- `BMOE_READY` gains `gpu`, and the metrics CSV preamble gains `gpu=`, both carrying the **resolved**
+  device (empty / `cpu` when the dense path ran on the CPU). A run that asked for the GPU on a
+  device without one records the fallback, so a bench cell can never be mistaken for a GPU cell it
+  silently was not. The example app exposes the whole thing as a **Dense weights on GPU** toggle in
+  the Compute section, which displays the device the engine actually got rather than echoing the
+  switch back.
+
+### Fixed
+- `--dense-weights anon|ahwb` no longer tries to rebind tensors the GPU has taken; they are not
+  under host-memory reclaim pressure, so skipping them loses nothing, and rebinding a device-resident
+  tensor would have been ignored at best.
+- A stray `%` in the `--dense-weights` help text was read by `printf` as a conversion specifier, so
+  that line printed garbage and read past the argument list. Pre-existing, unrelated to the above.
+- `scripts/build-android.ps1` now judges `cmake` by its exit code instead of by whether it wrote to
+  stderr, so it works under Windows PowerShell 5.1 and not only under `pwsh` (the NDK toolchain
+  prints progress to stderr, which 5.1 turns into a terminating error).
+
 ## [0.15.1] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,17 @@ Semantic Versioning.
 
   Off by default at every level. The OpenCL backend is opt-in at build time (`-DBMOE_OPENCL=ON`)
   because linking it makes `libOpenCL` a hard load-time dependency: such a binary will not start on
-  a device with no OpenCL driver, where the default build runs fine. See `docs/gpu-offload.md` for
-  the build recipe and, importantly, for what is **not** yet known — this ships gated and measured
-  on nothing; the argument for it is the byte split plus the compute/stall attribution, not a
-  benchmark.
+  a device with no OpenCL driver, where the default build runs fine.
+
+  **Measured, and on a phone it loses: 2.6x slower than the CPU**, degrading monotonically with how
+  much is offloaded (3.175 tok/s CPU, 2.985 at `--gpu-layers 12`, 1.207 fully offloaded). Two costs
+  compound, both scaling with the offload: the dense and expert halves interleave at every layer, so
+  a two-device split crosses the boundary twice per layer (98 graph splits against 1); and the GPU
+  shares the same LPDDR, so its ~2 GiB of allocations add to memory pressure rather than relieving
+  it, producing 5 958 major faults per token against zero on the CPU run. Output was
+  token-identical, so this is a performance verdict and not a correctness one. The feature ships
+  gated and off so the measurement is reproducible, not because it is recommended. See
+  `docs/gpu-offload.md` and `docs/bench-data/2026-07-27-gpu-dense-offload/`.
 - `BMOE_READY` gains `gpu`, and the metrics CSV preamble gains `gpu=`, both carrying the **resolved**
   device (empty / `cpu` when the dense path ran on the CPU). A run that asked for the GPU on a
   device without one records the fallback, so a bench cell can never be mistaken for a GPU cell it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,23 @@ Semantic Versioning.
   because linking it makes `libOpenCL` a hard load-time dependency: such a binary will not start on
   a device with no OpenCL driver, where the default build runs fine.
 
-  **Measured, and on a phone it loses: 2.6x slower than the CPU**, degrading monotonically with how
-  much is offloaded (3.175 tok/s CPU, 2.985 at `--gpu-layers 12`, 1.207 fully offloaded). Two costs
-  compound, both scaling with the offload: the dense and expert halves interleave at every layer, so
-  a two-device split crosses the boundary twice per layer (98 graph splits against 1); and the GPU
-  shares the same LPDDR, so its ~2 GiB of allocations add to memory pressure rather than relieving
-  it, producing 5 958 major faults per token against zero on the CPU run. Output was
-  token-identical, so this is a performance verdict and not a correctness one. The feature ships
-  gated and off so the measurement is reproducible, not because it is recommended. See
-  `docs/gpu-offload.md` and `docs/bench-data/2026-07-27-gpu-dense-offload/`.
+  **Measured on a phone: behind the CPU, and not yet settled.** 3.175 tok/s on the CPU against
+  2.752 with the dense path offloaded — a ~15% gap, once `--ubatch` below removed a self-inflicted
+  cost that had made it look like 2.6x. What remains is structural: the dense and expert halves
+  interleave at every layer, so a two-device split crosses the boundary twice per layer (98 graph
+  splits against 1) and each crossing copies an activation. The configuration that would settle it,
+  `--gpu-layers 1` (output head only, 1-2 splits instead of 98), is owed. Output is token-identical
+  throughout, so this is a performance question and never a correctness one. Ships gated and off so
+  the measurement is reproducible, not because it is recommended. See `docs/gpu-offload.md` and
+  `docs/bench-data/2026-07-27-gpu-dense-offload/`.
+- **`--ubatch N`: the widest graph computed at once, decoupled from the context.** Compute buffers
+  are reserved for the worst-case graph, and the engine had always set `n_ubatch = n_ctx` so that
+  any fitting prompt prefills in one pass — which quietly ties resident memory to the context
+  rather than to the work. Measured at n_ctx 2048: **320 MiB of CPU compute buffer, falling to
+  80 MiB at 512**; with a GPU in the graph, 1203 MiB falling to 301 MiB. On an engine whose whole
+  problem is that the expert cache and the dense weights compete for RAM, that is a real budget,
+  and it was invisible. Decode is unaffected — a decode graph is one token wide whatever this says;
+  the cost is prefill throughput. Default 0 keeps the previous behaviour exactly.
 - `BMOE_READY` gains `gpu`, and the metrics CSV preamble gains `gpu=`, both carrying the **resolved**
   device (empty / `cpu` when the dense path ran on the CPU). A run that asked for the GPU on a
   device without one records the fallback, so a bench cell can never be mistaken for a GPU cell it

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ option(BMOE_BUILD_CLI   "Build the bmoe-cli host tool"              ON)
 # configured and cross-compiled on their own without building the engine.
 option(BMOE_BUILD_TOOLS "Build standalone diagnostic tools (bmoe-iobench)" OFF)
 
+# Off by default, and deliberately so. Enabling it links ggml's OpenCL backend, which is a hard
+# link-time dependency on libOpenCL: the resulting binary will not start on a device that has no
+# OpenCL driver at all. The engine's own GPU support is runtime-probed and degrades cleanly (see
+# core/src/engine/gpu_device.h), but that probe never runs if the process cannot load. So the
+# default build stays dependency-free and runs everywhere, and an OpenCL build is an explicit
+# choice for a device known to have a driver. See docs/gpu-offload.md for the Android recipe.
+option(BMOE_OPENCL "Build with the OpenCL GPU backend (adds a libOpenCL dependency)" OFF)
+
 # --- Optional native dependency: llama.cpp ----------------------------------------
 # The streaming seam uses only the public C API (llama.h). We additionally link llama.cpp's
 # `common` layer for one thing: chat-template rendering + reasoning parsing (common_chat_*),
@@ -48,6 +56,13 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/llama.cpp/CMakeLists.txt")
     set(LLAMA_BUILD_SERVER  OFF CACHE BOOL "" FORCE)
     set(LLAMA_BUILD_COMMON  ON  CACHE BOOL "" FORCE)
     set(LLAMA_CURL          OFF CACHE BOOL "" FORCE)  # common's model-download path unused
+    if(BMOE_OPENCL)
+        # The one GGML_* option this project sets. Everything else about the backend — which
+        # device, whether one exists — is decided at runtime, so nothing else needs configuring
+        # here; the Adreno kernel set is upstream's own default.
+        set(GGML_OPENCL ON CACHE BOOL "" FORCE)
+        message(STATUS "bmoe: OpenCL GPU backend enabled (binary will require libOpenCL at load)")
+    endif()
     add_subdirectory(third_party/llama.cpp EXCLUDE_FROM_ALL)
 endif()
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -209,10 +209,14 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
     // n_expert_used is the EFFECTIVE routing width, after any override. A UI needs it to say
     // anything sensible about --drop-cold-experts, whose threshold is a fraction of 1/top-k: the
     // same percentage trims a tail at 8 and takes half the routing at 2. 0 on a non-MoE model.
+    // gpu is what the offload RESOLVED to, not what was asked for — empty when the dense path ran
+    // on the CPU, whether because it was not requested or because this device offered no GPU. A UI
+    // that echoed its own switch back would report a fallback as a success.
     std::printf("BMOE_READY {\"load_s\":%.3f,\"arch\":\"%s\",\"n_ctx\":%d,\"think_ctl\":\"%s\","
-                "\"n_expert_used\":%d}\n",
+                "\"n_expert_used\":%d,\"gpu\":\"%s\"}\n",
                 session->load_seconds(), json_escape(session->arch()).c_str(), session->n_ctx(),
-                bmoe::think_control_name(session->think_control()), session->n_expert_used());
+                bmoe::think_control_name(session->think_control()), session->n_expert_used(),
+                json_escape(session->gpu_device()).c_str());
     std::fflush(stdout);
 
     std::mutex mtx;
@@ -362,7 +366,7 @@ static void print_usage(const char * argv0) {
         "                          reclaim hits zram not flash — the win on >RAM models;\n"
         "                          ahwb = as anon, but into dma-buf memory the kernel may not reclaim\n"
         "                          at all — not even to zram, which is what anon still pays for.\n"
-        "                          Android-only; measured +17.9% on a long generation, off by default)\n"
+        "                          Android-only; measured +17.9%% on a long generation, off by default)\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -374,6 +378,14 @@ static void print_usage(const char * argv0) {
         "      --drop-no-renorm    do not rescale the surviving weights after a drop (A/B)\n"
         "      --drop-in-prefill   drop during prefill too (off: the cold cache makes it expensive)\n"
         "      --list-archs        print supported MoE architectures and exit\n"
+        "\n"
+        "  GPU (dense path only — routed experts always compute on the CPU, see docs/gpu-offload.md):\n"
+        "      --gpu               offload the non-expert weights to a GPU device if the device has\n"
+        "                          one; stays on the CPU with a note when it does not. Independent\n"
+        "                          of --moe-stream. Lossless: placement does not change arithmetic.\n"
+        "      --gpu-layers N      how many layers to offload (default -1 = all). Implies --gpu.\n"
+        "      --gpu-require       fail instead of falling back when no GPU is found, so an A/B\n"
+        "                          cannot silently compare CPU against CPU. Implies --gpu.\n"
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
         "BMOE_N_EXPERT_USED\n",
@@ -488,7 +500,20 @@ int main(int argc, char ** argv) {
             cfg.moe.prefetch_layers = std::atoi(next("--prefetch"));
         else if (a == "--prefetch-sync") // debug: complete speculative reads synchronously
             cfg.moe.prefetch_sync = true;
-        else if (a == "--drop-cold-experts")
+        // Dense-path GPU offload. Independent of --moe-stream: it moves the non-expert half of the
+        // model, which exists whether or not the experts are streamed.
+        else if (a == "--gpu")
+            cfg.gpu.enabled = true;
+        // Both imply --gpu: there is no reading of "offload 20 layers" that does not want the
+        // offload. The library API still rejects the inconsistent pair, for callers that build a
+        // RunConfig directly.
+        else if (a == "--gpu-layers") {
+            cfg.gpu.n_layers = std::atoi(next("--gpu-layers"));
+            cfg.gpu.enabled = true;
+        } else if (a == "--gpu-require") { // measuring the GPU: refuse to fall back and compare CPU to CPU
+            cfg.gpu.require = true;
+            cfg.gpu.enabled = true;
+        } else if (a == "--drop-cold-experts")
             cfg.moe.drop_cold_frac = (float) std::atof(next("--drop-cold-experts"));
         else if (a == "--drop-no-renorm")
             cfg.moe.drop_renorm = false;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -328,6 +328,11 @@ static void print_usage(const char * argv0) {
         "  -n, --n-predict N       tokens to generate (default 128)\n"
         "  -t, --threads N         compute threads (default 4)\n"
         "  -c, --ctx-size N        context size (default 2048)\n"
+        "      --ubatch N          widest graph computed at once (0 = as wide as the context).\n"
+        "                          Compute buffers are reserved for it, so a smaller value hands\n"
+        "                          RAM back to the expert cache at the cost of prefill speed;\n"
+        "                          decode is unaffected. Measured: 2048 reserves 320 MiB on CPU\n"
+        "                          and 1203 MiB with a GPU in the graph, 512 reserves 80/301.\n"
         "      --chatml            wrap the prompt in the model family's chat turn (gemma/chatml)\n"
         "      --no-think          render the chat template with reasoning disabled\n"
         "      --progress          emit machine telemetry (one JSON line per token)\n"
@@ -424,6 +429,8 @@ int main(int argc, char ** argv) {
             cfg.n_threads = std::atoi(next("-t"));
         else if (a == "-c" || a == "--ctx-size")
             cfg.n_ctx = std::atoi(next("-c"));
+        else if (a == "--ubatch")
+            cfg.n_ubatch = std::atoi(next("--ubatch"));
         else if (a == "--n-expert-used")
             cfg.n_expert_used = std::atoi(next("--n-expert-used"));
         else if (a == "--temp")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ if(BMOE_HAVE_LLAMA)
         src/moe/expert_stream_source.cpp
         src/moe/router_hook.cpp
         src/engine/session.cpp
+        src/engine/gpu_device.cpp
         src/engine/chat_parse.cpp
         src/engine/thinking_control.cpp
         src/engine/runtime.cpp

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -142,6 +142,41 @@ struct MoeStreamConfig {
     static constexpr int prefetch_layers_max = 8;
 };
 
+// GPU offload of the DENSE half of the model. The streamed experts always stay on the CPU, and
+// that split is structural rather than a tuning choice: the streamer works by rebinding an expert
+// tensor's ->data to a host buffer it refills every token, and a device backend never re-reads
+// that pointer — it copies the weights into device memory once at load and dispatches against
+// cached handles thereafter. So a streamed expert on a GPU would silently compute whatever the
+// warm-up left behind. What a GPU *can* take is everything else: embeddings, attention/SSM, norms
+// and lm_head, which are resident, uploaded once, and never touched by the rebind.
+//
+// The prize is not marginal. A MoE uses 100% of its dense weights on every token but only
+// k/n_expert of its expert weights, which puts the two halves in the same order of magnitude
+// (measured: Qwen3-30B-A3B carries 951 MiB of dense weights against ~1.10 GiB of expert bytes
+// touched per token), so moving the dense side off the CPU removes roughly half the per-token
+// GEMV work — and decode on this engine is compute-bound once the I/O levers are in
+// (see docs/benchmarks.md).
+//
+// Availability is a property of the device, not of the build: the engine asks the ggml backend
+// registry at load time whether any GPU device exists and falls back to CPU when none does, so
+// the same binary is correct on a phone with no usable GPU driver. Nothing here names a vendor
+// or an API — whichever backend the build registered (OpenCL on Adreno/Mali today) is discovered
+// through the same registry.
+struct GpuConfig {
+    bool enabled = false; // opt in to offloading the dense path to a GPU device
+
+    // How many layers to hand to the GPU. -1 (the default) offloads every layer llama.cpp is
+    // willing to take; a smaller number offloads the last N, which is the knob to reach for when
+    // the whole dense set does not fit in what the driver will allocate. Ignored when disabled.
+    int n_layers = -1;
+
+    // Fail the load instead of falling back to CPU when no GPU device is present. Off by default
+    // because falling back is the right behaviour for a shipped app, but an A/B that silently
+    // compares CPU against CPU is worse than one that refuses to start — the same reasoning that
+    // makes DenseWeightsMode::Pinned fail rather than degrade.
+    bool require = false;
+};
+
 // A full run: model, prompt, decoding, streaming, telemetry.
 struct RunConfig {
     std::string model_path;
@@ -175,6 +210,7 @@ struct RunConfig {
 
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
+    GpuConfig gpu; // dense-path GPU offload; orthogonal to streaming (see GpuConfig)
 };
 
 // Validation result: ok plus a human-readable reason when not.

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -184,6 +184,20 @@ struct RunConfig {
     int n_predict = 128;
     int n_threads = 4;
     int n_ctx = 2048;
+
+    // Largest batch computed in one graph, i.e. the prefill chunk size. 0 (the default) means
+    // "follow n_ctx", which prefills any fitting prompt in a single pass.
+    //
+    // It is worth exposing because it does not only cost time, it costs RESIDENT MEMORY: the
+    // scheduler reserves compute buffers for the worst-case graph, which is a full-width prefill,
+    // and on this engine every MiB reserved is a MiB the expert cache and the dense weights do not
+    // get. Measured at n_ctx 2048: 320 MiB of CPU compute buffer, falling to 80 MiB at 512 — and
+    // with a GPU in the graph the same scaling took 1203 MiB down to 301 MiB, which was the
+    // difference between a fault storm and none at all (docs/gpu-offload.md).
+    //
+    // Decode is unaffected: a decode graph is one token wide whatever this says. The cost is
+    // prefill throughput, which processes a long prompt in more, smaller passes.
+    int n_ubatch = 0;
     bool chatml = false;   // wrap the prompt in the model family's chat turn (arch-aware)
     bool progress = false; // emit machine telemetry (one JSON line per token)
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -154,6 +154,12 @@ struct RunInfo {
     int prefetch_layers = 0;
     std::string dense_weights = "anon"; // dense (non-expert) policy: "mmap" | "warm" | "anon"
     float drop_cold_frac = 0.0f;        // cache-aware expert dropping threshold (0 = off)
+
+    // The GPU device the dense path was offloaded to, empty when it ran on the CPU. Resolved, like
+    // cache_mb above: a run that asked for the GPU on a device without one records the empty string,
+    // so a bench cell can never be mistaken for a GPU cell it silently was not. The registry's
+    // device name, not its prose description — the CSV preamble is whitespace-split key=value.
+    std::string gpu;
 };
 
 // Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_run_info once before the

--- a/core/include/bmoe/recipe.h
+++ b/core/include/bmoe/recipe.h
@@ -50,4 +50,19 @@ const MoeRecipe * moe_recipe_at(int i);
 // (the same one holding the weights, or the layer's FFN would copy across devices every token).
 std::string expert_tensor_pattern(const MoeRecipe & recipe);
 
+// The tensors that must stay on the CPU when part of the model is offloaded to a GPU: the experts
+// above, plus the MoE **router**.
+//
+// The router is here for a different reason than the experts. The experts cannot move because the
+// streamer rebinds their memory. The router cannot move because the streamer *reads its output* —
+// the `ffn_moe_topk-<il>` node says which experts to fetch, and the hook dereferences it from the
+// host. Computed on a device backend, that node's `->data` is not a host address (and is not null
+// either, so it segfaults rather than failing a check). Pinning the router weight keeps its whole
+// argsort/top-k chain, and therefore the routing the hook reads, CPU-side.
+//
+// `ffn_gate_inp` is not a per-architecture guess: llama.cpp names every MoE router that, from a
+// single table entry, exactly as `ffn_moe_topk` names every routing node — a name the hook already
+// depends on. It is the same seam, not a new one.
+std::string cpu_pinned_tensor_pattern(const MoeRecipe & recipe);
+
 } // namespace bmoe

--- a/core/include/bmoe/recipe.h
+++ b/core/include/bmoe/recipe.h
@@ -9,6 +9,8 @@
 // This header is pure policy: it has no llama.cpp dependency and compiles standalone.
 #pragma once
 
+#include <string>
+
 namespace bmoe {
 
 // The expert weight tensors of a MoE layer, named `blk.<il>.<suffix>.weight` in the gguf.
@@ -32,5 +34,20 @@ const MoeRecipe * find_moe_recipe(const char * arch);
 // Number of registered recipes and indexed access, for `--list-archs` and tests.
 int n_moe_recipes();
 const MoeRecipe * moe_recipe_at(int i);
+
+// A regular expression matching exactly this recipe's expert tensors, e.g.
+// `\.(ffn_gate_exps|ffn_up_exps|ffn_down_exps)\.` — the form llama.cpp's tensor buffer-type
+// overrides expect (an unanchored std::regex search over the full gguf tensor name).
+//
+// Derived from the suffix table rather than written out, so a recipe row added for a new
+// architecture pins its own experts to the CPU with no second place to update. The escaped dots
+// bound the suffix so it cannot match a longer name that merely contains it.
+//
+// Note this matches the per-expert companions too (`ffn_down_exps.scale` and friends), unlike the
+// streamer's own tensor matching, which requires an exact `.weight` tail. The two ask different
+// questions and correctly give different answers: the streamer asks "do I read this from flash?"
+// (no — a scale is small and resident), while placement asks "which device computes with this?"
+// (the same one holding the weights, or the layer's FFN would copy across devices every token).
+std::string expert_tensor_pattern(const MoeRecipe & recipe);
 
 } // namespace bmoe

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -45,6 +45,7 @@ struct SessionConfig {
     bool compute_trace_layers = false;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
+    GpuConfig gpu; // dense-path GPU offload, resolved against the device at open()
 };
 
 // The RunConfig → SessionConfig mapping, in one place. Both entry points that open a session from a
@@ -127,6 +128,12 @@ public:
     // rather than leaving a Thinking toggle that silently does nothing. Always Template when chat
     // mode is off, where no template is rendered and the question does not arise.
     ThinkControl think_control() const;
+
+    // What the GPU offload actually did, which is not what the config asked for whenever the device
+    // has no usable GPU: empty means the dense path ran on the CPU, either because it was not
+    // requested or because nothing was found. A caller that surfaces a GPU switch should report
+    // this rather than echo its own setting back, or a fallback looks like a success.
+    const std::string & gpu_device() const;
 
     // Set the expert-cache budget in MiB and evict down to it now. PRECONDITION: no generate() in
     // flight — call it between generations (e.g. from an app's memory-pressure callback). A no-op

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -36,6 +36,10 @@ struct SessionConfig {
     int n_threads = 4;
     int n_ctx = 2048;
     int n_batch = 512; // prefill chunk capacity; longer prompts are prefilled in n_batch slices
+    // Widest graph actually computed at once. 0 = follow n_batch. Sizing this down trades prefill
+    // throughput for resident compute buffers, which on this engine compete with the expert cache.
+    // See RunConfig::n_ubatch.
+    int n_ubatch = 0;
     bool chatml = false;
     // Active-expert (top-k) override applied at load via a kv_override on the arch-prefixed
     // expert_used_count key. 0 = use the model's own count. See RunConfig::n_expert_used.

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -24,6 +24,15 @@ ValidationResult validate(const RunConfig & cfg) {
     if (cfg.n_ctx <= 0) {
         return fail("n_ctx must be positive");
     }
+    // 0 means "as wide as the context"; anything larger than the context would be reserved for a
+    // batch that can never arrive, which is the opposite of what this knob is for.
+    if (cfg.n_ubatch < 0) {
+        return fail("n_ubatch must be >= 0 (0 = as wide as the context)");
+    }
+    if (cfg.n_ubatch > cfg.n_ctx) {
+        return fail("n_ubatch=" + std::to_string(cfg.n_ubatch) + " exceeds n_ctx=" + std::to_string(cfg.n_ctx) +
+                    ": the compute buffers would be reserved for a batch that cannot occur.");
+    }
     // Lower bound only: 0 means "use the model default". The upper bound (<= the model's
     // real expert count) needs the loaded gguf, so it is deferred to run() where the model
     // is available — same rationale as the streaming checks that stay out of this pure path.

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -49,6 +49,17 @@ ValidationResult validate(const RunConfig & cfg) {
         return fail("moe.overlap requires moe.enabled");
     }
 
+    // GPU offload. Whether a GPU device actually exists is a runtime question answered in run()
+    // against the backend registry — validate() stays pure — so all that can be checked here is
+    // that the knobs describe a coherent request.
+    if (cfg.gpu.n_layers < -1) {
+        return fail("gpu.n_layers must be >= -1 (-1 = every layer the backend will take)");
+    }
+    if (!cfg.gpu.enabled && (cfg.gpu.require || cfg.gpu.n_layers != -1)) {
+        return fail("gpu.require and gpu.n_layers are only meaningful with gpu.enabled: a run that "
+                    "did not ask for the GPU would silently ignore them.");
+    }
+
     if (cfg.moe.enabled) {
         const MoeStreamConfig & m = cfg.moe;
         if (m.io_threads < 1 || m.io_threads > MoeStreamConfig::io_threads_max) {

--- a/core/src/engine/gpu_device.cpp
+++ b/core/src/engine/gpu_device.cpp
@@ -1,0 +1,80 @@
+#include "gpu_device.h"
+
+#include <cstdio>
+
+namespace bmoe {
+
+namespace {
+
+// Fill the descriptive fields once a device has been chosen. Split out so the two acceptance
+// passes below stay about *selection* and cannot disagree about what they report.
+GpuDevice describe_device(ggml_backend_dev_t dev) {
+    GpuDevice g;
+    g.found = true;
+    g.dev = dev;
+
+    const char * name = ggml_backend_dev_name(dev);
+    const char * desc = ggml_backend_dev_description(dev);
+    g.name = name ? name : "";
+    g.description = desc ? desc : "";
+
+    if (ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev)) {
+        const char * rn = ggml_backend_reg_name(reg);
+        g.backend = rn ? rn : "";
+    }
+
+    // Not every driver answers this; ggml zeroes what it cannot fill, and 0 reads as "unknown"
+    // rather than "empty" at every call site.
+    size_t free_b = 0, total_b = 0;
+    ggml_backend_dev_memory(dev, &free_b, &total_b);
+    g.mem_free = (uint64_t) free_b;
+    g.mem_total = (uint64_t) total_b;
+    return g;
+}
+
+} // namespace
+
+GpuDevice find_gpu_device() {
+    // llama_backend_init() also does this, but discovery has to work for a caller that wants to
+    // know what is available *before* committing to a load. The registry counts as loaded once it
+    // holds anything, so the repeat call is free.
+    if (ggml_backend_reg_count() == 0) {
+        ggml_backend_load_all();
+    }
+
+    // Two passes rather than one with a preference score: a discrete GPU is unambiguously the
+    // better target when both are present, and the integrated fallback is what phones actually
+    // offer. Anything else the registry exposes (CPU, BLAS/AMX accelerators, the tensor-parallel
+    // meta device) is not something the dense path can be handed to.
+    for (enum ggml_backend_dev_type want : {GGML_BACKEND_DEVICE_TYPE_GPU, GGML_BACKEND_DEVICE_TYPE_IGPU}) {
+        for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+            ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+            if (dev && ggml_backend_dev_type(dev) == want) {
+                return describe_device(dev);
+            }
+        }
+    }
+    return {};
+}
+
+std::string describe(const GpuDevice & g) {
+    if (!g.found) {
+        return "none";
+    }
+    std::string s = g.name;
+    if (!g.backend.empty()) {
+        s += " (" + g.backend + ")";
+    }
+    if (!g.description.empty() && g.description != g.name) {
+        s += " — " + g.description;
+    }
+    if (g.mem_total > 0) {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), ", %llu/%llu MiB free", (unsigned long long) (g.mem_free >> 20),
+                      (unsigned long long) (g.mem_total >> 20));
+        s += buf;
+    }
+    return s;
+}
+
+} // namespace bmoe

--- a/core/src/engine/gpu_device.h
+++ b/core/src/engine/gpu_device.h
@@ -1,0 +1,40 @@
+// GPU device discovery.
+//
+// The engine never names a vendor or a graphics API. It asks the ggml backend registry what
+// devices this build registered and takes the first one that is a GPU, which keeps the policy
+// ("offload the dense path if there is somewhere to offload it to") independent of whether the
+// backend underneath is OpenCL on an Adreno, Vulkan on a Mali, or something that does not exist
+// yet. A build compiled without any GPU backend, and a device whose driver is missing or refuses
+// to initialise, both land in the same place: no device found, and the caller decides whether
+// that is a fallback or an error.
+#pragma once
+
+#include "ggml-backend.h"
+
+#include <cstdint>
+#include <string>
+
+namespace bmoe {
+
+// A GPU the registry offered, or `found == false`. The handle is owned by the registry and stays
+// valid for the process lifetime; it is passed straight to llama_model_params::devices.
+struct GpuDevice {
+    bool found = false;
+    ggml_backend_dev_t dev = nullptr;
+    std::string name;        // registry device name, e.g. "GPUOpenCL"
+    std::string description; // driver-reported description, e.g. "QUALCOMM Adreno(TM) 830"
+    std::string backend;     // registry (backend) name, e.g. "OpenCL"
+    uint64_t mem_free = 0;   // bytes the driver reports free; 0 when it does not report
+    uint64_t mem_total = 0;  // bytes the driver reports total; 0 when it does not report
+};
+
+// Find a usable GPU. Discrete GPUs are preferred over integrated ones only because that is the
+// registry's own ordering convention; on the devices this engine targets the two are the same
+// silicon. Safe to call before llama_backend_init() — it loads any dynamic backends itself.
+GpuDevice find_gpu_device();
+
+// One line describing what was found, for the run banner and the telemetry preamble. Returns
+// "none" when nothing was found, so the caller can log unconditionally.
+std::string describe(const GpuDevice & g);
+
+} // namespace bmoe

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -11,7 +11,8 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.model_path = cfg.model_path;
     sc.n_threads = cfg.n_threads;
     sc.n_ctx = cfg.n_ctx;
-    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
+    sc.n_batch = cfg.n_ctx;     // one-batch prefill for any prompt that fits the context
+    sc.n_ubatch = cfg.n_ubatch; // 0 = follow n_batch; smaller trades prefill speed for memory
     sc.chatml = cfg.chatml;
     sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
     sc.compute_trace_layers = cfg.compute_trace_layers;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -17,6 +17,7 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.compute_trace_layers = cfg.compute_trace_layers;
     sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
+    sc.gpu = cfg.gpu; // dense-path offload; falls back to CPU at open() if the device has no GPU
     return sc;
 }
 

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -3,6 +3,7 @@
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
 #include "chat_parse.h"
+#include "gpu_device.h"
 #include "thinking_control.h"
 #include "../moe/router_hook.h"
 #include "../moe/expert_stream_source.h"
@@ -176,6 +177,8 @@ dense_bytes_per_layer(const GgufOffsets & offs, const std::vector<LayerExperts> 
 struct Session::Impl {
     SessionConfig cfg;
     std::string arch;
+    std::string gpu_device; // what the offload actually got, prose; empty means it ran on the CPU
+    std::string gpu_name;   // the same device as one whitespace-free token, for the CSV preamble
     double load_seconds = 0.0;
 
     // Ownership order matters at teardown: the source's I/O pool holds fds into the mmap'd
@@ -263,6 +266,9 @@ int Session::n_expert_used() const {
 ThinkControl Session::think_control() const {
     return impl_->think_ctl;
 }
+const std::string & Session::gpu_device() const {
+    return impl_->gpu_device;
+}
 void Session::set_cache_budget_mb(int mib) {
     impl_->source.set_cache_budget((size_t) std::max(0, mib) * 1024ull * 1024ull);
 }
@@ -308,7 +314,8 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     };
 
     // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
-    // q4_K buffer would break the rebind), experts on CPU.
+    // q4_K buffer would break the rebind), everything on CPU. The GPU block below may move the
+    // dense half off the CPU; the experts stay here in every configuration.
     llama_model_params mparams = llama_model_default_params();
     mparams.use_mmap = true;
     mparams.use_extra_bufts = false;
@@ -336,6 +343,59 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         std::snprintf(kv_overrides[0].key, sizeof(kv_overrides[0].key), "%s", key.c_str());
         kv_overrides[0].val_i64 = cfg.n_expert_used;
         mparams.kv_overrides = kv_overrides;
+    }
+
+    // Dense-path GPU offload. Two things are arranged together here, and both must outlive the load
+    // call below: the device list, and a buffer-type override pinning the routed experts to the CPU.
+    // The pin is what makes the split safe rather than merely fast — llama.cpp resolves a matching
+    // override BEFORE it consults the layer's assigned device, so an expert tensor stays in host
+    // memory even in a layer that was handed to the GPU, and the streamer's rebind keeps working
+    // exactly as it does on a CPU-only run. See GpuConfig in bmoe/config.h for why the experts can
+    // never move.
+    GpuDevice gpu;
+    std::string expert_pattern;
+    ggml_backend_dev_t gpu_devs[2] = {nullptr, nullptr};
+    llama_model_tensor_buft_override buft_overrides[2];
+    std::memset(buft_overrides, 0, sizeof(buft_overrides)); // second entry stays the pattern==NULL terminator
+    if (cfg.gpu.enabled) {
+        gpu = find_gpu_device();
+        if (!gpu.found) {
+            // Availability is a device property, so "no GPU here" is an ordinary outcome, not a
+            // misconfiguration — unless the caller said it was measuring the GPU, in which case
+            // falling back would silently compare CPU against CPU.
+            if (cfg.gpu.require) {
+                return fail("gpu.require is set but no GPU device is available: this build registered no GPU "
+                            "backend, or the device has no usable driver");
+            }
+            std::fprintf(stderr, "bmoe: gpu — no device available, dense path stays on CPU\n");
+        } else {
+            gpu_devs[0] = gpu.dev;
+            mparams.devices = gpu_devs;
+            // -1 reaches llama.cpp as "every layer" (it normalises negatives to n_layer_all + 1),
+            // so the default needs no layer count of our own.
+            mparams.n_gpu_layers = cfg.gpu.n_layers;
+
+            // Pin the experts by name, from the recipe. Looked up independently of cfg.moe.enabled:
+            // an mmap baseline run is just as unable to fit a >RAM expert set into device memory,
+            // and keeping the placement identical across that A/B is the point. A model with no
+            // recipe (a dense model, or a MoE family not yet registered) pins nothing and offloads
+            // whole — correct for the former, and for the latter it fails loudly at allocation
+            // rather than quietly streaming from a device buffer it cannot rebind.
+            const GgufModelInfo & info = gguf();
+            const MoeRecipe * placement = info.ok ? find_moe_recipe(info.arch.c_str()) : nullptr;
+            if (placement) {
+                expert_pattern = expert_tensor_pattern(*placement);
+            }
+            if (!expert_pattern.empty()) {
+                buft_overrides[0].pattern = expert_pattern.c_str();
+                buft_overrides[0].buft = ggml_backend_cpu_buffer_type();
+                mparams.tensor_buft_overrides = buft_overrides;
+            }
+            im.gpu_device = describe(gpu);
+            im.gpu_name = gpu.name;
+            std::fprintf(stderr, "bmoe: gpu — offloading the dense path to %s%s\n", im.gpu_device.c_str(),
+                         expert_pattern.empty() ? "" : " (routed experts pinned to CPU)");
+        }
     }
 
     llama_model * model = llama_model_load_from_file(cfg.model_path.c_str(), mparams);
@@ -469,9 +529,18 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         if (cfg.moe.dense_weights == DenseWeightsMode::Anonymous || cfg.moe.dense_weights == DenseWeightsMode::Pinned) {
             const std::unordered_set<std::string> expert_names = expert_tensor_names(layers);
             std::vector<DenseTensorRef> dense;
+            int skipped_device = 0;
             for (const auto & kv : im.hook->captured_weights()) {
                 const std::string & name = kv.first;
                 if (expert_names.count(name)) continue;
+                // A tensor the GPU took is not ours to rebind: its ->data addresses device memory
+                // the backend resolved once at load, so pointing it at a host buffer would be
+                // ignored at best. These policies exist to survive host memory reclaim, which is
+                // not a pressure device-resident weights are under, so skipping them loses nothing.
+                if (kv.second->buffer && !ggml_backend_buffer_is_host(kv.second->buffer)) {
+                    ++skipped_device;
+                    continue;
+                }
                 auto off = offs.off_by_name.find(name);
                 auto sz = offs.size_by_name.find(name);
                 if (off == offs.off_by_name.end() || sz == offs.size_by_name.end()) continue; // not a file tensor
@@ -480,6 +549,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                 d.file_off = off->second;
                 d.size = sz->second;
                 dense.push_back(d);
+            }
+            if (skipped_device > 0) {
+                std::fprintf(stderr, "bmoe: dense-weights — %d tensors left on the GPU (device-resident)\n",
+                             skipped_device);
             }
             im.source.set_dense_tensors(std::move(dense));
         }
@@ -567,6 +640,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
         ri.drop_cold_frac = cfg.moe.enabled ? cfg.moe.drop_cold_frac : 0.0f;
+        ri.gpu = im.gpu_name; // resolved, so a fallback to CPU records "" and not the request
         // The CSV keeps the two familiar flags, derived from the resolved dense-weights policy.
         ri.dense_weights = cfg.moe.dense_weights == DenseWeightsMode::Mmap        ? "mmap"
                            : cfg.moe.dense_weights == DenseWeightsMode::Anonymous ? "anon"

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -384,7 +384,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             const GgufModelInfo & info = gguf();
             const MoeRecipe * placement = info.ok ? find_moe_recipe(info.arch.c_str()) : nullptr;
             if (placement) {
-                expert_pattern = expert_tensor_pattern(*placement);
+                expert_pattern = cpu_pinned_tensor_pattern(*placement);
             }
             if (!expert_pattern.empty()) {
                 buft_overrides[0].pattern = expert_pattern.c_str();
@@ -394,7 +394,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             im.gpu_device = describe(gpu);
             im.gpu_name = gpu.name;
             std::fprintf(stderr, "bmoe: gpu — offloading the dense path to %s%s\n", im.gpu_device.c_str(),
-                         expert_pattern.empty() ? "" : " (routed experts pinned to CPU)");
+                         expert_pattern.empty() ? "" : " (routed experts and the router pinned to CPU)");
         }
     }
 
@@ -487,6 +487,17 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         llama_batch warm = llama_batch_get_one(&warm_tok, 1);
         if (llama_decode(ctx, warm) != 0) return fail("capture warm-up decode failed");
         im.hook->end_capture();
+
+        // The streamer reads each layer's routing out of the graph from the host. If the scheduler
+        // put a routing node on a device backend, that read is not merely wrong, it is a wild
+        // pointer — so refuse the session here rather than crash on the first real token. Only
+        // reachable with GPU offload, and only if the CPU pin above failed to keep the router.
+        if (im.hook->topk_on_device()) {
+            return fail("the MoE routing node was computed on a device backend, where the streamer "
+                        "cannot read it. The router should have been pinned to the CPU alongside the "
+                        "experts — re-run without --gpu, or report this with the model's architecture "
+                        "(see docs/gpu-offload.md)");
+        }
 
         GgufOffsets offs = read_gguf_offsets(cfg.model_path.c_str());
         if (!offs.ok) return fail("cannot read gguf offsets: " + cfg.model_path);

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -439,7 +439,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
     cparams.n_batch = cfg.n_batch;
-    cparams.n_ubatch = cfg.n_batch;
+    // The graph is reserved for the widest ubatch, so this is what sets the resident compute
+    // buffers — the memory this engine is always short of. 0 keeps the historical behaviour
+    // (one graph as wide as the batch); a smaller value chunks prefill to buy that memory back.
+    cparams.n_ubatch = cfg.n_ubatch > 0 ? (uint32_t) cfg.n_ubatch : (uint32_t) cfg.n_batch;
     // The streamer needs the callback to see routing; the compute trace needs it to time nodes.
     // Installing it for the trace alone is what lets a NON-streamed run be measured — the dense
     // mmap baseline the streamed numbers are argued against.

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -1,10 +1,21 @@
 #include "bmoe/metrics.h"
 
 #include <cstdio>
+#include <string>
 
 namespace bmoe {
 
 namespace {
+
+// The preamble is whitespace-split key=value, so any value taken from outside (a driver-reported
+// device name) has to be reduced to one token before it lands there.
+std::string no_whitespace(const std::string & s) {
+    std::string out = s;
+    for (char & c : out) {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') c = '_';
+    }
+    return out;
+}
 
 class CsvMetricsSink final : public IMetricsSink {
 public:
@@ -23,9 +34,14 @@ public:
                      r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx);
         std::fprintf(f_,
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d force_cache=%d "
-                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d dense_weights=%s drop_cold_frac=%.4g\n",
+                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d dense_weights=%s drop_cold_frac=%.4g "
+                     "gpu=%s\n",
                      r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.force_cache, r.io_threads, r.o_direct,
-                     r.overlap, r.prefetch_layers, r.dense_weights.c_str(), (double) r.drop_cold_frac);
+                     r.overlap, r.prefetch_layers, r.dense_weights.c_str(), (double) r.drop_cold_frac,
+                     // "cpu" rather than an empty value: the preamble is whitespace-split key=value,
+                     // so an empty one would swallow the following key on older parsers. Whitespace
+                     // inside a driver-supplied name would do the same, hence the scrub.
+                     (r.gpu.empty() ? std::string("cpu") : no_whitespace(r.gpu)).c_str());
         write_header();
     }
 

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -76,4 +76,14 @@ std::string expert_tensor_pattern(const MoeRecipe & recipe) {
     return "\\.(" + alt + ")\\.";
 }
 
+std::string cpu_pinned_tensor_pattern(const MoeRecipe & recipe) {
+    const std::string experts = expert_tensor_pattern(recipe);
+    if (experts.empty()) return {};
+    // Splice the router into the alternation the experts already built, rather than returning two
+    // patterns: llama.cpp takes the first override that matches, so one expression cannot be
+    // shadowed by the other.
+    const std::string tail = ")\\.";
+    return experts.substr(0, experts.size() - tail.size()) + "|ffn_gate_inp" + tail;
+}
+
 } // namespace bmoe

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -1,6 +1,7 @@
 #include "bmoe/recipe.h"
 
 #include <cstring>
+#include <string>
 
 namespace bmoe {
 
@@ -62,6 +63,17 @@ int n_moe_recipes() {
 }
 const MoeRecipe * moe_recipe_at(int i) {
     return (i >= 0 && i < k_n_recipes) ? &k_recipes[i] : nullptr;
+}
+
+std::string expert_tensor_pattern(const MoeRecipe & recipe) {
+    std::string alt;
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+        if (!recipe.exps_suffix[p]) continue; // slot unused by this architecture
+        if (!alt.empty()) alt += '|';
+        alt += recipe.exps_suffix[p];
+    }
+    if (alt.empty()) return {}; // a recipe naming nothing pins nothing, rather than matching everything
+    return "\\.(" + alt + ")\\.";
 }
 
 } // namespace bmoe

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -1,6 +1,7 @@
 #include "router_hook.h"
 
 #include "ggml.h"
+#include "ggml-backend.h"
 #include "../io/platform_io.h"
 
 #include <cstdio>
@@ -83,6 +84,22 @@ static void gather_weights(const ggml_tensor * t, int nu, int nt, std::vector<fl
 // nb[1] (n_expert * 4), not n_expert_used * 4 — see the gather at the topk node.
 static int32_t * id_at(ggml_tensor * t, int j, int k) {
     return (int32_t *) ((char *) t->data + (size_t) j * t->nb[1] + (size_t) k * t->nb[0]);
+}
+
+// Can this node's contents be reached through `->data` from the host?
+//
+// Everything the hook does — reading the routing, gathering the weights, editing them for the drop
+// policy — dereferences `->data` directly, which is only meaningful for a node the CPU backend
+// computed. A device backend's `->data` is not a host address at all (ggml's OpenCL backend stores
+// an offset there and keeps the real allocation in `->extra`), and it is NON-NULL, so the old
+// `t->data &&` test waved it through and the first read segfaulted.
+//
+// With `--gpu` the MoE routing path is pinned to the CPU precisely so this stays true (see
+// cpu_pinned_tensor_pattern in arch_registry.cpp). This is the assertion of that invariant rather
+// than a fallback: if it ever fires, the placement is wrong and the run must not continue pretending
+// it routed correctly.
+static bool host_readable(const ggml_tensor * t) {
+    return t->data && (!t->buffer || ggml_backend_buffer_is_host(t->buffer));
 }
 
 void RouterHook::begin_capture() {
@@ -395,6 +412,16 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 if (src->op == GGML_OP_NONE) captured_weights_[src->name] = src;
             }
         }
+        // The streamer reads each layer's routing straight out of this node, so it has to be a node
+        // the CPU computed. Noticing here — during the warm-up decode, while the caller can still
+        // refuse to open — is the difference between a clear error and a segfault on the first real
+        // token. It can only happen with a device backend in the graph; see host_readable().
+        {
+            int cl = -1;
+            if (std::sscanf(t->name, "ffn_moe_topk-%d", &cl) == 1 && cl >= 0 && !host_readable(t)) {
+                topk_on_device_ = true;
+            }
+        }
         return false; // capture never isolates a node
     }
 
@@ -432,19 +459,19 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     // one offered (match_weights explains why) and let the flush read it. This runs BEFORE the drop
     // policy edits the same tensor, so the trace records the routing the router produced, not the
     // one the policy left behind — `dropped` is what says which is which.
-    if (is_weights && t->data && t->type == GGML_TYPE_F32 && pending_.layer == wl && pending_.nu > 0)
+    if (is_weights && host_readable(t) && t->type == GGML_TYPE_F32 && pending_.layer == wl && pending_.nu > 0)
         gather_weights(t, pending_.nu, pending_.nt, pending_.weights);
 
     // Learn which node ends this layer's weight chain, and — once known — use it as the point where
     // the routing is decided: everything the drop policy needs is final here, and nothing has
     // consumed it yet. The learning pass and the deferral are the same walk, so a layer whose chain
     // shape the hook has not seen yet simply keeps the undropped behaviour.
-    if (is_weights && t->data && t->type == GGML_TYPE_F32 && drop_.layer == wl) {
+    if (is_weights && host_readable(t) && t->type == GGML_TYPE_F32 && drop_.layer == wl) {
         chain_last_ = t->name;
         if (drop_.deferred && wl >= 0 && wl < (int) term_node_.size() && term_node_[wl] == t->name) apply_drop(t);
     }
 
-    if (source_ && is_topk && t->data && t->type == GGML_TYPE_I32) {
+    if (source_ && is_topk && host_readable(t) && t->type == GGML_TYPE_I32) {
         // selected_experts is [n_expert_used, n_tokens] but a VIEW of the full argsort
         // [n_expert, n_tokens]: its row stride is nb[1] (= n_expert*4), not
         // n_expert_used*4. Gather respecting the strides — a flat read would grab token

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -60,6 +60,12 @@ public:
     // against the gguf tensor set, which those do not belong to. Only .tensor is meaningful here.
     const std::unordered_map<std::string, ggml_tensor *> & captured_weights() const { return captured_weights_; }
 
+    // True when the warm-up decode computed a layer's routing node on a device backend, whose
+    // contents the streamer cannot read from the host. Only reachable with GPU offload, and only if
+    // the routing path was not pinned to the CPU as it is meant to be. Checked once after capture:
+    // the alternative is a segfault on the first real token.
+    bool topk_on_device() const { return topk_on_device_; }
+
     void set_source(IExpertSource * src) { source_ = src; } // non-null → stream mode
 
     // Temporal prefetch depth K: while streaming layer l, hint the source to read ahead the
@@ -150,6 +156,7 @@ private:
     MoeRecipe recipe_;
     int n_layer_ = 0;
     bool capturing_ = false;
+    bool topk_on_device_ = false;      // see topk_on_device()
     IExpertSource * source_ = nullptr; // non-null → stream mode
     std::vector<LayerExperts> captured_;
     std::unordered_map<std::string, ggml_tensor *> captured_weights_; // non-expert weight leaves (see captured_weights)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ core/
                 dense_weights — non-expert weight policy + the residency sensor
     engine/     session — composition + the generation loop (open/generate/close)
                 runtime — the one-shot run() wrapper over a Session
+                gpu_device — GPU discovery via the ggml registry, vendor/API agnostic
                 chat_parse — reasoning-parser wiring (llama.cpp `common`, see seam.md)
                 thinking_control — how "thinking off" is honoured, probed per model
     metrics/    csv_metrics_sink, route_trace_sink, decode_trace_sink

--- a/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
+++ b/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
@@ -1,0 +1,70 @@
+# Dense-path GPU offload — measured NEGATIVE on device (2026-07-27)
+
+**Verdict: `--gpu` is 2.6x SLOWER than the CPU on a phone-class integrated GPU, and it degrades
+monotonically with how much is offloaded. The idea is refuted for this class of device. It is
+correct — the output is token-identical — just slower.**
+
+## Setup
+
+One device (arm64 phone, integrated Adreno-class GPU, UFS 4.x), `Qwen3-30B-A3B-Q4_K_M`
+(`qwen3moe`, 48 layers, 128 experts, top-8). Every cell: `--moe-stream --cache-mb 2000
+--io-threads 4 --overlap --dense-weights anon`, same prompt. The engine binary is identical across
+cells — the OpenCL backend is linked in for all of them, so the backend's fixed init cost is not
+what separates them.
+
+The matched pair ran **GPU first**, which favours the GPU: the device was coolest for it.
+
+## Numbers
+
+| Config | tok/s | compute s/tok | majflt/token | graph splits | OpenCL model buf |
+|---|---:|---:|---:|---:|---:|
+| CPU (no offload) | **3.175** | 0.124 | **0** | 1 | — |
+| `--gpu-layers 12` | 2.985 | — | 234 | 24 | 357 MiB |
+| `--gpu` (all 48 layers) | **1.207** | 0.614 | **5 958** | 98 | 785 MiB |
+
+Flash traffic is identical across cells (485.5 vs 486.0 MiB/token), so the streamer did exactly the
+same I/O work: nothing here is an artefact of a different read pattern.
+
+## Why — two compounding costs, both of which scale with the offload
+
+**1. The halves interleave, so the split is paid 96 times per token.** A MoE layer is
+dense → routed experts → dense → routed experts, 48 times. Putting the dense half on the GPU and
+the experts on the CPU therefore crosses the device boundary twice per layer: **98 graph splits**
+against 1 for the CPU-only graph. Every crossing copies and synchronises an activation. This is
+structural, not a tuning problem — it is what "dense on one device, experts on another" means for
+this architecture. At 12 layers the splits drop to 24 and most of the loss goes with them.
+
+**2. The GPU has no memory of its own.** This is the deeper one. On a phone the GPU shares the same
+LPDDR, so "offloading" does not relieve memory pressure — it **adds** to it. The OpenCL allocations
+(785 MiB of weights plus a **1203 MiB compute buffer**, and note that buffer is a fixed cost that
+does not shrink with `--gpu-layers`) land on top of the 2000 MiB expert cache and the mmap'd model,
+and push the system into reclaim. The result is a fault storm: **5 958 major faults per token
+against zero on the CPU run**.
+
+That zero is the point. `--dense-weights anon` exists precisely to keep the dense weights out of
+the page cache so a reclaim cannot drop them to a flash refault, and it achieves exactly that on the
+CPU path. The GPU offload reintroduces the memory war that this engine's whole dense-weight policy
+was built to end.
+
+## What the pre-measurement argument got wrong
+
+The case for this feature was: a MoE uses 100% of its dense weights every token against
+`k/n_expert` of its experts, so the dense half is ~half the per-token arithmetic, and decode is
+compute-bound. Both premises are still true — and both were irrelevant.
+
+The reasoning was about **how much work** the dense half is. It said nothing about **where that work
+sits in the graph** (interleaved with the experts, so the boundary is crossed constantly) or about
+**what the accelerator costs to feed** (physical RAM, on a device already losing a memory war). A
+byte-count argument is not a placement argument, in the same way a hit-rate curve is not a
+throughput argument.
+
+## What this does not settle
+
+- **One device class.** An integrated mobile GPU sharing LPDDR is the worst case for both mechanisms.
+  A discrete GPU with its own VRAM inverts cost 2 entirely, and this says nothing about it.
+- **One model, one run per cell.** The gap is far larger than any plausible drift, and the
+  dose-response across 0/12/48 layers orders perfectly, but these are not repeated cells.
+- **Prefill is unmeasured.** It is compute-bound and batched, which is the regime a GPU is actually
+  good at; every number here is decode.
+- **It is not a correctness problem.** GPU output was token-identical to CPU output. The feature
+  works; it is simply not worth using here.

--- a/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
+++ b/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
@@ -1,8 +1,16 @@
-# Dense-path GPU offload — measured NEGATIVE on device (2026-07-27)
+# Dense-path GPU offload — measured on device (2026-07-27)
 
-**Verdict: `--gpu` is 2.6x SLOWER than the CPU on a phone-class integrated GPU, and it degrades
-monotonically with how much is offloaded. The idea is refuted for this class of device. It is
-correct — the output is token-identical — just slower.**
+> **Corrected the same day. The first verdict below ("2.6x slower, the GPU adds memory pressure")
+> blamed the GPU for a cost this engine was inflicting on itself.** Most of the loss came from the
+> compute buffers being reserved for a full-context prefill graph — our own `n_ubatch = n_ctx`
+> choice — not from the offload. Capping the ubatch took the GPU from 1.207 to **2.752 tok/s** and
+> major faults from 5 958 to **1.06**. The section "What the first pass got wrong" has the detail;
+> the headline numbers in the table are kept because they are real, they were just misattributed.
+
+**Verdict (as it stands): the offload still loses to the CPU, but by ~15% rather than 2.6x, and the
+remaining gap is the graph-split cost alone. Not yet refuted — the sweep that would settle it
+(`--gpu-layers 1`, i.e. output head only, which crosses the device boundary once instead of 96
+times) is owed.** It is correct throughout — the output is token-identical — just slower so far.
 
 ## Setup
 
@@ -45,6 +53,41 @@ That zero is the point. `--dense-weights anon` exists precisely to keep the dens
 the page cache so a reclaim cannot drop them to a flash refault, and it achieves exactly that on the
 CPU path. The GPU offload reintroduces the memory war that this engine's whole dense-weight policy
 was built to end.
+
+## What the first pass got wrong — the compute buffer, not the GPU
+
+Cost 2 above is largely **self-inflicted and fixable**. The compute buffer is reserved for the
+worst-case graph, and this engine sets `n_ubatch = n_ctx` so that any fitting prompt prefills in one
+pass. That makes the reservation scale with the context, not with the offload:
+
+| n_ctx | OpenCL compute buffer | CPU compute buffer |
+|---|---:|---:|
+| 2048 | 1203 MiB | 320 MiB |
+| 512 | 301 MiB | 80 MiB |
+
+Exactly 4x for a 4x context — nothing to do with the GPU, which needs the same buffer per token
+either way. Re-running the offload with the smaller reservation:
+
+| Config | tok/s | compute s/tok | majflt/token |
+|---|---:|---:|---:|
+| `--gpu`, n_ctx 2048 | 1.207 | 0.614 | 5 958 |
+| `--gpu`, n_ctx 512 | **2.752** | 0.188 | **1.06** |
+| CPU, n_ctx 2048 | 3.175 | 0.124 | 0 |
+
+The fault storm was never the GPU "having no memory of its own" in any interesting sense — it was
+~900 MiB of avoidable reservation pushing an already-tight system into reclaim. With it gone the
+offload costs ~15%, not 2.6x, and what remains is cost 1: the 98 graph splits, whose per-token
+compute overhead (0.188 against 0.124) is the whole residual.
+
+This is why `--ubatch N` now exists as its own knob. Note it is not a GPU fix: 240 MiB of the CPU
+path's own reservation is equally avoidable, and on this engine every MiB reserved is a MiB the
+expert cache does not get.
+
+**Owed, and the reason this is not filed as refuted:** a `--gpu-layers` sweep at a capped ubatch,
+in particular `--gpu-layers 1`. That offloads only the output head — a single large matmul at the
+end of the graph, with no expert layer after it to hand control back to — so it should cost 1-2
+splits instead of 98 while still moving real work. If the residual is entirely split cost, that is
+the configuration where the offload can win.
 
 ## What the pre-measurement argument got wrong
 

--- a/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
+++ b/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
@@ -1,113 +1,139 @@
 # Dense-path GPU offload — measured on device (2026-07-27)
 
-> **Corrected the same day. The first verdict below ("2.6x slower, the GPU adds memory pressure")
-> blamed the GPU for a cost this engine was inflicting on itself.** Most of the loss came from the
-> compute buffers being reserved for a full-context prefill graph — our own `n_ubatch = n_ctx`
-> choice — not from the offload. Capping the ubatch took the GPU from 1.207 to **2.752 tok/s** and
-> major faults from 5 958 to **1.06**. The section "What the first pass got wrong" has the detail;
-> the headline numbers in the table are kept because they are real, they were just misattributed.
+**Verdict: with the memory confound removed, GPU offload of the dense path is between neutral and
+mildly negative on a phone-class integrated GPU — and the residual differences are inside this
+device's run-to-run noise, which is ±6%. It is never a correctness problem: output is
+token-identical. It is simply not a lever here.**
 
-**Verdict (as it stands): the offload still loses to the CPU, but by ~15% rather than 2.6x, and the
-remaining gap is the graph-split cost alone. Not yet refuted — the sweep that would settle it
-(`--gpu-layers 1`, i.e. output head only, which crosses the device boundary once instead of 96
-times) is owed.** It is correct throughout — the output is token-identical — just slower so far.
+This file records three passes, because the first two were wrong in instructive ways and the
+corrections are the useful part.
 
 ## Setup
 
 One device (arm64 phone, integrated Adreno-class GPU, UFS 4.x), `Qwen3-30B-A3B-Q4_K_M`
-(`qwen3moe`, 48 layers, 128 experts, top-8). Every cell: `--moe-stream --cache-mb 2000
---io-threads 4 --overlap --dense-weights anon`, same prompt. The engine binary is identical across
-cells — the OpenCL backend is linked in for all of them, so the backend's fixed init cost is not
-what separates them.
+(`qwen3moe`, 48 layers, 128 experts, top-8). Shared configuration in every cell:
+`--moe-stream --cache-mb 2000 --io-threads 4 --overlap --dense-weights anon`, same prompt, 96
+tokens. The binary is identical across cells — the OpenCL backend is linked in even for the CPU
+cells — so backend init cost is not what separates them.
 
-The matched pair ran **GPU first**, which favours the GPU: the device was coolest for it.
+## Pass 1: the wrong answer (n_ctx 2048, uncapped ubatch)
 
-## Numbers
+| Config | tok/s | compute s/tok | majflt/token | graph splits |
+|---|---:|---:|---:|---:|
+| CPU | 3.175 | 0.124 | 0 | 1 |
+| `--gpu-layers 12` | 2.985 | — | 234 | 24 |
+| `--gpu` (all 48) | 1.207 | 0.614 | 5 958 | 98 |
 
-| Config | tok/s | compute s/tok | majflt/token | graph splits | OpenCL model buf |
-|---|---:|---:|---:|---:|---:|
-| CPU (no offload) | **3.175** | 0.124 | **0** | 1 | — |
-| `--gpu-layers 12` | 2.985 | — | 234 | 24 | 357 MiB |
-| `--gpu` (all 48 layers) | **1.207** | 0.614 | **5 958** | 98 | 785 MiB |
+Read at the time as "2.6x slower, because the GPU shares the same LPDDR and adds memory pressure".
+That attribution was wrong.
 
-Flash traffic is identical across cells (485.5 vs 486.0 MiB/token), so the streamer did exactly the
-same I/O work: nothing here is an artefact of a different read pattern.
+## Pass 2: it was our own compute buffer
 
-## Why — two compounding costs, both of which scale with the offload
-
-**1. The halves interleave, so the split is paid 96 times per token.** A MoE layer is
-dense → routed experts → dense → routed experts, 48 times. Putting the dense half on the GPU and
-the experts on the CPU therefore crosses the device boundary twice per layer: **98 graph splits**
-against 1 for the CPU-only graph. Every crossing copies and synchronises an activation. This is
-structural, not a tuning problem — it is what "dense on one device, experts on another" means for
-this architecture. At 12 layers the splits drop to 24 and most of the loss goes with them.
-
-**2. The GPU has no memory of its own.** This is the deeper one. On a phone the GPU shares the same
-LPDDR, so "offloading" does not relieve memory pressure — it **adds** to it. The OpenCL allocations
-(785 MiB of weights plus a **1203 MiB compute buffer**, and note that buffer is a fixed cost that
-does not shrink with `--gpu-layers`) land on top of the 2000 MiB expert cache and the mmap'd model,
-and push the system into reclaim. The result is a fault storm: **5 958 major faults per token
-against zero on the CPU run**.
-
-That zero is the point. `--dense-weights anon` exists precisely to keep the dense weights out of
-the page cache so a reclaim cannot drop them to a flash refault, and it achieves exactly that on the
-CPU path. The GPU offload reintroduces the memory war that this engine's whole dense-weight policy
-was built to end.
-
-## What the first pass got wrong — the compute buffer, not the GPU
-
-Cost 2 above is largely **self-inflicted and fixable**. The compute buffer is reserved for the
-worst-case graph, and this engine sets `n_ubatch = n_ctx` so that any fitting prompt prefills in one
-pass. That makes the reservation scale with the context, not with the offload:
+Compute buffers are reserved for the worst-case graph, and this engine set `n_ubatch = n_ctx` so any
+fitting prompt prefills in one pass. The reservation therefore scaled with the **context**, not with
+the offload:
 
 | n_ctx | OpenCL compute buffer | CPU compute buffer |
 |---|---:|---:|
 | 2048 | 1203 MiB | 320 MiB |
 | 512 | 301 MiB | 80 MiB |
 
-Exactly 4x for a 4x context — nothing to do with the GPU, which needs the same buffer per token
-either way. Re-running the offload with the smaller reservation:
+Exactly 4x for a 4x context, on both backends — nothing to do with the GPU. Re-run with the smaller
+reservation: **1.207 → 2.752 tok/s, and 5 958 → 1.06 major faults per token.**
 
-| Config | tok/s | compute s/tok | majflt/token |
-|---|---:|---:|---:|
-| `--gpu`, n_ctx 2048 | 1.207 | 0.614 | 5 958 |
-| `--gpu`, n_ctx 512 | **2.752** | 0.188 | **1.06** |
-| CPU, n_ctx 2048 | 3.175 | 0.124 | 0 |
+The fault storm was ~900 MiB of avoidable reservation pushing an already-tight system into reclaim.
+This is why `--ubatch N` now exists, and note it is not a GPU fix: 240 MiB of the CPU path's own
+reservation is equally avoidable, and on this engine every MiB reserved is a MiB the expert cache
+does not get.
 
-The fault storm was never the GPU "having no memory of its own" in any interesting sense — it was
-~900 MiB of avoidable reservation pushing an already-tight system into reclaim. With it gone the
-offload costs ~15%, not 2.6x, and what remains is cost 1: the 98 graph splits, whose per-token
-compute overhead (0.188 against 0.124) is the whole residual.
+## Pass 3: the honest sweep (n_ctx 2048, `--ubatch 256`)
 
-This is why `--ubatch N` now exists as its own knob. Note it is not a GPU fix: 240 MiB of the CPU
-path's own reservation is equally avoidable, and on this engine every MiB reserved is a MiB the
-expert cache does not get.
+Five cells, one pass, CPU first **and** last so thermal drift is bounded rather than assumed:
 
-**Owed, and the reason this is not filed as refuted:** a `--gpu-layers` sweep at a capped ubatch,
-in particular `--gpu-layers 1`. That offloads only the output head — a single large matmul at the
-end of the graph, with no expert layer after it to hand control back to — so it should cost 1-2
-splits instead of 98 while still moving real work. If the residual is entirely split cost, that is
-the configuration where the offload can win.
+| `--gpu-layers` | tok/s | graph splits | CPU occupancy | majflt/token |
+|---|---:|---:|---:|---:|
+| 0 (CPU, first) | 2.941 | 1 | 87.9% | 0 |
+| 48 (all) | 2.768 | 96 | 54.3% | 1.12 |
+| 12 | 2.866 | 24 | 62.1% | 15.36 |
+| 1 (output head only) | **3.029** | 2 | 67.9% | 17.15 |
+| 0 (CPU, last) | 2.778 | 1 | 90.4% | 0.11 |
+
+Two things to read here. **The GPU really does take work off the CPU** — occupancy falls from 88% to
+54% at full offload. And within this pass, throughput orders perfectly and inversely by split count
+(96 → 2.768, 24 → 2.866, 2 → 3.029), which is what a boundary-crossing cost looks like.
+
+The two CPU cells bound the drift: 2.941 → 2.778, i.e. **-5.5% over thirteen minutes**, so later
+cells are handicapped. Drift-corrected, `--gpu-layers 1` looked like roughly +7%.
+
+## The repeat that killed it
+
+`--gpu-layers 1` against CPU, alternating, same session:
+
+| cell | tok/s |
+|---|---:|
+| `--gpu-layers 1` | 2.934 |
+| CPU | **3.116** |
+
+The opposite ordering, by a similar margin. Across both passes `--gpu-layers 1` reads 3.029 and
+2.934 while CPU reads 2.941, 2.778 and 3.116 — the two distributions overlap completely.
+
+**So the +7% was noise.** Run-to-run variation on this device is around ±6%, which is larger than
+every GPU effect measured except the full-offload penalty. The one result that survives repetition
+is the negative one: full offload (96 splits) is consistently a little slower than CPU.
+
+The repeat was cut short at two cells — the phone entered doze and killed the run, and
+`svc power stayon true` did not prevent it. Four more cells are owed, but they would be deciding
+between "neutral" and "slightly negative", not resurrecting a win.
+
+## Why full offload loses, mechanically
+
+The dense and expert halves **interleave**: a MoE layer is dense → routed experts → dense → routed
+experts, 48 times. Splitting them across two devices therefore crosses the device boundary twice per
+layer — 96 splits against 1 — and every crossing copies and synchronises an activation. The freed
+CPU time (88% → 54% occupancy) is real; the boundary tax simply eats it.
+
+That is also why `--gpu-layers 1` is the only configuration that even gets close: the output head is
+the one dense component with no expert layer after it to hand control back to, so it costs 2 splits
+instead of 96. It is still not a win, because one matmul (243 MiB of weights) is too small a share
+of the per-token work for its saving to clear the noise.
 
 ## What the pre-measurement argument got wrong
 
 The case for this feature was: a MoE uses 100% of its dense weights every token against
 `k/n_expert` of its experts, so the dense half is ~half the per-token arithmetic, and decode is
-compute-bound. Both premises are still true — and both were irrelevant.
+compute-bound. Both premises are still true, and both were insufficient.
 
 The reasoning was about **how much work** the dense half is. It said nothing about **where that work
-sits in the graph** (interleaved with the experts, so the boundary is crossed constantly) or about
-**what the accelerator costs to feed** (physical RAM, on a device already losing a memory war). A
-byte-count argument is not a placement argument, in the same way a hit-rate curve is not a
-throughput argument.
+sits in the graph** — interleaved, so the boundary is crossed constantly. A byte-count argument is
+not a placement argument, in the same way a hit-rate curve is not a throughput argument.
 
-## What this does not settle
+## Open, and worth more than another repeat
 
-- **One device class.** An integrated mobile GPU sharing LPDDR is the worst case for both mechanisms.
-  A discrete GPU with its own VRAM inverts cost 2 entirely, and this says nothing about it.
-- **One model, one run per cell.** The gap is far larger than any plausible drift, and the
-  dose-response across 0/12/48 layers orders perfectly, but these are not repeated cells.
-- **Prefill is unmeasured.** It is compute-bound and batched, which is the regime a GPU is actually
-  good at; every number here is decode.
-- **It is not a correctness problem.** GPU output was token-identical to CPU output. The feature
-  works; it is simply not worth using here.
+- **Contiguous layer blocks.** The 96 splits are a property of *this* partition (dense-GPU /
+  experts-CPU), not of GPU offload as such. Offloading the first N layers **whole** — experts
+  included, resident rather than streamed — would put the boundary in one place: ~2 splits total.
+  llama.cpp already expresses this (a per-block regex over `blk.<il>.`), so the pin could be made
+  layer-aware rather than global. The cost is that those layers' experts stop streaming and become
+  resident: ~363 MiB per layer on this model, RAM the expert cache no longer gets. That trade is
+  untested and is the only remaining shape in which GPU offload could plausibly win here.
+- **Does a freed CPU make the cache worth more?** Full offload cuts CPU occupancy to 54% and leaves
+  decode more I/O-bound than before (compute 0.187 against flash 0.648 s/token). If compute is no
+  longer competing, cache and lane levers should buy more with the GPU on than off — i.e. the right
+  comparison is not GPU-vs-CPU at a fixed cache but the *cache curve* under each. Untested. Note the
+  GPU frees no RAM: the dense weights move from anon buffers to OpenCL buffers, both of which are
+  the same physical LPDDR (951 MiB became 726 on GPU + 214 on CPU).
+- **Prefill is unmeasured.** It is batched and compute-bound, the regime a GPU actually suits, and
+  every number here is decode.
+- **Discrete GPUs are a different question entirely.** Dedicated VRAM changes the memory story and
+  the transfer story at once; none of this transfers to a desktop.
+
+## Method notes for whoever repeats this
+
+- `--ubatch` must be capped, or the compute-buffer reservation dominates everything else.
+- One run per cell is not enough: this device's noise is ±6%, and it swallowed a 7% effect.
+- Bracket every sweep with the baseline at both ends. The drift here was -5.5% in 13 minutes.
+- The phone dozes and kills detached runs; `svc power stayon true` was not sufficient. Keep the
+  screen genuinely awake, or expect to lose the tail of a long sweep.
+- adb over Wi-Fi drops repeatedly under this load — run the sweep with `setsid` on the device and
+  write results per cell as they complete (`scripts/bench-gpu-sweep.sh`), so a dropped connection
+  costs the connection and not the data.

--- a/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
+++ b/docs/bench-data/2026-07-27-gpu-dense-offload/findings.md
@@ -1,9 +1,17 @@
 # Dense-path GPU offload — measured on device (2026-07-27)
 
 **Verdict: with the memory confound removed, GPU offload of the dense path is between neutral and
-mildly negative on a phone-class integrated GPU — and the residual differences are inside this
-device's run-to-run noise, which is ±6%. It is never a correctness problem: output is
-token-identical. It is simply not a lever here.**
+mildly negative on a phone-class integrated GPU — and on the first model the residual differences
+are inside this device's run-to-run noise, which is ±6%. It is never a correctness problem: output
+is token-identical. It is simply not a lever here.**
+
+**Update, same day: on a second model with a faster CPU baseline the sign is no longer ambiguous —
+full offload −27%, output head alone −16 to −21%, both outside the noise. See
+[Confirmation on a second model](#confirmation-on-a-second-model-neutral-becomes-negative) below.
+The wider question of whether *any* GPU placement helps decode was settled separately, and it does
+not — including holding the routed experts in device memory, which measures 0.22×. That experiment
+needs seams carried on a llama.cpp fork branch, so it lives outside this tree:
+[feat/gpu-expert-slots](https://github.com/Helldez/BigMoeOnEdge/tree/feat/gpu-expert-slots).**
 
 This file records three passes, because the first two were wrong in instructive ways and the
 corrections are the useful part.
@@ -126,6 +134,36 @@ not a placement argument, in the same way a hit-rate curve is not a throughput a
   every number here is decode.
 - **Discrete GPUs are a different question entirely.** Dedicated VRAM changes the memory story and
   the transfer story at once; none of this transfers to a desktop.
+
+## Confirmation on a second model: neutral becomes negative
+
+Repeated the same two configurations on `Qwen3.6-35B-A3B` (Q4_0, 40 layers), this time with the
+full current recipe including `--drop-cold-experts 0.75`. Palindrome order `hyb, cpu, cpu, hyb`, and
+the SoC changed clock state midway, so cells are compared **within** a clock state. Raw output in
+[qwen36-confirmation.txt](qwen36-confirmation.txt).
+
+| `--gpu-layers` | clock | tok/s | compute s/tok | majflt/token |
+|---|---|---:|---:|---:|
+| 1 (output head only) | 3.03 GHz | 5.064 | 0.141 | 7.11 |
+| **0 (CPU)** | 3.03 GHz | **6.383** | 0.098 | 0.29 |
+| **0 (CPU)** | 2.27 GHz | **5.528** | 0.131 | 0.49 |
+| 1 (output head only) | 2.27 GHz | 4.663 | 0.157 | 1.65 |
+| 48→40 (all layers) | 2.27 GHz | 4.062 | 0.192 | 9.95 |
+
+`--gpu-layers 1` is **−21%** at the high clock and **−16%** at the low one, the same sign in both
+halves of the palindrome and outside the ±6% noise. Full offload is **−27%**.
+
+This does not contradict the Qwen3-30B result above; it explains it. Both configurations measured
+neutral there, and the CPU baseline has since got faster — `--drop-cold-experts` is worth ~+18% on
+this model. A fixed cost measured against a smaller total is a larger fraction of it. The
+boundary-crossing tax did not grow; everything it is being compared against shrank.
+
+The full-offload row shows the trade in one line: the GPU really does free the CPU (occupancy 70% →
+50%, and the overlapped I/O residual improves from 0.035 to 0.030 s/token), while compute rises
+0.131 → 0.192 and ~10 major faults per token appear from the OpenCL compute buffer's memory
+pressure. The freed CPU time is real; the boundary tax eats all of it and then some.
+
+Note these are Q4_0 numbers and are **not** comparable to the Q4_K_M figures in the README tables.
 
 ## Method notes for whoever repeats this
 

--- a/docs/bench-data/2026-07-27-gpu-dense-offload/qwen36-confirmation.txt
+++ b/docs/bench-data/2026-07-27-gpu-dense-offload/qwen36-confirmation.txt
@@ -1,0 +1,60 @@
+Confirmation cells on a second model (2026-07-27), Qwen3.6-35B-A3B Q4_0, 40 layers.
+Shared settings: --moe-stream --cache-mb 2000 --io-threads 4 --overlap --dense-weights anon
+                 -c 2048 --ubatch 256 -n 96 --drop-cold-experts 0.75
+
+Palindrome order hyb, cpu, cpu, hyb, where hyb = --gpu-layers 1 --gpu-require.
+scaling_max_freq is logged per cell: the SoC changed clock state mid-sweep, so cells are
+compared WITHIN a clock state, never across it.
+
+START 21:02:19
+=== mt-hyb-210219 21:02:19 freq=3033600
+rc=0 21:03:22
+generation: 96 tokens, 0.197 s/token (5.064 tok/s)
+compute: 58.8% CPU occupancy (0.4647 cpu-s/token over 4 threads), 7.11 major faults/token
+prefill: 7 tokens, 1.836 s (3.8 tok/s) | model load 40.745 s | TTFT 42.582 s
+moe-stream: read 11802.9 MiB (122.95 MiB/token), decode 0.197 s/token (compute 0.141 + cache mgmt 0.017 + flash I/O 0.204 s/token, 602 MiB/s)
+moe-cache: 68.2% hit, resident 1998.5 MiB
+moe-overlap: stall 0.039 s/token (flash reads overlapped with FFN compute)
+moe-drop: 5920/30720 routed experts dropped (19.3%), threshold 0.75 x uniform
+=== mt-cpu-210437 21:04:37 freq=3033600
+rc=0 21:05:14
+generation: 96 tokens, 0.157 s/token (6.383 tok/s)
+compute: 79.1% CPU occupancy (0.4955 cpu-s/token over 4 threads), 0.29 major faults/token
+prefill: 7 tokens, 1.838 s (3.8 tok/s) | model load 18.841 s | TTFT 20.679 s
+moe-stream: read 11802.9 MiB (122.95 MiB/token), decode 0.157 s/token (compute 0.098 + cache mgmt 0.013 + flash I/O 0.202 s/token, 609 MiB/s)
+moe-cache: 68.2% hit, resident 1998.5 MiB
+moe-overlap: stall 0.046 s/token (flash reads overlapped with FFN compute)
+moe-drop: 5920/30720 routed experts dropped (19.3%), threshold 0.75 x uniform
+=== mt-cpu-210629 21:06:29 freq=2265600
+rc=0 21:07:16
+generation: 96 tokens, 0.181 s/token (5.528 tok/s)
+compute: 70.1% CPU occupancy (0.5069 cpu-s/token over 4 threads), 0.49 major faults/token
+prefill: 7 tokens, 1.798 s (3.9 tok/s) | model load 26.516 s | TTFT 28.313 s
+moe-stream: read 11802.9 MiB (122.95 MiB/token), decode 0.181 s/token (compute 0.131 + cache mgmt 0.015 + flash I/O 0.179 s/token, 686 MiB/s)
+moe-cache: 68.2% hit, resident 1998.5 MiB
+moe-overlap: stall 0.035 s/token (flash reads overlapped with FFN compute)
+moe-drop: 5920/30720 routed experts dropped (19.3%), threshold 0.75 x uniform
+=== mt-hyb-210831 21:08:31 freq=2265600
+rc=0 21:09:40
+generation: 96 tokens, 0.214 s/token (4.663 tok/s)
+compute: 62.4% CPU occupancy (0.5353 cpu-s/token over 4 threads), 1.65 major faults/token
+prefill: 7 tokens, 4.872 s (1.4 tok/s) | model load 42.541 s | TTFT 47.413 s
+moe-stream: read 11802.9 MiB (122.95 MiB/token), decode 0.214 s/token (compute 0.157 + cache mgmt 0.020 + flash I/O 0.211 s/token, 582 MiB/s)
+moe-cache: 68.2% hit, resident 1998.5 MiB
+moe-overlap: stall 0.038 s/token (flash reads overlapped with FFN compute)
+moe-drop: 5920/30720 routed experts dropped (19.3%), threshold 0.75 x uniform
+ALLDONE 21:10:55
+
+Full dense offload (--gpu-require, all 40 layers), same settings, 2265600 kHz state.
+Compare against the mt-cpu-210629 cell above.
+
+=== dense-gpu 21:14:05 freq=2265600
+rc=0
+generation: 96 tokens, 0.246 s/token (4.062 tok/s)
+compute: 49.5% CPU occupancy (0.4875 cpu-s/token over 4 threads), 9.95 major faults/token
+prefill: 7 tokens, 1.690 s (4.1 tok/s) | model load 51.588 s | TTFT 53.278 s
+moe-stream: read 12320.2 MiB (128.34 MiB/token), decode 0.246 s/token (compute 0.192 + cache mgmt 0.024 + flash I/O 0.208 s/token, 618 MiB/s)
+moe-cache: 67.0% hit, resident 1998.3 MiB
+moe-overlap: stall 0.030 s/token (flash reads overlapped with FFN compute)
+moe-drop: 5956/30720 routed experts dropped (19.4%), threshold 0.75 x uniform
+ALLDONE freq=2265600

--- a/docs/gpu-offload.md
+++ b/docs/gpu-offload.md
@@ -90,6 +90,38 @@ behind it — everything links, nothing crashes, no GPU is ever found.
 Host builds take `-DBMOE_OPENCL=ON` the same way; `scripts/build-host.sh` and CI pass no GGML flags,
 so the default host build and the byte-identity gates are untouched.
 
+### The Android linker step everyone hits
+
+OpenCL is **not** an NDK library, and an Android app cannot load `/vendor/lib64/libOpenCL.so`
+just because the file exists. Without the right declaration the dynamic linker fails the process
+before `main` in one of two ways, both confusing:
+
+```
+library "libOpenCL.so" not found: needed by libggml-opencl.so in namespace (default)
+cannot locate symbol "_ZN7android15PermissionCache15checkPermission..." referenced by libgui.so
+```
+
+The second one appears when `LD_LIBRARY_PATH` is widened to `/vendor/lib64:/system/lib64` to get
+past the first: the loader then pulls the Adreno driver's own graphics dependencies into the app's
+namespace, where they cannot resolve. Widening the path further does not fix it, and neither does
+`LD_PRELOAD` — it is a namespace problem, not a search-path one.
+
+The actual fix is one manifest line (already in the example app):
+
+```xml
+<uses-native-library android:name="libOpenCL.so" android:required="false" />
+```
+
+This works only if the driver is listed in the device's `/vendor/etc/public.libraries.txt`, which is
+what makes a vendor library loadable by apps at all. Check before assuming:
+
+```
+adb shell cat /vendor/etc/public.libraries.txt | grep -i opencl
+```
+
+`required="false"` keeps the app installable on devices without it. Note the declaration is what
+lets the app's spawned `bmoe-cli` link — the engine runs as a subprocess of the app, not via JNI.
+
 ## Reading what happened
 
 Never trust the request — read the resolution:

--- a/docs/gpu-offload.md
+++ b/docs/gpu-offload.md
@@ -136,45 +136,71 @@ One caveat for benchmarking: an OpenCL-enabled binary registers and initialises 
 startup whether or not the toggle is on, so it carries a fixed init cost the default build does not.
 Compare toggle-on against toggle-off **on the same binary**, not against a CPU-only build.
 
-## Status: measured, currently behind the CPU, not yet settled
+## Status: measured — between neutral and mildly negative, and inside the noise
 
-Full numbers and method:
+Full numbers, the two wrong turns that preceded them, and method notes:
 [bench-data/2026-07-27-gpu-dense-offload](bench-data/2026-07-27-gpu-dense-offload/findings.md).
 
-| Config | tok/s | compute s/tok | majflt/token | graph splits |
-|---|---:|---:|---:|---:|
-| CPU | 3.175 | 0.124 | 0 | 1 |
-| `--gpu`, full context ubatch | 1.207 | 0.614 | 5 958 | 98 |
-| `--gpu`, capped ubatch | **2.752** | 0.188 | **1.06** | 98 |
+At `--ubatch 256`, `Qwen3-30B-A3B`, cache 2000, one pass with CPU first and last:
 
-It is never a correctness problem — GPU output was token-identical to CPU output, which is the
-losslessness claim holding.
+| `--gpu-layers` | tok/s | graph splits | CPU occupancy |
+|---|---:|---:|---:|
+| 0 (CPU) | 2.941 … 2.778 | 1 | 88 → 90% |
+| 48 (all) | 2.768 | 96 | **54%** |
+| 12 | 2.866 | 24 | 62% |
+| 1 (output head) | 3.029 | 2 | 68% |
 
-**The first measured verdict was wrong about why.** It read as "2.6x slower, because the GPU shares
-the same LPDDR and adds memory pressure". Most of that pressure was self-inflicted: compute buffers
-are reserved for the worst-case graph, and this engine sets `n_ubatch = n_ctx` so any fitting prompt
-prefills in one pass. That reservation scales with the **context**, not with the offload — 1203 MiB
-at n_ctx 2048 against 301 MiB at 512, the same 4x the CPU path shows (320 → 80 MiB). Capping it took
-the offload from 1.207 to 2.752 tok/s and the fault storm from 5 958 to 1.06 per token. Hence
-`--ubatch N`, which is not a GPU fix — the CPU path is reserving 240 avoidable MiB of its own, and
-on this engine every MiB reserved is a MiB the expert cache does not get.
+**The GPU genuinely takes work off the CPU** — occupancy drops from 88% to 54% at full offload — and
+within a single pass throughput orders perfectly and inversely by split count. But the device's
+run-to-run noise is **±6%**, and a repeat of the best-looking cell reversed its sign (`--gpu-layers 1`
+at 2.934 against a CPU cell at 3.116). Only the negative survives repetition: full offload is
+consistently a little slower than CPU. Treat this as a lever that does not exist here, not as one
+worth tuning.
 
-What remains is one cost, and it is the structural one: **the halves interleave.** A MoE layer is
-dense → experts → dense → experts, 48 times, so splitting them across two devices crosses the
-boundary twice per layer — 98 graph splits against 1 — and every crossing copies and synchronises an
-activation. That is the whole residual gap (compute 0.188 against 0.124).
+It is never a correctness problem — output is token-identical, which is the losslessness claim
+holding.
 
-**Owed before this can be called either way:** a `--gpu-layers` sweep at a capped ubatch, above all
-`--gpu-layers 1`. That offloads only the output head — one large matmul at the end of the graph,
-with no expert layer after it to hand control back to — so it should pay 1-2 splits instead of 98
-while still moving real work off the CPU. If the residual really is all split cost, that is where
-the offload can win.
+### Why: the halves interleave
 
-Also still open: a discrete GPU with its own VRAM changes the memory story completely, so none of
-this transfers to a desktop; and prefill — batched and compute-bound, the regime a GPU actually
-suits — is unmeasured, since every number here is decode.
+A MoE layer is dense → routed experts → dense → routed experts, 48 times. Splitting those across two
+devices crosses the boundary **twice per layer** — 96 graph splits against 1 — and every crossing
+copies and synchronises an activation. The freed CPU time is real; the boundary tax eats it. That is
+also why `--gpu-layers 1` comes closest: the output head is the one dense component with no expert
+layer after it, so it costs 2 splits rather than 96 — but one matmul is too small a share of the
+per-token work for its saving to clear the noise.
 
-The pre-measurement argument for the feature (the dense half is ~half the per-token arithmetic, and
-decode is compute-bound) remains true and remains insufficient: it was about *how much work* the
-dense half is, and said nothing about *where that work sits in the graph*. A byte-count argument is
-not a placement argument.
+### The first two verdicts were wrong, in useful ways
+
+The initial reading was "2.6x slower, because the GPU shares the same LPDDR and adds memory
+pressure". Most of that pressure was self-inflicted: compute buffers are reserved for the worst-case
+graph, and this engine set `n_ubatch = n_ctx` so any fitting prompt prefills in one pass. The
+reservation therefore scaled with the **context**, not the offload — 1203 MiB at n_ctx 2048 against
+301 MiB at 512, the same 4x the CPU path shows (320 → 80 MiB). Capping it moved the offload from
+1.207 to 2.752 tok/s and major faults from 5 958 to 1.06. Hence `--ubatch N`, which is not a GPU fix
+at all: the CPU path reserves 240 avoidable MiB of its own.
+
+The second reading was "`--gpu-layers 1` wins by ~7%". It did not replicate. One run per cell was
+not enough against ±6% noise.
+
+The *pre*-measurement argument (the dense half is ~half the per-token arithmetic, and decode is
+compute-bound) remains true and remains insufficient: it was about *how much work* the dense half
+is, and said nothing about *where that work sits in the graph*. A byte-count argument is not a
+placement argument.
+
+### What could still change the answer
+
+- **Contiguous layer blocks.** 96 splits is a property of *this* partition, not of offload as such.
+  Offloading the first N layers **whole** — experts included, resident rather than streamed — puts
+  the boundary in one place (~2 splits). llama.cpp already expresses per-block placement with a
+  regex over `blk.<il>.`, so the CPU pin could be made layer-aware instead of global. The cost is
+  that those layers stop streaming: ~363 MiB of resident experts per layer on this model, RAM the
+  expert cache no longer gets. Untested, and the only remaining shape in which this could win here.
+- **The cache curve, not a single point.** Full offload leaves decode more I/O-bound than before
+  (compute 0.187 against flash 0.648 s/token), so cache and lane levers should buy *more* with the
+  GPU on. The right experiment is the cache sweep under each backend, not GPU-vs-CPU at one budget.
+  Note the GPU frees no RAM — the dense weights move from anon buffers to OpenCL buffers, both the
+  same physical LPDDR.
+- **Prefill**, which is batched and compute-bound — the regime a GPU actually suits. Every number
+  here is decode.
+- **Discrete GPUs**, where dedicated VRAM changes the memory and transfer stories at once. None of
+  this transfers to a desktop.

--- a/docs/gpu-offload.md
+++ b/docs/gpu-offload.md
@@ -1,0 +1,116 @@
+# GPU offload of the dense path
+
+`--gpu` runs the **non-expert** half of the model on a GPU. The routed experts always stay on the
+CPU. That split is not a tuning choice, and this document is mostly about why.
+
+## Why the experts can never move
+
+The streamer works by rebinding an expert tensor's `->data` to a host buffer it refills from flash
+before every token (see [seam.md](seam.md)). This works because the CPU backend reads that pointer
+at graph-execution time, so bytes written between the routing node and the `MUL_MAT_ID` node are
+the bytes the kernel multiplies.
+
+No GPU backend behaves that way. ggml's OpenCL backend reads `tensor->data` exactly once, in
+`init_tensor` at load, and thereafter dispatches against `cl_mem` handles cached in `tensor->extra`;
+the pointer it read is not even a real address, just an offset base. There is no zero-copy path —
+no `CL_MEM_USE_HOST_PTR`, no SVM, no dma-buf import — so a weight in device memory is a *copy* made
+once at load. A streamed expert placed there would silently compute whatever the warm-up decode
+left behind, forever.
+
+The deeper reason survives any future backend that fixed the pointer question: the upload-once model
+assumes the weights fit. A 22 GB model on a 12 GB phone is the case this engine exists for.
+
+## Why the dense half is worth moving anyway
+
+A MoE uses **100% of its dense weights on every token** but only `k / n_expert` of its expert
+weights. That puts the two halves in the same order of magnitude:
+
+| Model | dense weights | expert bytes touched per token |
+|---|---:|---:|
+| Qwen3-30B-A3B (128 experts, top-8) | 951 MiB | ~1.10 GiB |
+| Qwen3.6-35B-A3B (256 experts, top-8) | ~1 GiB | ~0.67 GiB |
+
+(The dense figure is the engine's own `dense-weights=anon — N MiB` line, i.e. every non-expert
+tensor in the file.)
+
+So the dense side is roughly half the per-token GEMV work — and decode on this engine is
+compute-bound once the I/O levers are in: on Qwen3.6 with cache 3000, `ahwb` and drop-cold, a token
+spends ~194 ms computing against ~41 ms stalled on flash. Moving half the arithmetic off four phone
+cores is the largest remaining lever that costs no quality.
+
+**It is lossless.** Placement changes where a matmul runs, not what the model is. Unlike
+`--n-expert-used` or `--drop-cold-experts`, nothing is skipped. (Floating-point reassociation on a
+different backend can still move the last bits of a logit; the byte-identity gates run on the CPU
+and are not a claim about cross-backend determinism.)
+
+## How it is arranged
+
+Two things, set together in `session.cpp` before the load:
+
+1. `llama_model_params::devices` gets the discovered GPU, and `n_gpu_layers` says how much to
+   offload (`-1`, the default, means every layer).
+2. `tensor_buft_overrides` pins the expert tensors to the CPU buffer type. llama.cpp resolves a
+   matching override **before** it consults the layer's assigned device, so an expert stays in host
+   memory even in a layer that was handed to the GPU.
+
+The pin pattern is **derived from the architecture recipe**, not written out:
+`expert_tensor_pattern()` turns a recipe's suffix table into `\.(ffn_gate_exps|ffn_up_exps|...)\.`.
+A recipe row added for a new MoE family therefore pins its own experts with nothing else to update.
+It deliberately also matches the per-expert companions (`ffn_down_exps.scale`), which the streamer
+itself excludes: the streamer asks "do I read this from flash?", placement asks "which device
+computes with this?", and the answers differ.
+
+Device discovery (`core/src/engine/gpu_device.h`) goes through the ggml backend registry and names
+no vendor or API. A build with no GPU backend and a device with no driver produce the same result —
+no device found — and the engine falls back to the CPU with a note. `--gpu-require` turns that
+fallback into a failure, which is what a benchmark wants: an A/B that silently compares CPU against
+CPU is worse than one that refuses to start.
+
+`--dense-weights anon|ahwb` and this are not in conflict but they do overlap: tensors the GPU took
+are skipped by the rebind (they are not under host-memory reclaim pressure any more), and the
+engine reports how many it left alone.
+
+## Building it
+
+Off by default. Enabling the OpenCL backend makes `libOpenCL.so` a hard load-time dependency, so
+the binary **will not start** on a device without an OpenCL driver — while the default build runs
+everywhere. The engine's own GPU support is runtime-probed and degrades cleanly, but that probe
+never runs if the process cannot load.
+
+```powershell
+pwsh scripts/fetch-opencl-android.ps1      # Khronos headers + an ICD loader to link against
+pwsh scripts/build-android.ps1 -OpenCL     # stages libggml-opencl.so into the app
+```
+
+The loader built by the first script is a **link stub only** and is not shipped: at runtime
+`libOpenCL.so` resolves to the device's own driver in `/vendor/lib64`, which the app already has on
+`LD_LIBRARY_PATH`. Shipping the Khronos loader would outrank the vendor driver and then find no ICD
+behind it — everything links, nothing crashes, no GPU is ever found.
+
+Host builds take `-DBMOE_OPENCL=ON` the same way; `scripts/build-host.sh` and CI pass no GGML flags,
+so the default host build and the byte-identity gates are untouched.
+
+## Reading what happened
+
+Never trust the request — read the resolution:
+
+- `BMOE_READY` carries `"gpu":"<device>"`, empty when the dense path ran on the CPU.
+- The CSV preamble carries `gpu=<device>` or `gpu=cpu`, so a bench cell cannot be mistaken for a GPU
+  cell it silently was not.
+- The app's **Dense weights on GPU** setting shows the resolved device, and warns when a session
+  asked for the GPU and got the CPU.
+
+One caveat for benchmarking: an OpenCL-enabled binary registers and initialises the backend at
+startup whether or not the toggle is on, so it carries a fixed init cost the default build does not.
+Compare toggle-on against toggle-off **on the same binary**, not against a CPU-only build.
+
+## Status
+
+Implemented and gated; **not yet measured on device**. The prize argued above is an inference from
+the byte split and the compute/stall attribution, not a number anyone has run. Two things worth
+checking first, because either could sink it:
+
+- decode is batch-1, i.e. GEMV, which is memory-bound — a GPU's advantage there is bandwidth, not
+  FLOPs, and it shares the same LPDDR;
+- Adreno's `CL_DEVICE_MAX_MEM_ALLOC_SIZE` may sit below the dense footprint, in which case
+  `--gpu-layers N` (offload the last N only) is the knob.

--- a/docs/gpu-offload.md
+++ b/docs/gpu-offload.md
@@ -136,31 +136,45 @@ One caveat for benchmarking: an OpenCL-enabled binary registers and initialises 
 startup whether or not the toggle is on, so it carries a fixed init cost the default build does not.
 Compare toggle-on against toggle-off **on the same binary**, not against a CPU-only build.
 
-## Status: measured, and it loses
+## Status: measured, currently behind the CPU, not yet settled
 
-**On a phone-class integrated GPU this is 2.6x SLOWER than the CPU**, and it degrades monotonically
-with how much is offloaded — 3.175 tok/s on the CPU, 2.985 at `--gpu-layers 12`, 1.207 with the
-whole dense path offloaded. Full numbers and method:
+Full numbers and method:
 [bench-data/2026-07-27-gpu-dense-offload](bench-data/2026-07-27-gpu-dense-offload/findings.md).
 
-It is not a correctness problem — the GPU run's output was token-identical to the CPU run's, which
-is the losslessness claim holding. It is simply not worth using on this class of device. Two costs
-compound, and both scale with the offload:
+| Config | tok/s | compute s/tok | majflt/token | graph splits |
+|---|---:|---:|---:|---:|
+| CPU | 3.175 | 0.124 | 0 | 1 |
+| `--gpu`, full context ubatch | 1.207 | 0.614 | 5 958 | 98 |
+| `--gpu`, capped ubatch | **2.752** | 0.188 | **1.06** | 98 |
 
-1. **The halves interleave.** A MoE layer is dense → experts → dense → experts, 48 times, so putting
-   the two halves on two devices crosses the boundary twice per layer: 98 graph splits against 1.
-   Every crossing copies and synchronises an activation.
-2. **The GPU has no memory of its own.** It shares the same LPDDR, so offloading does not relieve
-   memory pressure, it adds to it — 785 MiB of weights plus a fixed 1203 MiB compute buffer, on top
-   of the expert cache and the mmap'd model. That pushes the system into reclaim: **5 958 major
-   faults per token against zero on the CPU run**, reintroducing exactly the memory war that
-   `--dense-weights anon` exists to end.
+It is never a correctness problem — GPU output was token-identical to CPU output, which is the
+losslessness claim holding.
 
-The argument this feature was built on — the dense half is ~half the per-token arithmetic, and
-decode is compute-bound — is still true and turned out to be irrelevant. It was about *how much
-work* the dense half is, and said nothing about *where that work sits in the graph* or *what the
-accelerator costs to feed*. A byte-count argument is not a placement argument.
+**The first measured verdict was wrong about why.** It read as "2.6x slower, because the GPU shares
+the same LPDDR and adds memory pressure". Most of that pressure was self-inflicted: compute buffers
+are reserved for the worst-case graph, and this engine sets `n_ubatch = n_ctx` so any fitting prompt
+prefills in one pass. That reservation scales with the **context**, not with the offload — 1203 MiB
+at n_ctx 2048 against 301 MiB at 512, the same 4x the CPU path shows (320 → 80 MiB). Capping it took
+the offload from 1.207 to 2.752 tok/s and the fault storm from 5 958 to 1.06 per token. Hence
+`--ubatch N`, which is not a GPU fix — the CPU path is reserving 240 avoidable MiB of its own, and
+on this engine every MiB reserved is a MiB the expert cache does not get.
 
-What that leaves open: a discrete GPU with its own VRAM removes cost 2 entirely, so none of this
-transfers to a desktop; and prefill — batched and compute-bound, the regime a GPU is actually good
-at — is unmeasured, since every number here is decode.
+What remains is one cost, and it is the structural one: **the halves interleave.** A MoE layer is
+dense → experts → dense → experts, 48 times, so splitting them across two devices crosses the
+boundary twice per layer — 98 graph splits against 1 — and every crossing copies and synchronises an
+activation. That is the whole residual gap (compute 0.188 against 0.124).
+
+**Owed before this can be called either way:** a `--gpu-layers` sweep at a capped ubatch, above all
+`--gpu-layers 1`. That offloads only the output head — one large matmul at the end of the graph,
+with no expert layer after it to hand control back to — so it should pay 1-2 splits instead of 98
+while still moving real work off the CPU. If the residual really is all split cost, that is where
+the offload can win.
+
+Also still open: a discrete GPU with its own VRAM changes the memory story completely, so none of
+this transfers to a desktop; and prefill — batched and compute-bound, the regime a GPU actually
+suits — is unmeasured, since every number here is decode.
+
+The pre-measurement argument for the feature (the dense half is ~half the per-token arithmetic, and
+decode is compute-bound) remains true and remains insufficient: it was about *how much work* the
+dense half is, and said nothing about *where that work sits in the graph*. A byte-count argument is
+not a placement argument.

--- a/docs/gpu-offload.md
+++ b/docs/gpu-offload.md
@@ -136,7 +136,7 @@ One caveat for benchmarking: an OpenCL-enabled binary registers and initialises 
 startup whether or not the toggle is on, so it carries a fixed init cost the default build does not.
 Compare toggle-on against toggle-off **on the same binary**, not against a CPU-only build.
 
-## Status: measured — between neutral and mildly negative, and inside the noise
+## Status: measured — a lever that does not exist on this class of device
 
 Full numbers, the two wrong turns that preceded them, and method notes:
 [bench-data/2026-07-27-gpu-dense-offload](bench-data/2026-07-27-gpu-dense-offload/findings.md).
@@ -157,8 +157,24 @@ at 2.934 against a CPU cell at 3.116). Only the negative survives repetition: fu
 consistently a little slower than CPU. Treat this as a lever that does not exist here, not as one
 worth tuning.
 
+Repeated later the same day on `Qwen3.6-35B-A3B` (Q4_0, 40 layers) with the current recipe including
+`--drop-cold-experts`, as a palindrome, the ambiguity is gone: full offload **−27%**, output head
+alone **−16 to −21%**, both outside the noise and consistent in both halves. That is not a
+contradiction — the CPU baseline got faster (drop-cold is worth ~+18% on this model), so the same
+fixed boundary cost is now a larger share of a smaller total.
+
 It is never a correctness problem — output is token-identical, which is the losslessness claim
 holding.
+
+Nor is the answer different for the routed experts. Holding them in device memory as a
+flash-filled residency pool measures **0.22×**, and even a model held entirely resident with nothing
+streamed measures ~0.79×. The mechanism is the same underneath every placement: batch-1 decode is
+bandwidth-bound matrix-vector work, and an integrated GPU shares the CPU's memory. That experiment
+needs seams carried on a llama.cpp fork branch and therefore lives outside this tree, at
+[feat/gpu-expert-slots](https://github.com/Helldez/BigMoeOnEdge/tree/feat/gpu-expert-slots).
+
+**What is still open is prefill.** It is batched and compute-bound, the regime a GPU suits, and an
+independent measurement on this device puts GPU prefill at ~2.3×. Every number above is decode.
 
 ### Why: the halves interleave
 

--- a/docs/gpu-offload.md
+++ b/docs/gpu-offload.md
@@ -136,13 +136,31 @@ One caveat for benchmarking: an OpenCL-enabled binary registers and initialises 
 startup whether or not the toggle is on, so it carries a fixed init cost the default build does not.
 Compare toggle-on against toggle-off **on the same binary**, not against a CPU-only build.
 
-## Status
+## Status: measured, and it loses
 
-Implemented and gated; **not yet measured on device**. The prize argued above is an inference from
-the byte split and the compute/stall attribution, not a number anyone has run. Two things worth
-checking first, because either could sink it:
+**On a phone-class integrated GPU this is 2.6x SLOWER than the CPU**, and it degrades monotonically
+with how much is offloaded — 3.175 tok/s on the CPU, 2.985 at `--gpu-layers 12`, 1.207 with the
+whole dense path offloaded. Full numbers and method:
+[bench-data/2026-07-27-gpu-dense-offload](bench-data/2026-07-27-gpu-dense-offload/findings.md).
 
-- decode is batch-1, i.e. GEMV, which is memory-bound — a GPU's advantage there is bandwidth, not
-  FLOPs, and it shares the same LPDDR;
-- Adreno's `CL_DEVICE_MAX_MEM_ALLOC_SIZE` may sit below the dense footprint, in which case
-  `--gpu-layers N` (offload the last N only) is the knob.
+It is not a correctness problem — the GPU run's output was token-identical to the CPU run's, which
+is the losslessness claim holding. It is simply not worth using on this class of device. Two costs
+compound, and both scale with the offload:
+
+1. **The halves interleave.** A MoE layer is dense → experts → dense → experts, 48 times, so putting
+   the two halves on two devices crosses the boundary twice per layer: 98 graph splits against 1.
+   Every crossing copies and synchronises an activation.
+2. **The GPU has no memory of its own.** It shares the same LPDDR, so offloading does not relieve
+   memory pressure, it adds to it — 785 MiB of weights plus a fixed 1203 MiB compute buffer, on top
+   of the expert cache and the mmap'd model. That pushes the system into reclaim: **5 958 major
+   faults per token against zero on the CPU run**, reintroducing exactly the memory war that
+   `--dense-weights anon` exists to end.
+
+The argument this feature was built on — the dense half is ~half the per-token arithmetic, and
+decode is compute-bound — is still true and turned out to be irrelevant. It was about *how much
+work* the dense half is, and said nothing about *where that work sits in the graph* or *what the
+accelerator costs to feed*. A byte-count argument is not a placement argument.
+
+What that leaves open: a discrete GPU with its own VRAM removes cost 2 entirely, so none of this
+transfers to a desktop; and prefill — batched and compute-bound, the regime a GPU is actually good
+at — is unmeasured, since every number here is decode.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -31,6 +31,11 @@ serial path, and only a single ~25-line hook (with an explicit sunset) for the o
   never re-reads the pointer afterwards. The **dense** half can be offloaded (`--gpu`, see
   [gpu-offload.md](gpu-offload.md)), and on a MoE that is roughly half the per-token arithmetic,
   because 100% of the dense weights are used every token against `k/n_expert` of the experts.
+  Measured, that offload does not pay on an integrated mobile GPU — and neither does any other
+  placement, including one that does move the experts into device memory by rebinding their
+  *contents* rather than a pointer. Decode is bandwidth-bound matrix-vector work and an integrated
+  GPU shares the CPU's memory. So this limitation is best read as a property of the hardware class,
+  not only of the rebind.
 - **Shared experts stay resident.** Architectures with an always-on shared expert (e.g.
   `gemma4`) stream the routed experts but keep the shared expert — and any dense layers —
   resident (in the page cache, or in the engine's own buffers under `--dense-weights anon`),

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -26,9 +26,11 @@ serial path, and only a single ~25-line hook (with an explicit sunset) for the o
 - **n=1 only.** The expert sparsity exists only for single-token decode, so streaming is
   incompatible with speculative decoding or batching. Prefill streams the union of the
   prompt's routed experts (still far below the full bank, but larger than one token's).
-- **CPU experts.** Streamed experts are computed on CPU; the rebind targets host memory.
-  GPU offload of the streamed experts is not supported (the dense parts can still use the
-  GPU). Decode is flash-I/O-bound anyway, so this is rarely the bottleneck.
+- **CPU experts.** Streamed experts are computed on CPU, and structurally must be: the rebind
+  targets host memory, while a GPU backend copies weights into device memory once at load and
+  never re-reads the pointer afterwards. The **dense** half can be offloaded (`--gpu`, see
+  [gpu-offload.md](gpu-offload.md)), and on a MoE that is roughly half the per-token arithmetic,
+  because 100% of the dense weights are used every token against `k/n_expert` of the experts.
 - **Shared experts stay resident.** Architectures with an always-on shared expert (e.g.
   `gemma4`) stream the routed experts but keep the shared expert — and any dense layers —
   resident (in the page cache, or in the engine's own buffers under `--dense-weights anon`),

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -279,7 +279,8 @@ Responses (stdout):
 
 ```
 BMOE_READY {"load_s":<float>,"arch":"<string>","n_ctx":<int>,
-            "think_ctl":"template|prefill|none","n_expert_used":<int>}  # once, after the model loads
+            "think_ctl":"template|prefill|none","n_expert_used":<int>,
+            "gpu":"<device>"}                                          # once, after the model loads
 BMOE_BEGIN {"id":<int>}                                                # a generation started
 BMOE_LOAD / BMOE_PROGRESS ...                                          # per token, as above
 BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -102,10 +102,14 @@ every streaming setting — the two halves of the model do not overlap — and i
 it changes where the arithmetic runs, not what is computed. Roughly half the per-token work moves,
 because a MoE uses all of its dense weights on every token but only `k/n_expert` of its experts.
 
-Two things to know before reading a result from it. It needs a GPU-enabled build
-(`pwsh scripts/build-android.ps1 -OpenCL`, after `pwsh scripts/fetch-opencl-android.ps1`) **and** a
-device with an OpenCL driver; the setting reports the device it actually got and warns when a
-session asked for the GPU and fell back to the CPU, so trust that line rather than the switch. And
-it is **not yet measured** — see `../../docs/gpu-offload.md` for what is argued versus what is
-known, including why the batch-1 decode case may not favour a GPU as much as the byte split
-suggests.
+It needs a GPU-enabled build (`pwsh scripts/build-android.ps1 -OpenCL`, after
+`pwsh scripts/fetch-opencl-android.ps1`) **and** a device with an OpenCL driver; the setting reports
+the device it actually got and warns when a session asked for the GPU and fell back to the CPU, so
+trust that line rather than the switch.
+
+**Measured on a phone, it is 2.6x slower than leaving everything on the CPU**, so the toggle exists
+to reproduce that result rather than because it is recommended. The GPU shares the same memory, so
+its allocations add to the memory pressure this engine already fights (5 958 major faults per token
+against zero), and the dense and expert halves interleave at every layer, so a two-device split
+crosses the boundary twice per layer. Output is unaffected — it is slower, not wrong. See
+`../../docs/gpu-offload.md`.

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -94,3 +94,18 @@ expert cache at 4000 MiB, 4 I/O lanes and 4 compute threads, decode settles arou
 sweep point from the benchmark protocol, not the app default: the app ships a fixed 2000 MiB
 expert cache. See `../../docs/benchmark-method.md` for the full procedure and the cache/thread
 sweep.
+
+The Compute section also exposes **Dense weights on GPU** (experimental, off by default), which
+maps to the engine's `--gpu`: attention, norms and the output head run on the GPU while the routed
+experts stay on the CPU, where the streamer refills their memory every token. It combines with
+every streaming setting — the two halves of the model do not overlap — and is **lossless**, since
+it changes where the arithmetic runs, not what is computed. Roughly half the per-token work moves,
+because a MoE uses all of its dense weights on every token but only `k/n_expert` of its experts.
+
+Two things to know before reading a result from it. It needs a GPU-enabled build
+(`pwsh scripts/build-android.ps1 -OpenCL`, after `pwsh scripts/fetch-opencl-android.ps1`) **and** a
+device with an OpenCL driver; the setting reports the device it actually got and warns when a
+session asked for the GPU and fell back to the CPU, so trust that line rather than the switch. And
+it is **not yet measured** — see `../../docs/gpu-offload.md` for what is argued versus what is
+known, including why the batch-1 decode case may not favour a GPU as much as the byte split
+suggests.

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -107,9 +107,9 @@ It needs a GPU-enabled build (`pwsh scripts/build-android.ps1 -OpenCL`, after
 the device it actually got and warns when a session asked for the GPU and fell back to the CPU, so
 trust that line rather than the switch.
 
-**Measured on a phone, it is 2.6x slower than leaving everything on the CPU**, so the toggle exists
-to reproduce that result rather than because it is recommended. The GPU shares the same memory, so
-its allocations add to the memory pressure this engine already fights (5 958 major faults per token
-against zero), and the dense and expert halves interleave at every layer, so a two-device split
-crosses the boundary twice per layer. Output is unaffected — it is slower, not wrong. See
-`../../docs/gpu-offload.md`.
+**Measured on a phone it does not pay**: between neutral and slightly behind the CPU, with the
+differences inside the device's own ±6% run-to-run noise. The GPU does take real work off the CPU
+(occupancy falls from 88% to 54%), but the dense and expert halves interleave at every layer, so a
+two-device split crosses the boundary twice per layer — 96 graph splits against 1 — and the boundary
+tax eats the saving. The toggle exists so the result can be reproduced, not because it is
+recommended. Output is unaffected: it is not faster, not wrong. See `../../docs/gpu-offload.md`.

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,12 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BigMoeOnEdge">
 
+        <!-- The GPU build's OpenCL backend needs the vendor driver, which is not an NDK library.
+             It IS listed in the device's /vendor/etc/public.libraries.txt on GPUs that expose it,
+             and this is the declaration that puts such a library in the app's linker namespace.
+             required=false so the app still installs and runs on devices without it. -->
+        <uses-native-library android:name="libOpenCL.so" android:required="false" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -38,6 +38,12 @@ data class AppSettings(
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
     val dropColdPct: Int = 75,
+    // Run the dense (non-expert) half of the model on the GPU. The routed experts always stay on
+    // the CPU — the streamer refills their memory every token and no GPU backend re-reads a host
+    // pointer — so this is orthogonal to every streaming setting above and safe to combine with
+    // all of them. Off by default: it needs an OpenCL-enabled build AND a device with a driver,
+    // and the engine reports what it actually got rather than what was asked for.
+    val gpuDense: Boolean = false,
     val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
     val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
 ) {
@@ -99,6 +105,11 @@ data class AppSettings(
             // of the uniform share; the setting is stored as a percentage.
             if (dropColdPct > 0 && cacheOn) a += listOf("--drop-cold-experts", (dropColdPct / 100.0).toString())
         }
+        // Outside the mmap gate: the GPU takes the dense weights, which exist in both modes and
+        // are exactly the half the streamer never touches. Not --gpu-require: on a build or a
+        // device without a GPU the engine falls back to the CPU and says so in BMOE_READY, which
+        // is what an app should do — refusing to start would strand the user with no way back.
+        if (gpuDense) a += "--gpu"
         return a
     }
 
@@ -110,7 +121,7 @@ data class AppSettings(
      */
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, oDirect,
-               overlap, denseWeights, prefetchLayers, dropColdPct)
+               overlap, denseWeights, prefetchLayers, dropColdPct, gpuDense)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -124,6 +135,7 @@ data class AppSettings(
             .putString("denseWeights", denseWeights.name)
             .putInt("prefetchLayers", prefetchLayers)
             .putInt("dropColdPct", dropColdPct)
+            .putBoolean("gpuDense", gpuDense)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
             .apply()
@@ -221,6 +233,7 @@ data class AppSettings(
                 },
                 prefetchLayers = p.getInt("prefetchLayers", d.prefetchLayers),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
+                gpuDense = p.getBoolean("gpuDense", d.gpuDense),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunBus.kt
@@ -39,6 +39,10 @@ data class UiState(
     // 0 = not MoE. Settings needs it because "Drop cold experts" is a fraction of 1/top-k, so the
     // same percentage means something very different on a narrow routing.
     val nExpertUsed: Int? = null,
+    // The GPU device the dense path actually landed on, from BMOE_READY. Empty means it ran on the
+    // CPU — either the setting was off, or this build/device has no GPU and the engine fell back.
+    // Settings shows this instead of echoing the switch, so a fallback cannot read as a success.
+    val gpuDevice: String? = null,
     val transcript: List<ChatTurn> = emptyList(), // committed turns; the in-flight answer is `answer`
     val streaming: Boolean = true,  // is the loaded session using the MoE streamer (vs mmap baseline)?
 ) {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -115,7 +115,8 @@ class RunService : Service() {
             // thinkControl is a property of the model being loaded, so it goes the same way — the
             // incoming session reports its own at BMOE_READY.
             it.copy(state = EngineState.LOADING, error = null, sessionSig = sig, answer = "", summary = "",
-                transcript = emptyList(), streaming = streaming, ioMode = null, thinkControl = null)
+                transcript = emptyList(), streaming = streaming, ioMode = null, thinkControl = null,
+                gpuDevice = null)
         }
 
         thread(name = "bmoe-session") { runSession(argv, model, myEpoch, dying) }
@@ -203,7 +204,12 @@ class RunService : Service() {
             t.startsWith("BMOE_READY ") -> {
                 val ctl = Regex(""""think_ctl":"([a-z_]+)"""").find(t)?.groupValues?.get(1)
                 val topk = Regex(""""n_expert_used":(\d+)""").find(t)?.groupValues?.get(1)?.toIntOrNull()
-                RunBus.update { it.copy(state = EngineState.READY, thinkControl = ctl, nExpertUsed = topk) }
+                // Resolved, not requested: empty when the dense path ran on the CPU. Older engines
+                // omit the field entirely, which reads the same as "no GPU" — the correct fallback.
+                val gpu = Regex(""""gpu":"([^"]*)"""").find(t)?.groupValues?.get(1) ?: ""
+                RunBus.update {
+                    it.copy(state = EngineState.READY, thinkControl = ctl, nExpertUsed = topk, gpuDevice = gpu)
+                }
                 main.post { notify("Model ready") }
                 pending?.let { p -> pending = null; sendGenerate(p) } ?: scheduleIdleUnload()
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -196,6 +196,33 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 IntSetting("Tokens to generate", AppSettings.NPREDICT_CHOICES, current.nPredict) {
                     onChange(current.copy(nPredict = it))
                 }
+                SwitchRow(
+                    "Dense weights on GPU (experimental)",
+                    "Runs attention, norms and the output head on the GPU. The routed experts stay " +
+                        "on the CPU — the streamer refills their memory every token and no GPU can " +
+                        "follow that — so this combines with every streaming setting above. Roughly " +
+                        "half the per-token maths moves off the CPU; lossless, it only changes where " +
+                        "the work runs.",
+                    current.gpuDense,
+                ) { onChange(current.copy(gpuDense = it)) }
+                // What the engine RESOLVED, never the switch echoed back: an app build without the
+                // GPU backend, or a device with no driver, silently runs on the CPU, and a toggle
+                // that just showed itself as "on" would hide exactly that.
+                if (current.gpuDense) {
+                    val gpu = ui.gpuDevice
+                    Text(
+                        when {
+                            gpu == null -> "Load a model to see whether this device offers a GPU."
+                            gpu.isEmpty() -> "⚠ No GPU available — this session is running the dense " +
+                                "path on the CPU. Either this build has no GPU backend or the device " +
+                                "has no driver; nothing else changes."
+                            else -> "Running on $gpu."
+                        },
+                        fontSize = 12.sp,
+                        color = if (gpu?.isEmpty() == true) MaterialTheme.colorScheme.error
+                                else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
             Section("Prompt") {

--- a/examples/android/app/src/main/jniLibs/arm64-v8a/README.md
+++ b/examples/android/app/src/main/jniLibs/arm64-v8a/README.md
@@ -20,3 +20,17 @@ libggml.so
 libggml-base.so
 libggml-cpu.so
 ```
+
+## Optional: the GPU build
+
+`pwsh scripts/build-android.ps1 -OpenCL` (after `pwsh scripts/fetch-opencl-android.ps1`) adds
+`libggml-opencl.so` to the set, which is what the app's **Dense weights on GPU** setting needs.
+
+Note what is deliberately *not* staged: `libOpenCL.so`. The GPU build leaves it as an unresolved
+`DT_NEEDED` so the device's own driver in `/vendor/lib64` satisfies it — the app already puts that
+directory on `LD_LIBRARY_PATH`. Shipping the Khronos loader here instead would take priority over
+the vendor driver and then find no ICD to dispatch to: everything would link, nothing would crash,
+and no GPU would ever be found.
+
+The trade-off is that a GPU-built CLI **will not start at all** on a device with no OpenCL driver,
+where the default build runs fine. See `../../../../../../docs/gpu-offload.md`.

--- a/scripts/bench-gpu-cache.sh
+++ b/scripts/bench-gpu-cache.sh
@@ -1,0 +1,69 @@
+#!/system/bin/sh
+# Does a freed CPU make the expert cache worth more?
+#
+# The question this answers is NOT "is the GPU faster" — that was measured and it is not
+# (docs/bench-data/2026-07-27-gpu-dense-offload/). It is whether the cache CURVE differs between
+# backends. Full offload cuts CPU occupancy from 88% to 54% and leaves decode more I/O-bound
+# (compute 0.187 against flash 0.648 s/token), so if compute is no longer competing, each extra MiB
+# of cache should convert into throughput more efficiently with the GPU on than off. That is a
+# difference of differences: (gpu_big - gpu_small) against (cpu_big - cpu_small).
+#
+# Which is a demanding thing to measure on a device whose run-to-run noise is +-6%. Two defences:
+#
+#   * every configuration runs TWICE, and
+#   * the cell order is a PALINDROME. Under a drift that is linear in time — which is what thermal
+#     drift looked like in the previous sweep, -5.5% over 13 minutes — a palindrome gives every
+#     configuration the same mean timestamp, so the drift cancels in the averages instead of being
+#     estimated and subtracted.
+#
+# Usage (from the host):
+#   adb shell 'dumpsys deviceidle disable'          # or the phone dozes and kills this
+#   adb shell run-as io.bigmoeonedge.example.dev sh -c \
+#     'setsid sh /data/local/tmp/bmoe/bench-gpu-cache.sh </dev/null >/dev/null 2>&1 &'
+set -u
+
+APP=io.bigmoeonedge.example.dev
+LIB=$(pm path $APP 2>/dev/null | head -1 | sed 's|package:||; s|/base.apk||')/lib/arm64
+OUT=/data/data/$APP/files/gpu-cache
+MODEL=${MODEL:-/data/local/tmp/bmoe/Qwen3-30B-A3B-Q4_K_M.gguf}
+NPRED=${NPRED:-96}
+COOLDOWN=${COOLDOWN:-90}
+SMALL=${SMALL:-2000}
+BIG=${BIG:-3500}
+
+mkdir -p "$OUT"
+export LD_LIBRARY_PATH="$LIB:/system/lib64:/vendor/lib64"
+CLI="$LIB/libbmoe-cli.so"
+
+# --ubatch is capped for the same reason as everywhere else: at a full-context ubatch the compute
+# buffer reservation (1203 MiB with a GPU in the graph) dominates whatever else is being measured.
+BASE="--moe-stream --io-threads 4 --overlap --dense-weights anon -c 2048 --ubatch 256 -n $NPRED"
+PROMPT="Explain gravity in one paragraph."
+
+RESULTS="$OUT/results.txt"
+: > "$RESULTS"
+echo "model=$MODEL n_predict=$NPRED small=$SMALL big=$BIG cooldown=${COOLDOWN}s" >> "$RESULTS"
+
+run_cell() {
+    backend=$1; cache=$2
+    if [ "$backend" = "gpu" ]; then EXTRA="--gpu-require"; else EXTRA=""; fi
+    cell="$backend-$cache-$(date +%H%M%S)"
+    echo "=== $cell start $(date +%T)" >> "$RESULTS"
+    $CLI -m "$MODEL" $BASE --cache-mb "$cache" -p "$PROMPT" $EXTRA > "$OUT/$cell.out" 2>&1
+    rc=$?
+    grep -E "^generation:|^compute:|^moe-stream:|^moe-cache:" "$OUT/$cell.out" >> "$RESULTS" 2>/dev/null
+    echo "=== $cell done rc=$rc $(date +%T)" >> "$RESULTS"
+    sleep "$COOLDOWN"
+}
+
+# The palindrome. Read outward from the middle: each configuration appears once in each half.
+run_cell cpu "$SMALL"
+run_cell gpu "$SMALL"
+run_cell cpu "$BIG"
+run_cell gpu "$BIG"
+run_cell gpu "$BIG"
+run_cell cpu "$BIG"
+run_cell gpu "$SMALL"
+run_cell cpu "$SMALL"
+
+echo "ALLDONE $(date +%T)" >> "$RESULTS"

--- a/scripts/bench-gpu-sweep.sh
+++ b/scripts/bench-gpu-sweep.sh
@@ -1,0 +1,55 @@
+#!/system/bin/sh
+# GPU offload sweep, run ON the device, detached from adb.
+#
+# Why detached: this bench takes ~15 minutes, and adb over Wi-Fi does not survive that — the phone
+# drops the connection when the screen locks, which kills the shell and the run with it. `setsid`
+# puts the sweep in its own session so it keeps going, and every cell writes its result as it
+# finishes, so a drop costs the connection and not the data.
+#
+# Usage (from the host, once the app is installed and the CLI staged):
+#   adb shell run-as io.bigmoeonedge.example.dev sh -c \
+#     'setsid sh /data/local/tmp/bmoe/bench-gpu-sweep.sh </dev/null >/dev/null 2>&1 &'
+# then collect:
+#   adb shell run-as io.bigmoeonedge.example.dev cat <APPDATA>/files/gpu-sweep/results.txt
+#
+# The cell order is deliberately not monotone in --gpu-layers, and the CPU cell runs first AND last:
+# thermal drift and accumulated memory pressure both make later cells worse, so a sweep that only
+# went 0,1,12,48 could not tell a real effect from the device getting tired. The two CPU cells
+# bracket that drift and say how much of any difference is the device rather than the config.
+set -u
+
+APP=io.bigmoeonedge.example.dev
+LIB=$(pm path $APP 2>/dev/null | head -1 | sed 's|package:||; s|/base.apk||')/lib/arm64
+OUT=/data/data/$APP/files/gpu-sweep
+MODEL=${MODEL:-/data/local/tmp/bmoe/Qwen3-30B-A3B-Q4_K_M.gguf}
+NPRED=${NPRED:-96}
+COOLDOWN=${COOLDOWN:-90}
+
+mkdir -p "$OUT"
+export LD_LIBRARY_PATH="$LIB:/system/lib64:/vendor/lib64"
+CLI="$LIB/libbmoe-cli.so"
+
+# One shared configuration; only --gpu-layers varies between cells. --ubatch is capped because the
+# compute buffers are reserved for the widest graph, and at a full-context ubatch that reservation
+# (1203 MiB with a GPU in the graph) dominates everything this sweep is trying to measure.
+ARGS="--moe-stream --cache-mb 2000 --io-threads 4 --overlap --dense-weights anon -c 2048 --ubatch 256 -n $NPRED"
+PROMPT="Explain gravity in one paragraph."
+
+RESULTS="$OUT/results.txt"
+: > "$RESULTS"
+echo "model=$MODEL n_predict=$NPRED cooldown=${COOLDOWN}s" >> "$RESULTS"
+
+for g in 0 48 12 1 0; do
+    if [ "$g" -eq 0 ]; then EXTRA=""; else EXTRA="--gpu-layers $g"; fi
+    cell="g$g-$(date +%H%M%S)"
+    echo "=== $cell start $(date +%T)" >> "$RESULTS"
+    # Capture the whole cell: a crash or an OOM kill has to be visible as such, not as a blank row.
+    $CLI -m "$MODEL" $ARGS -p "$PROMPT" $EXTRA > "$OUT/$cell.out" 2>&1
+    rc=$?
+    grep -E "^generation:|^compute:|^moe-stream:|graph splits|compute buffer size =|OpenCL model buffer" \
+        "$OUT/$cell.out" >> "$RESULTS" 2>/dev/null
+    echo "=== $cell done rc=$rc $(date +%T)" >> "$RESULTS"
+    sleep "$COOLDOWN"
+done
+
+echo "ALLDONE $(date +%T)" >> "$RESULTS"

--- a/scripts/build-android.ps1
+++ b/scripts/build-android.ps1
@@ -17,14 +17,31 @@
 # because it splits the CPU backend into dlopen'd variant .so's, which drops the bmoe fork's
 # statically-linked `ggml_cpu_set_expert_ready_hook` (the I/O–compute overlap hook) — the two are
 # mutually exclusive today. A single dotprod baseline keeps overlap and still covers the field.
+#
+# -OpenCL builds the GPU backend in, so `--gpu` can offload the dense path (the routed experts
+# always stay on the CPU — see docs/gpu-offload.md). It is opt-in because it makes libOpenCL a
+# hard load-time dependency: the resulting CLI will not start on a device with no OpenCL driver,
+# where the default build runs fine. Run scripts/fetch-opencl-android.ps1 first.
 param(
     [string]$BuildDir = "build-android",
     [string]$Abi      = "arm64-v8a",
     [int]$ApiLevel    = 29,
-    [string]$BuildType = "Release"
+    [string]$BuildType = "Release",
+    [switch]$OpenCL
 )
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
+
+# cmake and the NDK toolchain write ordinary progress to stderr, which Windows PowerShell turns
+# into a terminating error under `ErrorActionPreference = Stop` even on success (pwsh does not).
+# Judge them by their exit code so the script behaves the same in both shells.
+function Invoke-Native {
+    param([string]$What, [scriptblock]$Cmd)
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try { & $Cmd } finally { $ErrorActionPreference = $prev }
+    if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)" }
+}
 
 function Find-Ndk {
     if ($env:ANDROID_NDK_HOME -and (Test-Path $env:ANDROID_NDK_HOME)) { return $env:ANDROID_NDK_HOME }
@@ -42,19 +59,38 @@ $toolchain = Join-Path $ndk "build\cmake\android.toolchain.cmake"
 Write-Host "Using NDK: $ndk"
 
 $buildPath = Join-Path $root $BuildDir
-cmake -S $root -B $buildPath `
-    -G "Ninja" `
-    -DCMAKE_TOOLCHAIN_FILE="$toolchain" `
-    -DANDROID_ABI="$Abi" `
-    -DANDROID_PLATFORM="android-$ApiLevel" `
-    -DCMAKE_BUILD_TYPE="$BuildType" `
-    -DBMOE_BUILD_TESTS=OFF `
-    -DGGML_NATIVE=OFF `
-    -DGGML_OPENMP=OFF `
-    -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" `
-    -DLLAMA_CURL=OFF
 
-cmake --build $buildPath -j
+# Extra args rather than a second cmake invocation, so the two builds cannot drift apart in the
+# flags they share — the CPU target in particular is load-bearing (see the header note).
+$extra = @()
+if ($OpenCL) {
+    $clInc = Join-Path $root "third_party\opencl-sdk\install\$Abi\include"
+    $clLib = Join-Path $root "third_party\opencl-sdk\install\$Abi\lib\libOpenCL.so"
+    if (-not (Test-Path $clLib)) {
+        throw "OpenCL SDK not built for $Abi. Run: pwsh scripts/fetch-opencl-android.ps1 -Abi $Abi"
+    }
+    $extra += "-DBMOE_OPENCL=ON"
+    $extra += "-DOpenCL_INCLUDE_DIR=$clInc"
+    $extra += "-DOpenCL_LIBRARY=$clLib"
+    Write-Host "OpenCL GPU backend: ON (binary will require libOpenCL.so on the device)"
+}
+
+Invoke-Native "cmake configure" {
+    cmake -S $root -B $buildPath `
+        -G "Ninja" `
+        -DCMAKE_TOOLCHAIN_FILE="$toolchain" `
+        -DANDROID_ABI="$Abi" `
+        -DANDROID_PLATFORM="android-$ApiLevel" `
+        -DCMAKE_BUILD_TYPE="$BuildType" `
+        -DBMOE_BUILD_TESTS=OFF `
+        -DGGML_NATIVE=OFF `
+        -DGGML_OPENMP=OFF `
+        -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" `
+        -DLLAMA_CURL=OFF `
+        @extra
+}
+
+Invoke-Native "cmake build" { cmake --build $buildPath -j }
 
 # Stage the CLI and the shared libs it needs into the app's jniLibs as lib*.so.
 $jni = Join-Path $root "examples\android\app\src\main\jniLibs\$Abi"

--- a/scripts/fetch-opencl-android.ps1
+++ b/scripts/fetch-opencl-android.ps1
@@ -1,0 +1,104 @@
+# Fetch and build the OpenCL link-time dependency for the optional Android GPU build.
+#
+# ggml's OpenCL backend needs two things at COMPILE time that the Android NDK does not ship:
+# the Khronos headers, and a `libOpenCL.so` to link against. Neither is vendored — they are a
+# build prerequisite, not part of this project — so this script clones both from Khronos and
+# cross-compiles the ICD loader for the target ABI.
+#
+# The loader built here is a LINK STUB ONLY and is deliberately not staged into the app. At
+# runtime the engine resolves `libOpenCL.so` against the device's own driver in /vendor/lib64
+# (the app's ProcessBuilder already puts that on LD_LIBRARY_PATH). Shipping the Khronos loader
+# instead would take priority over the vendor driver and then find no ICD to dispatch to, which
+# is the failure mode where everything links, nothing crashes, and no GPU is ever found.
+#
+# Consequence worth knowing before using it: a binary built this way has a hard DT_NEEDED on
+# libOpenCL.so, so it will not START on a device with no OpenCL driver at all. That is why
+# BMOE_OPENCL is off by default; see docs/gpu-offload.md.
+param(
+    [string]$Abi      = "arm64-v8a",
+    [int]$ApiLevel    = 29,
+    [switch]$Force            # re-clone and rebuild even if the SDK dir already looks complete
+)
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$sdk  = Join-Path $root "third_party\opencl-sdk"
+
+# git and cmake both write ordinary progress to stderr, which Windows PowerShell turns into a
+# terminating error under `ErrorActionPreference = Stop` even when the command succeeded. Judge
+# them by their exit code, which is the only thing that actually says whether they worked.
+function Invoke-Native {
+    param([string]$What, [scriptblock]$Cmd)
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try { & $Cmd } finally { $ErrorActionPreference = $prev }
+    if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)" }
+}
+
+function Find-Ndk {
+    if ($env:ANDROID_NDK_HOME -and (Test-Path $env:ANDROID_NDK_HOME)) { return $env:ANDROID_NDK_HOME }
+    $base = if ($env:ANDROID_SDK_ROOT) { $env:ANDROID_SDK_ROOT } else { Join-Path $env:LOCALAPPDATA "Android\Sdk" }
+    $ndkDir = Join-Path $base "ndk"
+    if (Test-Path $ndkDir) {
+        $newest = Get-ChildItem $ndkDir -Directory | Sort-Object Name -Descending | Select-Object -First 1
+        if ($newest) { return $newest.FullName }
+    }
+    throw "Android NDK not found. Set ANDROID_NDK_HOME."
+}
+
+$headersDir = Join-Path $sdk "OpenCL-Headers"
+$loaderDir  = Join-Path $sdk "OpenCL-ICD-Loader"
+$installDir = Join-Path $sdk "install\$Abi"
+$libOut     = Join-Path $installDir "lib\libOpenCL.so"
+
+if ((Test-Path $libOut) -and -not $Force) {
+    Write-Host "opencl-sdk: already built at $installDir (use -Force to rebuild)"
+    Write-Host "OpenCL_INCLUDE_DIR=$(Join-Path $installDir 'include')"
+    Write-Host "OpenCL_LIBRARY=$libOut"
+    exit 0
+}
+
+New-Item -ItemType Directory -Force $sdk | Out-Null
+
+if (-not (Test-Path (Join-Path $headersDir "CL"))) {
+    Write-Host "opencl-sdk: cloning OpenCL-Headers"
+    if (Test-Path $headersDir) { Remove-Item -Recurse -Force $headersDir } # partial clone from a failed run
+    Invoke-Native "git clone OpenCL-Headers" { git clone --depth 1 -q https://github.com/KhronosGroup/OpenCL-Headers.git $headersDir }
+}
+if (-not (Test-Path (Join-Path $loaderDir "CMakeLists.txt"))) {
+    Write-Host "opencl-sdk: cloning OpenCL-ICD-Loader"
+    if (Test-Path $loaderDir) { Remove-Item -Recurse -Force $loaderDir }
+    Invoke-Native "git clone OpenCL-ICD-Loader" { git clone --depth 1 -q https://github.com/KhronosGroup/OpenCL-ICD-Loader.git $loaderDir }
+}
+
+# The headers are header-only: install them by copy so the include dir has the layout
+# find_package(OpenCL) expects (<prefix>/include/CL/*.h).
+$incOut = Join-Path $installDir "include\CL"
+New-Item -ItemType Directory -Force $incOut | Out-Null
+Copy-Item (Join-Path $headersDir "CL\*.h") $incOut -Force
+
+$ndk = Find-Ndk
+$toolchain = Join-Path $ndk "build\cmake\android.toolchain.cmake"
+if (-not (Test-Path $toolchain)) { throw "NDK toolchain file not found: $toolchain" }
+
+$loaderBuild = Join-Path $sdk "build-loader-$Abi"
+Write-Host "opencl-sdk: building the ICD loader for $Abi (link stub)"
+$inc = Join-Path $installDir 'include'
+Invoke-Native "ICD loader configure" {
+    cmake -S $loaderDir -B $loaderBuild -G "Ninja" `
+        -DCMAKE_TOOLCHAIN_FILE="$toolchain" -DANDROID_ABI="$Abi" `
+        -DANDROID_PLATFORM="android-$ApiLevel" -DCMAKE_BUILD_TYPE=Release `
+        -DOPENCL_ICD_LOADER_HEADERS_DIR="$inc" `
+        -DBUILD_TESTING=OFF
+}
+Invoke-Native "ICD loader build" { cmake --build $loaderBuild -j }
+
+$built = Get-ChildItem $loaderBuild -Recurse -Filter "libOpenCL.so" | Select-Object -First 1
+if (-not $built) { throw "ICD loader built but libOpenCL.so was not produced" }
+New-Item -ItemType Directory -Force (Split-Path -Parent $libOut) | Out-Null
+Copy-Item $built.FullName $libOut -Force
+
+Write-Host ""
+Write-Host "opencl-sdk ready:"
+Write-Host "  OpenCL_INCLUDE_DIR=$(Join-Path $installDir 'include')"
+Write-Host "  OpenCL_LIBRARY=$libOut"
+Write-Host "Now run: pwsh scripts/build-android.ps1 -OpenCL"

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -171,6 +171,21 @@ int main() {
         expect_fail("a NaN threshold is rejected", c);
     }
 
+    // n_ubatch: 0 follows the context; a value above it would reserve compute buffers for a batch
+    // that cannot occur, which inverts the memory saving the knob exists for.
+    {
+        RunConfig c = ok_base();
+        expect_ok("n_ubatch 0 (follow the context) is the default and valid", c);
+        c.n_ubatch = 512;
+        expect_ok("an n_ubatch below n_ctx is valid", c);
+        c.n_ubatch = c.n_ctx;
+        expect_ok("an n_ubatch equal to n_ctx is valid", c);
+        c.n_ubatch = c.n_ctx + 1;
+        expect_fail("an n_ubatch above n_ctx is rejected", c);
+        c.n_ubatch = -1;
+        expect_fail("a negative n_ubatch is rejected", c);
+    }
+
     // GPU offload. Availability is a runtime question, so validate() only settles coherence.
     {
         RunConfig c = ok_base();

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -210,10 +210,23 @@ int main() {
             const bool ok = !pat.empty() && pat.front() == '\\' && pat.back() == '.';
             std::printf("%s expert pattern for %s: %s\n", ok ? "[PASS]" : "[FAIL]", r->arch, pat.c_str());
             if (!ok) ++failures;
+
+            // The CPU pin must additionally carry the router: the streamer reads the routing node
+            // from the host, so leaving `ffn_gate_inp` on a device backend is a wild pointer, not a
+            // slow path. Its absence is exactly the bug that segfaulted the first GPU run.
+            const std::string pin = cpu_pinned_tensor_pattern(*r);
+            const bool pin_ok = pin.find("ffn_gate_inp") != std::string::npos && pin.back() == '.' &&
+                                pin.find(r->exps_suffix[0]) != std::string::npos;
+            std::printf("%s cpu pin for %s: %s\n", pin_ok ? "[PASS]" : "[FAIL]", r->arch, pin.c_str());
+            if (!pin_ok) ++failures;
         }
         // A recipe naming nothing must match nothing rather than everything — the failure mode
         // that would quietly pin the whole model to the CPU.
         const MoeRecipe empty{"none", {nullptr, nullptr, nullptr}};
+        if (!cpu_pinned_tensor_pattern(empty).empty()) {
+            std::printf("[FAIL] an empty recipe must yield an empty cpu pin\n");
+            ++failures;
+        }
         if (!expert_tensor_pattern(empty).empty()) {
             std::printf("[FAIL] an empty recipe must yield an empty pattern\n");
             ++failures;

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -7,6 +7,7 @@
 // Checks are explicit (not <cassert>): the Release build defines NDEBUG, which compiles assert out.
 
 #include "bmoe/config.h"
+#include "bmoe/recipe.h"
 
 #include <cstdio>
 #include <limits>
@@ -168,6 +169,57 @@ int main() {
         // and it would also skip the cache_on requirement above for the same reason.
         c.moe.drop_cold_frac = std::numeric_limits<float>::quiet_NaN();
         expect_fail("a NaN threshold is rejected", c);
+    }
+
+    // GPU offload. Availability is a runtime question, so validate() only settles coherence.
+    {
+        RunConfig c = ok_base();
+        expect_ok("gpu off is the default and valid", c);
+
+        c.gpu.enabled = true;
+        expect_ok("gpu on with the default layer count is valid", c);
+        c.gpu.n_layers = 0;
+        expect_ok("gpu with zero layers is valid (offload nothing, still a legal request)", c);
+        c.gpu.n_layers = 24;
+        expect_ok("gpu with an explicit layer count is valid", c);
+        c.gpu.n_layers = -2;
+        expect_fail("a layer count below -1 is rejected", c);
+
+        c = ok_base();
+        c.gpu.require = true;
+        expect_fail("gpu.require without gpu.enabled is rejected", c);
+        c = ok_base();
+        c.gpu.n_layers = 24;
+        expect_fail("gpu.n_layers without gpu.enabled is rejected", c);
+
+        // The offload is orthogonal to streaming: it moves the half of the model the streamer
+        // never touches, so every combination of the two is legal.
+        c = ok_moe();
+        c.moe.cache_mb = MoeStreamConfig::cache_min_mb;
+        c.gpu.enabled = true;
+        expect_ok("gpu offload combines with expert streaming", c);
+    }
+
+    // The expert-tensor pattern is derived from the recipe table, so every registered
+    // architecture must produce one — a row that pinned nothing would silently offload its
+    // experts to a device the streamer cannot rebind.
+    {
+        for (int i = 0; i < n_moe_recipes(); ++i) {
+            const MoeRecipe * r = moe_recipe_at(i);
+            const std::string pat = expert_tensor_pattern(*r);
+            const bool ok = !pat.empty() && pat.front() == '\\' && pat.back() == '.';
+            std::printf("%s expert pattern for %s: %s\n", ok ? "[PASS]" : "[FAIL]", r->arch, pat.c_str());
+            if (!ok) ++failures;
+        }
+        // A recipe naming nothing must match nothing rather than everything — the failure mode
+        // that would quietly pin the whole model to the CPU.
+        const MoeRecipe empty{"none", {nullptr, nullptr, nullptr}};
+        if (!expert_tensor_pattern(empty).empty()) {
+            std::printf("[FAIL] an empty recipe must yield an empty pattern\n");
+            ++failures;
+        } else {
+            std::printf("[PASS] an empty recipe yields an empty pattern\n");
+        }
     }
 
     if (failures == 0) {


### PR DESCRIPTION
Runs the **dense (non-expert) half** of the model on a GPU, and reports — with numbers — that on the hardware this engine targets it does not pay. Ships gated and off, because the measurement is worth having and the feature is not worth recommending.

> **Verdict up front.** On an integrated mobile GPU, decode is slower at every placement measured: full dense offload **0.73×**, output head alone **0.80×**, and (in a companion experiment) routed experts held in device memory **0.22×**, with even a fully resident model and nothing streamed at **~0.79×**. Output is token-identical throughout, so this is a performance result and never a correctness one. The GPU's one unrefuted advantage is batched **prefill** (~2.3×), which is not measured here.

## Why the experts stay on the CPU

The streamer rebinds an expert tensor's `->data` to a host buffer it refills from flash before every token. No GPU backend follows that: ggml's OpenCL backend reads `tensor->data` exactly once, in `init_tensor` at load, and dispatches against `cl_mem` handles cached in `tensor->extra` thereafter — the pointer it read is not even a real address. There is no zero-copy path either (no `CL_MEM_USE_HOST_PTR`, no SVM, no dma-buf import), so a device-side weight is a *copy*. A streamed expert placed there would silently compute whatever the warm-up decode left behind.

That argument is about rebinding a **pointer**, and it holds. It does not rule out rebinding the *contents*, which is what the companion experiment does — see the bottom of this description.

## Why the dense half looked worth moving

A MoE uses **100% of its dense weights on every token** but only `k/n_expert` of its expert weights, which puts the halves in the same order of magnitude:

| Model | dense | expert bytes touched/token |
|---|---:|---:|
| Qwen3-30B-A3B (128 experts, top-8) | 951 MiB | ~1.10 GiB |
| Qwen3.6-35B-A3B (256 experts, top-8) | ~1 GiB | ~0.67 GiB |

Decode here is compute-bound once the I/O levers are in, so moving ~half the arithmetic off four phone cores looked like the largest remaining lever that costs no quality. It is **lossless** — placement changes where a matmul runs, not what is computed.

That reasoning was about **how much work** the dense half is. It said nothing about **where that work sits in the graph**, and that turns out to be what decides it.

## Design

Two things set together before the load:

- `llama_model_params::devices` gets the discovered GPU; `n_gpu_layers` says how much (`-1` = all).
- `tensor_buft_overrides` pins the expert tensors to the CPU buffer type. llama.cpp resolves a matching override **before** the layer's device assignment, so an expert stays in host memory even in an offloaded layer.

**Device-agnostic.** Discovery goes through the ggml backend registry (`core/src/engine/gpu_device.h`) and names no vendor or API. A build with no GPU backend and a device with no driver produce the same result — no device found — and the engine falls back to the CPU with a note. `--gpu-require` turns that into a failure, so an A/B cannot silently compare CPU against CPU.

**Model-agnostic.** The pin pattern is derived from the architecture recipe (`expert_tensor_pattern()`), so a new MoE family added as a recipe row pins its own experts with nothing else to update. A unit test asserts every registered recipe yields a pattern.

## `--ubatch N`, the lever that did pay

Compute buffers are reserved for the widest graph, and the engine had always set `n_ubatch = n_ctx` so any fitting prompt prefills in one pass — which quietly tied resident memory to the **context** rather than to the work:

| n_ctx | OpenCL compute buffer | CPU compute buffer |
|---|---:|---:|
| 2048 | 1203 MiB | 320 MiB |
| 512 | 301 MiB | 80 MiB |

Exactly 4× for a 4× context, on both backends — nothing to do with the GPU. On an engine whose whole problem is that the expert cache and the dense weights compete for RAM, that was a real budget and it was invisible. Decode is unaffected (a decode graph is one token wide regardless); the cost is prefill throughput. Default 0 keeps the previous behaviour exactly.

This is also what invalidated the first measured verdict, below.

## What it measures

Three passes are recorded rather than one, because the first two were wrong in instructive ways and the corrections are the useful part.

**Pass 1 said 2.6× slower.** Wrong: that was our own compute-buffer reservation (~900 MiB of it) pushing an already-tight system into reclaim — 5 958 major faults per token. Capping `--ubatch` took the same cell from 1.207 to 2.752 tok/s.

**Pass 2 said `--gpu-layers 1` was worth +7%.** Also wrong: a repeat reversed the sign. This device's run-to-run noise is ±6%, larger than every GPU effect measured except the full-offload penalty.

**Pass 3, on a second model with a faster CPU baseline, is unambiguous.** `Qwen3.6-35B-A3B` (Q4_0, 40 layers) with the current recipe including `--drop-cold-experts`, run as a palindrome, `scaling_max_freq` logged per cell because the SoC changed clock state mid-sweep:

| `--gpu-layers` | clock | tok/s | compute s/tok | majflt/token |
|---|---|---:|---:|---:|
| 1 (output head only) | 3.03 GHz | 5.064 | 0.141 | 7.11 |
| **0 (CPU)** | 3.03 GHz | **6.383** | 0.098 | 0.29 |
| **0 (CPU)** | 2.27 GHz | **5.528** | 0.131 | 0.49 |
| 1 (output head only) | 2.27 GHz | 4.663 | 0.157 | 1.65 |
| all 40 layers | 2.27 GHz | 4.062 | 0.192 | 9.95 |

Full offload **−27%**, output head alone **−16 to −21%**, same sign in both halves of the palindrome. This does not contradict the neutral result on Qwen3-30B; it explains it. The CPU baseline got faster (`--drop-cold-experts` is worth ~+18% on this model), so the same fixed cost is a larger share of a smaller total.

## Why it loses, mechanically

The dense and expert halves **interleave**: a MoE layer is dense → routed experts → dense → routed experts, once per layer. Splitting them across two devices crosses the boundary **twice per layer** — 96 graph splits against 1 — and every crossing copies and synchronises an activation.

The GPU genuinely frees the CPU: occupancy falls 88% → 54% at full offload, and the overlapped I/O residual even improves (0.035 → 0.030 s/token). But compute rises 0.131 → 0.192 and ~10 major faults per token appear from the compute buffer's memory pressure. The freed CPU time is real; the boundary tax eats all of it.

`--gpu-layers 1` comes closest because the output head is the one dense component with no expert layer after it to hand control back to — 2 splits instead of 96. It is still not a win: one matmul is too small a share of the per-token work.

**And the deeper reason is the one this PR's original description guessed at and then set aside:** batch-1 decode is GEMV, memory-bound, and an integrated GPU shares the same LPDDR as the CPU, so there is no bandwidth to win. That guess was right, and it outranks the byte-count argument that motivated the feature.

## Flags and reporting

`--gpu`, `--gpu-layers N`, `--gpu-require`, `--ubatch N`. Reporting is **resolved, never requested**: `BMOE_READY` gains `"gpu"` and the CSV preamble gains `gpu=`, empty/`cpu` when the dense path ran on the CPU, so a bench cell cannot be mistaken for a GPU cell it silently was not. The app's **Dense weights on GPU** toggle displays the device the engine actually got and warns on a fallback.

For benchmarking, compare toggle-on against toggle-off **on the same binary**: an OpenCL-enabled build registers and initialises the backend at startup whether or not the toggle is on.

## Build

Off by default at every level. `-DBMOE_OPENCL=ON` is opt-in because linking the backend makes `libOpenCL` a hard load-time dependency: such a binary will not start on a device with no OpenCL driver, where the default build runs everywhere.

```
pwsh scripts/fetch-opencl-android.ps1    # Khronos headers + an ICD loader to link against
pwsh scripts/build-android.ps1 -OpenCL
```

The loader is a **link stub only** and is deliberately not shipped — at runtime `libOpenCL.so` resolves to the device's own `/vendor/lib64` driver. Shipping the Khronos loader would outrank the vendor driver and then find no ICD behind it: everything links, nothing crashes, no GPU is ever found. The app also needs `<uses-native-library android:name="libOpenCL.so" android:required="false"/>`, without which the linker kills the process before `main`.

`scripts/build-host.sh` and CI pass no GGML flags, so the default host build and the byte-identity gates are untouched.

## Also fixed

- `--dense-weights anon|ahwb` no longer tries to rebind tensors the GPU has taken (they are not under host-memory reclaim pressure; rebinding a device-resident tensor would be ignored at best).
- A stray `%` in the `--dense-weights` help text was read by `printf` as a conversion specifier, so that line printed garbage and read past the argument list. Pre-existing, unrelated.
- `scripts/build-android.ps1` judges `cmake` by its exit code rather than by whether it wrote to stderr, so it works under Windows PowerShell 5.1 and not only under `pwsh`.

## The companion experiment

Whether the routed **experts** can move to the GPU at all is answered separately, and negatively, on [`feat/gpu-expert-slots`](https://github.com/Helldez/BigMoeOnEdge/tree/feat/gpu-expert-slots): they can — by rebinding contents rather than a pointer, into a flash-filled residency pool — it is bit-exact, and it measures 0.22×. That work depends on seams carried on a llama.cpp fork branch, so it deliberately stays out of this tree and out of this PR.

## Verification

- Host gates **7/7** green; the streaming path is untouched.
- `config_validate` extended: the new knobs, and every recipe's expert pattern.
- clang-format 18 clean.
- Android arm64 cross-compile with `-OpenCL` succeeds; `libggml-opencl.so` carries the expected unresolved `libOpenCL.so` `DT_NEEDED` and is packaged in the dev APK.
- README benchmark tables deliberately untouched: the new cells are Q4_0 and those tables are Q4_K_M, so the numbers are not comparable.
- Full evidence and method notes in `docs/bench-data/2026-07-27-gpu-dense-offload/`, including the two wrong verdicts and why they were wrong.
