### PR TITLE
chore(release): 0.16.0 (versionCode 30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Semantic Versioning.
 - `BMOE_READY` gains `n_expert_used`, the effective routing width after any override (0 on a non-MoE
   model), so a UI can interpret the setting at all; `Session::n_expert_used()` exposes the same to
   embedders. Additive — older consumers ignore it.
+
 ### Fixed
 - The 0.15.0 entry for the app default still called the quality cost unquantified, contradicting the
   GSM8K result recorded in the same section. Corrected in place.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-28
+
 ### Added
 - **`--ubatch N`: the widest graph computed at once, decoupled from the context.** Compute buffers
   are reserved for the worst-case graph, and the engine had always set `n_ubatch = n_ctx` so that

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -50,8 +50,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 29
-        versionName '0.15.1'
+        versionCode 30
+        versionName '0.16.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.


### PR DESCRIPTION
Carves the accumulated `[Unreleased]` entries into `## [0.16.0] - 2026-07-28` and advances the
example app to versionCode 30 / versionName 0.16.0.

What the section contains:

- **`--ubatch N`** (#106): the widest graph computed at once, decoupled from the context. The engine
  had always set `n_ubatch = n_ctx`, tying 320 MiB of compute buffer at ctx 2048 to the context
  rather than to the work. Default 0 keeps the previous behaviour.
- **`--predict-log`** (#101): measures how much of a layer's routing is knowable a layer early, with
  a zero-staleness control that must read 100%. Diagnostics only, byte-identical.
- **`--predict-prefetch`** (#101): acts on that prediction. Ships **off by default** — its own
  matched-pair measurement refuted the read-ahead (−21% in the shipping configuration with the hit
  rate up), so the app defaults the budget to retention-only.
- Two fixes: the `%` in the `--dense-weights` help text, and `build-android.ps1` under Windows
  PowerShell 5.1.
