### PR TITLE
ci: stop rebuilding main for a docs-only merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Does this push carry anything a build could break?
+  #
+  # `paths-ignore` handles that for pull requests, but it cannot be put on the push trigger: the
+  # same trigger carries the release tags, and a tag push has no commit range for a path filter to
+  # read, so filtering here would silence the tag build that attaches the APK. Hence the decision
+  # is made once, in ten seconds, and each build job is gated on it.
+  #
+  # Anything not a push (pull_request, workflow_dispatch) and every tag build answers "yes"
+  # unconditionally — this is a saver for docs merges, not a second opinion on what to test.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.decide.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          say() { echo "code=$1" >> "$GITHUB_OUTPUT"; echo "code=$1"; }
+          case "$EVENT:$REF" in
+            push:refs/tags/*) say true; exit 0 ;;
+            push:*) ;;
+            *) say true; exit 0 ;;
+          esac
+          # A branch created by this push, or a force-push past the old head, leaves nothing to
+          # diff against; build rather than guess.
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            say true; exit 0
+          fi
+          files=$(git diff --name-only "$BEFORE" "$SHA")
+          echo "changed:"; echo "$files"
+          if echo "$files" | grep -qvE '(\.md$|^docs/|^LICENSE$|^\.gitignore$)'; then
+            say true
+          else
+            say false
+          fi
+
   format:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +73,8 @@ jobs:
             -print0 | xargs -0 clang-format --dry-run --Werror
 
   host-linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Merging a docs-only PR re-ran `format` and the full submodule build + `ctest` on exactly the tree the PR had already gated — `paths-ignore` is on the `pull_request` trigger only.

It cannot just be copied onto `push`: that trigger also carries the release tags, and a tag push has no commit range for a path filter to read, so filtering there would silence the tag build that attaches the APK.

So a ten-second `changes` guard job diffs the pushed range and `format` / `host-linux` are gated on its answer. `host-windows` and `android-apk` already skip main pushes on their own condition.

Answers `true` unconditionally for pull requests, manual runs, tag pushes, and any push whose previous head is unknown (branch creation, force push) — it only skips work it can prove redundant.

Guard logic run locally against real commits before pushing:

| case | verdict |
|---|---|
| docs-only push (`8e69bd4..2485c64`, README) | `false` |
| release push (`9e04e04..682ae5b`, gradle + md) | `true` |
| tag push `refs/tags/v0.16.0` | `true` |
| pull_request | `true` |
| unknown previous head | `true` |