### PR TITLE
fix(moe): locate router weights by the routing's shape, not by ne[0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Fixed
+- **Router weights are located by the routing's shape, not by a test a top-1 routing defeats.** The
+  helper that finds token `j`'s slot `k` inside a weight node told the 3-D `[1, nu, nt]` node from
+  the norm variant's pre-reshape 2-D `[nu, nt]` by asking whether `ne[0] == 1`. With `n_expert_used`
+  of 1 the 2-D node *is* `[1, nt]`, passes that test, and is read with the 3-D token stride — so
+  every token after the first is read from the wrong row, and under `--drop-cold-experts` in prefill
+  the policy's writes land on the wrong slot. It now matches the full extents against the routing's
+  own width and batch size, which separates the two shapes exactly; where both fit (a single token
+  at top-1) they name the same element. No shipped model in the catalog routes top-1, so this was
+  latent rather than active.
 - **A failed bounce reallocation no longer kills the lane for good.** `FileReader::read` freed the
   old buffer before allocating the new one but left the recorded size behind, so after a transient
   allocation failure the next *smaller* read saw enough capacity, skipped the realloc, and read into

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -59,15 +59,25 @@ static bool match_weights(const char * name, int & il_out) {
     return false;
 }
 
-// Gather the top-k router weights for every token of the batch. The node is [1, nu, nt] as built
-// (token j at nb[2], slot k at nb[1]) — except the norm variant, whose callback fires on the
-// pre-reshape 2-D [nu, nt] (token j at nb[1], slot k at nb[0]). ne[0] == 1 tells the two apart.
-// As with the topk ids, these are views: only the strides say where a token's row really starts.
 // Where token j's slot k lives inside a weight node. Single source of truth for the layout: the
-// reader below and the drop policy's writer must agree, or the policy would zero another token's
+// gather below and the drop policy's writer must agree, or the policy would zero another token's
 // slot. Returns a mutable pointer; the gather takes a const tensor and only reads through it.
-static float * weight_at(const ggml_tensor * t, int j, int k) {
-    const bool three_d = t->ne[0] == 1;
+//
+// The node is [1, nu, nt] as built (token j at nb[2], slot k at nb[1]) — except the norm variant,
+// whose callback fires on the pre-reshape 2-D [nu, nt] (token j at nb[1], slot k at nb[0]). As with
+// the topk ids these are views, so only the strides say where a token's row really starts.
+//
+// The routing's own width and batch size are what tell the two shapes apart. `ne[0] == 1` alone
+// does NOT: a top-1 routing makes the 2-D node [1, nt], which passes that test and would be read
+// with the token stride of a 3-D node — sending every token after the first to the wrong row, and
+// the drop policy's writes to the wrong slot. Match the full extents instead. Both fit only when
+// nu and nt are 1, where the two layouts name the same single element.
+static float * weight_at(const ggml_tensor * t, int nu, int nt, int j, int k) {
+    const bool fits_3d = t->ne[0] == 1 && t->ne[1] == nu && t->ne[2] == nt;
+    const bool fits_2d = t->ne[0] == nu && t->ne[1] == nt && t->ne[2] == 1;
+    // Neither fits only if the graph produced a shape build_moe_ffn does not emit; keep the old
+    // test as the fallback rather than inventing an offset for a node we do not recognise.
+    const bool three_d = fits_3d || (!fits_2d && t->ne[0] == 1);
     const size_t tok_nb = three_d ? t->nb[2] : t->nb[1];
     const size_t slot_nb = three_d ? t->nb[1] : t->nb[0];
     return (float *) ((char *) t->data + (size_t) j * tok_nb + (size_t) k * slot_nb);
@@ -77,7 +87,7 @@ static void gather_weights(const ggml_tensor * t, int nu, int nt, std::vector<fl
     out.assign((size_t) nu * nt, 0.0f);
     for (int j = 0; j < nt; ++j)
         for (int k = 0; k < nu; ++k)
-            out[(size_t) j * nu + k] = *weight_at(t, j, k);
+            out[(size_t) j * nu + k] = *weight_at(t, nu, nt, j, k);
 }
 
 // Same, for the selected-expert ids. The node is a VIEW of the full argsort, so the row stride is
@@ -160,7 +170,7 @@ void RouterHook::apply_drop(ggml_tensor * wt) {
                 kept += drop_w_[idx];
                 continue;
             }
-            *weight_at(wt, j, k) = 0.0f;
+            *weight_at(wt, nu, nt, j, k) = 0.0f;
             *id_at(D.ids, j, k) = best_id;
             drop_ids_[idx] = best_id;
             drop_mask_[idx] = 1;
@@ -174,7 +184,7 @@ void RouterHook::apply_drop(ggml_tensor * wt) {
         if (drop_renorm_ && n_dropped > 0 && kept > 0.0f) {
             const float g = total / kept;
             for (int k = 0; k < nu; ++k)
-                if (!drop_mask_[row + k]) *weight_at(wt, j, k) *= g;
+                if (!drop_mask_[row + k]) *weight_at(wt, nu, nt, j, k) *= g;
         }
     }
 


### PR DESCRIPTION
`weight_at` is the single source of truth for where token `j`'s slot `k` sits inside a router-weight node. The route trace reads through it and the drop policy writes through it, and the two agreeing is precisely what stops the policy from zeroing a different token's slot.

It distinguished the 3-D `[1, nu, nt]` node — the shape `build_moe_ffn` builds — from the norm variant's pre-reshape 2-D `[nu, nt]` by asking whether `ne[0] == 1`.

That test holds only while the routing is wider than one expert. **At `n_expert_used == 1` the 2-D node is `[1, nt]`**: it passes the `ne[0] == 1` test, is read with `nb[2]` as the token stride instead of `nb[1]`, and every token after the first comes from the wrong row. With `--drop-cold-experts` armed in prefill, the same misreading sends the policy's zeroing and its renormalisation writes to the wrong slot.

### The fix

Match the full extents against the routing's own `nu` and `nt`, which both call sites already have on hand:

- `[1, nu, nt]` with `ne[2] == nt` → 3-D
- `[nu, nt, 1]` → 2-D

These are mutually exclusive whenever it matters. Where both fit — a single token at top-1 — the two layouts name the same single element, so either answer is correct. A shape matching neither keeps the old `ne[0]` test rather than inventing an offset for a node we do not recognise.

### Why the gates did not catch it

`G8c` runs the drop policy at full strength with **top-k = 1**, which is exactly the configuration at issue, and passes both before and after. It decodes one token at a time: at `nt == 1` the wrong token stride is multiplied by `j == 0`, so it never moves the pointer. The bug needs `nt > 1` — prefill — together with top-1 routing and the norm gating variant.

No model in the shipped catalog routes top-1, so this is latent rather than active. It is a correctness fix in a helper documented as the layout's single source of truth, which is a bad place to leave a shape assumption that a legal configuration defeats.

### Verification

Byte-identity gates 7/7, format gate clean. Behaviour is unchanged for every routing width the catalog actually uses — for `nu > 1` the extent match and the old `ne[0]` test select the same layout.
