### PR TITLE
fix(io): stop a transient alloc failure from killing a reader lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+- **A failed bounce reallocation no longer kills the lane for good.** `FileReader::read` freed the
+  old buffer before allocating the new one but left the recorded size behind, so after a transient
+  allocation failure the next *smaller* read saw enough capacity, skipped the realloc, and read into
+  a null pointer — every subsequent read on that lane failing forever. The size is now cleared with
+  the pointer, so a failure costs one read instead of the lane.
+- **The buffered fallback stops paying O_DIRECT's mechanics.** When the platform refuses O_DIRECT, or
+  the open-time verify catches storage that mis-serves it (a FUSE-backed volume), reads still aligned
+  their window outward, staged into the bounce and memcpy'd the interior out — an extra copy of every
+  byte plus a leading partial-block over-read, in the mode that is already the slow one. Buffered
+  reads now go straight into the caller's memory, and report the bytes they actually moved rather
+  than a window they never pulled.
+- **A missing buffered tail fd is reported where it happens.** Its open was unchecked, and a read
+  reaching the file's sub-alignment EOF tail then fell back to the O_DIRECT fd — which must reject a
+  length that short — surfacing fd exhaustion as an unexplained read failure. It is now reported at
+  open, and a tail read that cannot be served says which fd is missing.
+
+### Changed
+- `vm_reserve` maps with `MAP_NORESERVE`, making the address-only contract true rather than
+  true-by-default: the expert cache reserves each span at full size and commits only resident
+  slices, so the untouched remainder should never be charged against a strict overcommit limit.
+- `pio::file_size` asks `fstat` instead of seeking to the end and back. Every consumer reads with
+  `pread`, so the fd position was mutated to answer a question about the file and nothing used it.
+
 ## [0.16.0] - 2026-07-28
 
 ### Added

--- a/core/src/io/file_reader.cpp
+++ b/core/src/io/file_reader.cpp
@@ -75,6 +75,11 @@ bool FileReader::open(const std::string & path, int lanes, bool direct, size_t a
             close();
             return false;
         }
+        // Not fatal — the buffered fd is only needed for a read that runs into a sub-alignment EOF
+        // tail, which expert slices never do. But say so here, where the cause (fd pressure) is still
+        // visible, rather than leaving a later tail read to fail with an unexplained EINVAL.
+        if (direct_ && !pio::fd_ok(fds_buf_[lane]))
+            std::fprintf(stderr, "bmoe: lane %d buffered tail fd unavailable — EOF-tail reads will fail\n", lane);
         bounces_[lane] = pio::alloc_aligned(align_, bounce_cap);
         if (!bounces_[lane]) {
             std::fprintf(stderr, "bmoe: lane %d bounce alloc failed\n", lane);
@@ -88,11 +93,41 @@ bool FileReader::open(const std::string & path, int lanes, bool direct, size_t a
 
 long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) {
     if (nbytes == 0) return 0;
+    const pio::fd_t fd = fds_[lane];
+
+    // Buffered mode: no alignment constraint, so the bounce buys nothing. Read straight into the
+    // caller's memory. This is the fallback path (the platform refused O_DIRECT, or the open-time
+    // verify caught storage that mis-serves it) and is already the slow mode — it must not also pay
+    // an extra copy of every byte plus a leading partial-block over-read just to share the mechanics
+    // O_DIRECT needs.
+    if (!direct_) {
+        const uint64_t end = (fsize_ && off + nbytes > fsize_) ? fsize_ : off + nbytes;
+        const auto t0 = clock_t_::now();
+        for (uint64_t a = off; a < end;) {
+            long long got = pio::pread_at(fd, (char *) dst + (a - off), (size_t) (end - a), a);
+            if (got <= 0) {
+                std::fprintf(stderr, "bmoe: pread failed at %llu\n", (unsigned long long) a);
+                return -1;
+            }
+            a += (uint64_t) got;
+        }
+        const auto t1 = clock_t_::now();
+        syscall_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+        const long long moved = (long long) (end - off);
+        read_bytes_.fetch_add(moved);
+        return moved; // no aligned window here: what was asked for is what was pulled
+    }
+
     const uint64_t a0 = off & ~(uint64_t) (align_ - 1);
     const uint64_t a1 = (off + nbytes + align_ - 1) & ~(uint64_t) (align_ - 1);
     const size_t len = (size_t) (a1 - a0);
     if (bounce_sz_[lane] < len) {
+        // Clear the size BEFORE the allocation: on failure the lane must look empty, not keep
+        // advertising the freed buffer's capacity — a later smaller read would skip the realloc and
+        // pread into a null pointer, turning one transient OOM into a permanently dead lane.
         if (bounces_[lane]) pio::aligned_free(bounces_[lane]);
+        bounces_[lane] = nullptr;
+        bounce_sz_[lane] = 0;
         bounces_[lane] = pio::alloc_aligned(align_, len);
         if (!bounces_[lane]) {
             std::fprintf(stderr, "bmoe: bounce realloc %zu failed\n", len);
@@ -101,10 +136,9 @@ long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) 
         bounce_sz_[lane] = len;
     }
     char * b = (char *) bounces_[lane];
-    const pio::fd_t fd = fds_[lane];
     const pio::fd_t fd_buf = fds_buf_[lane];
     const uint64_t read_end = (fsize_ && a1 > fsize_) ? fsize_ : a1;
-    const uint64_t bulk_end = direct_ ? (read_end & ~(uint64_t) (align_ - 1)) : read_end;
+    const uint64_t bulk_end = read_end & ~(uint64_t) (align_ - 1);
 
     const auto t0 = clock_t_::now();
     for (uint64_t a = a0; a < bulk_end;) {
@@ -115,8 +149,14 @@ long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) 
         }
         a += (uint64_t) got;
     }
+    if (bulk_end < read_end && !pio::fd_ok(fd_buf)) {
+        // The O_DIRECT fd would reject the sub-alignment length outright; say what is actually wrong.
+        std::fprintf(stderr, "bmoe: EOF tail at %llu needs the buffered fd, which failed to open\n",
+                     (unsigned long long) bulk_end);
+        return -1;
+    }
     for (uint64_t a = bulk_end; a < read_end;) { // sub-alignment EOF tail via the buffered fd
-        long long got = pio::pread_at(pio::fd_ok(fd_buf) ? fd_buf : fd, b + (a - a0), (size_t) (read_end - a), a);
+        long long got = pio::pread_at(fd_buf, b + (a - a0), (size_t) (read_end - a), a);
         if (got <= 0) {
             std::fprintf(stderr, "bmoe: tail pread failed at %llu\n", (unsigned long long) a);
             return -1;

--- a/core/src/io/file_reader.h
+++ b/core/src/io/file_reader.h
@@ -1,9 +1,10 @@
 // A pooled, positioned file reader with optional cache-bypassing (O_DIRECT) I/O.
 //
 // One reader owns N lane fds and N bounce buffers, so N threads can read distinct byte ranges of the
-// same file concurrently without contending. Each read aligns its window to the device block size,
-// pulls it into the lane's bounce buffer, and memcpy's the requested interior out — the mechanics
-// O_DIRECT requires. `direct` is a property of the reader, chosen by whoever opens it: the expert
+// same file concurrently without contending. A direct read aligns its window to the device block
+// size, pulls it into the lane's bounce buffer, and memcpy's the requested interior out — the
+// mechanics O_DIRECT requires; a buffered read has no such constraint and goes straight into the
+// caller's memory. `direct` is a property of the reader, chosen by whoever opens it: the expert
 // streamer and the dense-weights loader each construct their own, so one can bypass the page cache
 // while the other does not — the two O_DIRECT decisions are independent, not a shared global.
 //
@@ -41,9 +42,10 @@ public:
     int lanes() const { return (int) fds_.size(); }
 
     // Read `nbytes` at file offset `off` into `dst`, on `lane` (0 <= lane < lanes()). Thread-safe
-    // across distinct lanes — each has its own fd and bounce. Returns the aligned window actually
-    // pulled from the drive (>= nbytes; what the bandwidth must be judged against), or -1 on I/O
-    // error. A zero-length read is a no-op returning 0. The lane's bounce grows if a read needs more.
+    // across distinct lanes — each has its own fd and bounce. Returns what was actually pulled from
+    // the drive — the aligned window (>= nbytes) when direct, exactly the requested bytes when
+    // buffered — which is what the bandwidth must be judged against; or -1 on I/O error. A
+    // zero-length read is a no-op returning 0. The lane's bounce grows if a direct read needs more.
     long long read(int lane, void * dst, uint64_t off, uint64_t nbytes);
 
     // Aggregate accounting since open, summed across lanes.

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -16,12 +16,16 @@
 #include <cstring>
 #include <sys/mman.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <ctime>
 #ifndef O_DIRECT
 #define O_DIRECT 0
 #endif
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
+#endif
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0 // absent on some BSDs; the mapping is simply charged as usual there
 #endif
 #if defined(__ANDROID__)
 #include <android/hardware_buffer.h> // reclaim-exempt allocation; see pinned_alloc
@@ -171,9 +175,11 @@ long long pread_at(fd_t fd, void * buf, size_t count, uint64_t off) {
 }
 
 uint64_t file_size(fd_t fd) {
-    off_t sz = lseek(fd, 0, SEEK_END);
-    lseek(fd, 0, SEEK_SET);
-    return sz > 0 ? (uint64_t) sz : 0;
+    // fstat rather than a seek pair: every consumer reads with pread, so the fd's file position is
+    // never used — and mutating shared fd state to answer a question about the file is a trap waiting
+    // for the first caller that does rely on the position.
+    struct stat st;
+    return fstat(fd, &st) == 0 && st.st_size > 0 ? (uint64_t) st.st_size : 0;
 }
 
 void * alloc_aligned(size_t align, size_t sz) {
@@ -189,7 +195,11 @@ size_t vm_page() {
     return ps > 0 ? (size_t) ps : 4096;
 }
 void * vm_reserve(size_t sz) {
-    void * p = mmap(nullptr, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    // MAP_NORESERVE makes the "address-only" contract true rather than merely true-by-default: these
+    // spans are reserved at full expert-set size but only ever committed for resident slices, so the
+    // untouched remainder must not be charged against the commit limit (which is what strict
+    // overcommit would do, refusing a reservation the cache never intends to fill).
+    void * p = mmap(nullptr, sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
     return p == MAP_FAILED ? nullptr : p;
 }
 bool vm_commit(void * /*p*/, size_t /*sz*/) {


### PR DESCRIPTION
Three defects in the I/O layer, found in an audit of `core/` with a performance lens. All sit in the seam between what O_DIRECT requires and what the buffered fallback actually needs.

### A failed bounce reallocation killed the lane permanently

`FileReader::read` grows the lane's bounce when a read needs a wider window. It freed the old buffer first, then allocated — and on failure returned `-1` leaving `bounce_sz_` at the **old** capacity with a null pointer. The next *smaller* read then passed the capacity test, skipped the realloc, and preadd into null. One transient allocation failure turned into a lane that fails every read for the rest of the run.

The size is now cleared together with the pointer.

### The buffered fallback paid for mechanics it does not need

The buffered path is taken when the platform refuses O_DIRECT outright, or when the open-time verify catches storage that mis-serves it — the FUSE-backed volume case that already costs us the page-cache double residency. That path still aligned its window outward, staged the whole thing into the bounce, and memcpy'd the interior out. Buffered `pread` has no alignment constraint, so all of it was cost stacked onto the mode that is already the slow one: one extra copy of every byte, plus up to `align-1` bytes of head over-read per call.

Buffered reads now go straight into the caller's memory. The return value follows: the aligned window is a direct-mode concept, so buffered mode reports the bytes it actually moved rather than a window it never pulled — which also makes the effective-bandwidth accounting honest in that mode.

### A missing tail fd surfaced far from its cause

Each lane opens a second, buffered fd for the sub-alignment EOF tail an O_DIRECT read cannot cover. That open was unchecked; when it failed, the tail read fell back to the O_DIRECT fd with a length the kernel must reject. So fd exhaustion appeared as an unexplained read failure at an arbitrary offset. It is now reported at open — non-fatally, since expert slices never reach the file's tail — and a tail read that cannot be served names the missing fd.

### Also

- `vm_reserve` maps with `MAP_NORESERVE`. The expert cache reserves each span at full expert-set size and commits pages only for resident slices, so the untouched remainder should not be charged against a commit limit. Under the default heuristic overcommit this changes nothing; it makes the address-only contract true by construction rather than by the host's configuration.
- `pio::file_size` uses `fstat` instead of `lseek(SEEK_END)` + `lseek(SEEK_SET)`. Every consumer reads with `pread`, so the fd position was being mutated to answer a question about the file, and the reset existed only to undo that.

### Verification

Host build clean, byte-identity gates 7/7. No behaviour change on the shipping path (Android/adb storage serves O_DIRECT, so the direct path is untouched); the buffered changes are exercised whenever the verify downgrades.
