### PR TITLE
feat(engine): --ubatch N — the compute-buffer reservation nobody was watching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 /out/
 cmake-build-*/
 
+# OpenCL headers + ICD loader, fetched by scripts/fetch-opencl-android.ps1 for the optional
+# GPU build. Third-party sources we do not vendor: a build prerequisite, not our code.
+/third_party/opencl-sdk/
+
 # Models and large artifacts (never commit weights)
 *.gguf
 *.bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- **`--ubatch N`: the widest graph computed at once, decoupled from the context.** Compute buffers
+  are reserved for the worst-case graph, and the engine had always set `n_ubatch = n_ctx` so that
+  any fitting prompt prefills in one pass — which quietly ties **resident memory** to the context
+  rather than to the work. Measured at n_ctx 2048: **320 MiB of compute buffer, falling to 80 MiB
+  at 512**, scaling exactly with the context. On an engine whose whole problem is that the expert
+  cache and the dense weights compete for RAM, that is a real budget, and it was invisible.
+  Decode is unaffected — a decode graph is one token wide whatever this says; the cost is prefill
+  throughput, which processes a long prompt in more, smaller passes. Default 0 keeps the previous
+  behaviour exactly.
+
+  Found while chasing what looked like a catastrophic slowdown and turned out to be this
+  reservation pushing an already-tight system into reclaim — nearly 6 000 major faults per token,
+  none of them the workload's fault.
+
+### Fixed
+- A stray `%` in the `--dense-weights` help text was read by `printf` as a conversion specifier, so
+  that line printed garbage and read past the argument list.
+- `scripts/build-android.ps1` now judges `cmake` by its exit code instead of by whether it wrote to
+  stderr, so it works under Windows PowerShell 5.1 and not only under `pwsh` (the NDK toolchain
+  prints progress to stderr, which 5.1 turns into a terminating error).
+
 ## [0.15.1] - 2026-07-23
 
 ### Added

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -324,6 +324,11 @@ static void print_usage(const char * argv0) {
         "  -n, --n-predict N       tokens to generate (default 128)\n"
         "  -t, --threads N         compute threads (default 4)\n"
         "  -c, --ctx-size N        context size (default 2048)\n"
+        "      --ubatch N          widest graph computed at once (0 = as wide as the context).\n"
+        "                          Compute buffers are reserved for it, so a smaller value hands\n"
+        "                          RAM back to the expert cache at the cost of prefill speed;\n"
+        "                          decode is unaffected. Measured: a context of 2048 reserves\n"
+        "                          320 MiB, falling to 80 MiB at 512.\n"
         "      --chatml            wrap the prompt in the model family's chat turn (gemma/chatml)\n"
         "      --no-think          render the chat template with reasoning disabled\n"
         "      --progress          emit machine telemetry (one JSON line per token)\n"
@@ -362,7 +367,7 @@ static void print_usage(const char * argv0) {
         "                          reclaim hits zram not flash — the win on >RAM models;\n"
         "                          ahwb = as anon, but into dma-buf memory the kernel may not reclaim\n"
         "                          at all — not even to zram, which is what anon still pays for.\n"
-        "                          Android-only; measured +17.9% on a long generation, off by default)\n"
+        "                          Android-only; measured +17.9%% on a long generation, off by default)\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -412,6 +417,8 @@ int main(int argc, char ** argv) {
             cfg.n_threads = std::atoi(next("-t"));
         else if (a == "-c" || a == "--ctx-size")
             cfg.n_ctx = std::atoi(next("-c"));
+        else if (a == "--ubatch")
+            cfg.n_ubatch = std::atoi(next("--ubatch"));
         else if (a == "--n-expert-used")
             cfg.n_expert_used = std::atoi(next("--n-expert-used"));
         else if (a == "--temp")

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -149,6 +149,21 @@ struct RunConfig {
     int n_predict = 128;
     int n_threads = 4;
     int n_ctx = 2048;
+
+    // Largest batch computed in one graph, i.e. the prefill chunk size. 0 (the default) means
+    // "follow n_ctx", which prefills any fitting prompt in a single pass.
+    //
+    // It is worth exposing because it does not only cost time, it costs RESIDENT MEMORY: the
+    // scheduler reserves compute buffers for the worst-case graph, which is a full-width prefill,
+    // and on this engine every MiB reserved is a MiB the expert cache and the dense weights do not
+    // get. Measured at n_ctx 2048: 320 MiB of compute buffer, falling to 80 MiB at 512 — the
+    // reservation scales with the context, which is exactly the coupling this knob breaks. It was
+    // found while chasing a fault storm that turned out to be the reservation itself, not the
+    // workload.
+    //
+    // Decode is unaffected: a decode graph is one token wide whatever this says. The cost is
+    // prefill throughput, which processes a long prompt in more, smaller passes.
+    int n_ubatch = 0;
     bool chatml = false;   // wrap the prompt in the model family's chat turn (arch-aware)
     bool progress = false; // emit machine telemetry (one JSON line per token)
 

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -36,6 +36,10 @@ struct SessionConfig {
     int n_threads = 4;
     int n_ctx = 2048;
     int n_batch = 512; // prefill chunk capacity; longer prompts are prefilled in n_batch slices
+    // Widest graph actually computed at once. 0 = follow n_batch. Sizing this down trades prefill
+    // throughput for resident compute buffers, which on this engine compete with the expert cache.
+    // See RunConfig::n_ubatch.
+    int n_ubatch = 0;
     bool chatml = false;
     // Active-expert (top-k) override applied at load via a kv_override on the arch-prefixed
     // expert_used_count key. 0 = use the model's own count. See RunConfig::n_expert_used.

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -24,6 +24,15 @@ ValidationResult validate(const RunConfig & cfg) {
     if (cfg.n_ctx <= 0) {
         return fail("n_ctx must be positive");
     }
+    // 0 means "as wide as the context"; anything larger than the context would be reserved for a
+    // batch that can never arrive, which is the opposite of what this knob is for.
+    if (cfg.n_ubatch < 0) {
+        return fail("n_ubatch must be >= 0 (0 = as wide as the context)");
+    }
+    if (cfg.n_ubatch > cfg.n_ctx) {
+        return fail("n_ubatch=" + std::to_string(cfg.n_ubatch) + " exceeds n_ctx=" + std::to_string(cfg.n_ctx) +
+                    ": the compute buffers would be reserved for a batch that cannot occur.");
+    }
     // Lower bound only: 0 means "use the model default". The upper bound (<= the model's
     // real expert count) needs the loaded gguf, so it is deferred to run() where the model
     // is available — same rationale as the streaming checks that stay out of this pure path.

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -11,7 +11,8 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.model_path = cfg.model_path;
     sc.n_threads = cfg.n_threads;
     sc.n_ctx = cfg.n_ctx;
-    sc.n_batch = cfg.n_ctx; // one-batch prefill for any prompt that fits the context
+    sc.n_batch = cfg.n_ctx;     // one-batch prefill for any prompt that fits the context
+    sc.n_ubatch = cfg.n_ubatch; // 0 = follow n_batch; smaller trades prefill speed for memory
     sc.chatml = cfg.chatml;
     sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
     sc.compute_trace_layers = cfg.compute_trace_layers;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -379,7 +379,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
     cparams.n_batch = cfg.n_batch;
-    cparams.n_ubatch = cfg.n_batch;
+    // The graph is reserved for the widest ubatch, so this is what sets the resident compute
+    // buffers — the memory this engine is always short of. 0 keeps the historical behaviour
+    // (one graph as wide as the batch); a smaller value chunks prefill to buy that memory back.
+    cparams.n_ubatch = cfg.n_ubatch > 0 ? (uint32_t) cfg.n_ubatch : (uint32_t) cfg.n_batch;
     // The streamer needs the callback to see routing; the compute trace needs it to time nodes.
     // Installing it for the trace alone is what lets a NON-streamed run be measured — the dense
     // mmap baseline the streamed numbers are argued against.

--- a/scripts/build-android.ps1
+++ b/scripts/build-android.ps1
@@ -26,6 +26,17 @@ param(
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
 
+# cmake and the NDK toolchain write ordinary progress to stderr, which Windows PowerShell turns
+# into a terminating error under `ErrorActionPreference = Stop` even on success (pwsh does not).
+# Judge them by their exit code so the script behaves the same in both shells.
+function Invoke-Native {
+    param([string]$What, [scriptblock]$Cmd)
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try { & $Cmd } finally { $ErrorActionPreference = $prev }
+    if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)" }
+}
+
 function Find-Ndk {
     if ($env:ANDROID_NDK_HOME -and (Test-Path $env:ANDROID_NDK_HOME)) { return $env:ANDROID_NDK_HOME }
     $sdk = if ($env:ANDROID_SDK_ROOT) { $env:ANDROID_SDK_ROOT } else { "$env:LOCALAPPDATA\Android\Sdk" }
@@ -42,19 +53,21 @@ $toolchain = Join-Path $ndk "build\cmake\android.toolchain.cmake"
 Write-Host "Using NDK: $ndk"
 
 $buildPath = Join-Path $root $BuildDir
-cmake -S $root -B $buildPath `
-    -G "Ninja" `
-    -DCMAKE_TOOLCHAIN_FILE="$toolchain" `
-    -DANDROID_ABI="$Abi" `
-    -DANDROID_PLATFORM="android-$ApiLevel" `
-    -DCMAKE_BUILD_TYPE="$BuildType" `
-    -DBMOE_BUILD_TESTS=OFF `
-    -DGGML_NATIVE=OFF `
-    -DGGML_OPENMP=OFF `
-    -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" `
-    -DLLAMA_CURL=OFF
+Invoke-Native "cmake configure" {
+    cmake -S $root -B $buildPath `
+        -G "Ninja" `
+        -DCMAKE_TOOLCHAIN_FILE="$toolchain" `
+        -DANDROID_ABI="$Abi" `
+        -DANDROID_PLATFORM="android-$ApiLevel" `
+        -DCMAKE_BUILD_TYPE="$BuildType" `
+        -DBMOE_BUILD_TESTS=OFF `
+        -DGGML_NATIVE=OFF `
+        -DGGML_OPENMP=OFF `
+        -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" `
+        -DLLAMA_CURL=OFF
+}
 
-cmake --build $buildPath -j
+Invoke-Native "cmake build" { cmake --build $buildPath -j }
 
 # Stage the CLI and the shared libs it needs into the app's jniLibs as lib*.so.
 $jni = Join-Path $root "examples\android\app\src\main\jniLibs\$Abi"

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -170,6 +170,21 @@ int main() {
         expect_fail("a NaN threshold is rejected", c);
     }
 
+    // n_ubatch: 0 follows the context; a value above it would reserve compute buffers for a batch
+    // that cannot occur, which inverts the memory saving the knob exists for.
+    {
+        RunConfig c = ok_base();
+        expect_ok("n_ubatch 0 (follow the context) is the default and valid", c);
+        c.n_ubatch = 512;
+        expect_ok("an n_ubatch below n_ctx is valid", c);
+        c.n_ubatch = c.n_ctx;
+        expect_ok("an n_ubatch equal to n_ctx is valid", c);
+        c.n_ubatch = c.n_ctx + 1;
+        expect_fail("an n_ubatch above n_ctx is rejected", c);
+        c.n_ubatch = -1;
+        expect_fail("a negative n_ubatch is rejected", c);
+    }
+
     if (failures == 0) {
         std::printf("all config checks passed\n");
         return 0;


### PR DESCRIPTION
Salvaged from #104, which is being closed unmerged because the feature it was built for measures negative. This is the part of that work that has nothing to do with the GPU and should not die with it.

## The problem

Compute buffers are reserved for the worst-case graph, and this engine had always set `n_ubatch = n_ctx` so that any fitting prompt prefills in one pass. That quietly ties **resident memory** to the context rather than to the work:

| n_ctx | compute buffer reserved |
|---|---:|
| 2048 | 320 MiB |
| 512 | 80 MiB |

Exactly 4× for a 4× context. On an engine whose entire problem is that the expert cache and the dense weights compete for the same RAM, that is a real budget — and it was invisible, because nothing reported it and nothing could change it.

## The knob

`--ubatch N` sets the widest graph computed at once. `0` (the default) keeps the previous behaviour exactly, so this is inert unless asked for.

**Decode is unaffected** — a decode graph is one token wide whatever this says. The cost is prefill throughput: a long prompt is processed in more, smaller passes. That is the trade, and it is worth having explicitly on a device where the alternative is the kernel reclaiming the weights out from under the run.

`validate()` rejects a negative value, and one above `n_ctx`: reserving for a batch that cannot arrive is the inverse of what the knob is for.

## How it was found

Chasing what looked like a catastrophic slowdown — nearly 6 000 major faults per token — which turned out not to be the workload at all. It was this reservation pushing an already-tight system into reclaim. Capping it moved the affected configuration from 1.207 to 2.752 tok/s, and the fault count from 5 958 to 1.06 per token.

That measurement happened during GPU work, where the reservation was largest, but the coupling it exposed is the engine's own and applies to every configuration.

## Also fixed

Two unrelated things found alongside it:

- A stray `%` in the `--dense-weights` help text was read by `printf` as a conversion specifier, so that line printed garbage and read past the argument list.
- `scripts/build-android.ps1` judged `cmake` by whether it wrote to stderr rather than by its exit code, which broke it under Windows PowerShell 5.1 — the NDK toolchain prints progress to stderr, and 5.1 turns that into a terminating error under `ErrorActionPreference = Stop`. It now checks `$LASTEXITCODE`, so the script behaves the same in both shells.

## Verification

- Host byte-identity gates **7/7** green.
- `config_validate` extended with the new bounds.
- clang-format 18 clean.
- No submodule bump: this branch sits on `main`'s llama.cpp pointer.

## What is deliberately not here

Everything GPU. `--gpu`, `--gpu-layers`, `--gpu-require`, the OpenCL build path and the manifest change stay on `feat/gpu-dense-offload` (#104, closed) with the measurements that refuted them; expert residency in device memory stays on `feat/gpu-expert-slots` (#105, closed). Both are tagged and reachable, and neither belongs in `main`.
