### PR TITLE
fix(moe): publish a speculated expert whole, and wake only real waiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ Semantic Versioning.
   own width and batch size, which separates the two shapes exactly; where both fit (a single token
   at top-1) they name the same element. No shipped model in the catalog routes top-1, so this was
   latent rather than active.
+- **A failed page commit can no longer blacklist an expert from speculation for the rest of the
+  run.** `prefetch()` pushed a speculative read job per projection as it went, but recorded the
+  entry's pending count only after the last one. If a commit failed part-way through an expert, its
+  earlier jobs stayed queued against a count that was never set: a worker would decrement it below
+  zero, so the entry could never complete, the quiesce never saw it listed to release its pages, and
+  every later prefetch of that expert was skipped by the "already queued" test. An expert's jobs are
+  now staged and published as a unit, and a part-way failure hands its pages back. The path is
+  reachable only where page commit can fail (it is a no-op on POSIX), and only with prefetching on.
+- **`prefetch()` no longer holds the I/O mutex across its page commits.** It runs on the eval thread
+  immediately after a real batch was published, so a syscall per projection inside the lock stalled
+  the very lanes trying to pull real read indices out of it — undercutting the invariant that
+  speculation never delays real work. Pages are committed before the lock is taken; the lock now
+  covers only the bookkeeping.
 - **A failed bounce reallocation no longer kills the lane for good.** `FileReader::read` freed the
   old buffer before allocating the new one but left the recorded size behind, so after a transient
   allocation failure the next *smaller* read saw enough capacity, skipped the realloc, and read into
@@ -44,6 +57,14 @@ Semantic Versioning.
   an integer compare instead of a string one — on a path that ran for every weight node of every
   layer of every token with the drop policy armed. No routing decision changes; the byte-identity
   gates cover it.
+- **A completed slice read wakes a compute thread only when one is actually waiting.** Every
+  completed read took the readiness mutex and ran `notify_all`, waking *every* compute thread
+  blocked on *any* expert so each could re-check a predicate that was almost never its own — and
+  paying the mutex even in the common case where nobody was blocked at all, because the slice landed
+  inside the spin. Waiters now register themselves, and the publisher consults that count first.
+  Registration and publication are both sequentially consistent, so the two cannot miss each other:
+  either the waiter sees the flag already set and never sleeps, or the publisher sees the
+  registration and notifies.
 - `vm_reserve` maps with `MAP_NORESERVE`, making the address-only contract true rather than
   true-by-default: the expert cache reserves each span at full size and commits only resident
   slices, so the untouched remainder should never be charged against a strict overcommit limit.

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -274,8 +274,14 @@ void ExpertStreamSource::io_drain(int lane, uint64_t my_gen) {
         // in-flight batch, fixed until it fully drains) and wake any compute thread blocked on
         // it. Notify even on failure so a straggler wakes and observes fatal_ instead of hanging.
         if (j.flag >= 0) {
-            ready_[(size_t) j.flag].gen.store(batch_flag_gen_, std::memory_order_release);
-            {
+            // Publish first, then look for waiters. on_expert_ready registers itself before its own
+            // last look at the flag, and both operations are seq_cst, so the two cannot miss each
+            // other: either the compute thread sees the flag and never sleeps, or it is counted here
+            // and gets woken. With nobody waiting — the common case, since a slice usually lands
+            // inside the spin — this costs one atomic load instead of a mutex plus a notify_all that
+            // woke EVERY compute thread blocked on ANY expert to re-check its own predicate.
+            ready_[(size_t) j.flag].gen.store(batch_flag_gen_, std::memory_order_seq_cst);
+            if (ready_waiters_.load(std::memory_order_seq_cst) != 0) {
                 std::lock_guard<std::mutex> lk(ready_mtx_);
                 ready_cv_.notify_all();
             }
@@ -314,30 +320,70 @@ void ExpertStreamSource::prefetch(int il, const int32_t * ids, int n_ids) {
     if (!active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0) return;
     const LayerExperts & L = layers_[il];
     bool any = false;
-    std::lock_guard<std::mutex> lk(io_mtx_);
+
+    // Stage each expert's jobs locally and publish them only once ALL of its projections have been
+    // committed. Pushing them as they were built meant a commit failure mid-expert could leave jobs
+    // queued for an entry whose spec_remaining_ was never set: a worker would then decrement it from
+    // zero, the entry could never reach zero to complete, the quiesce would never see it in
+    // spec_touched_ to release, and the `!= 0` guard above would skip that expert's speculation for
+    // the rest of the run. One failure, permanent damage — in exactly the low-memory situation this
+    // path exists to degrade gracefully in.
+    //
+    // Committing before taking io_mtx_ matters for the same call: prefetch runs on the eval thread
+    // right after a real batch was published, so holding the mutex across a syscall per projection
+    // stalls the lanes trying to pull real read indices out of it. The pages are the eval thread's
+    // to commit — no worker touches them until the jobs below exist.
+    std::vector<IoJob> & staged = spec_stage_;
+    std::vector<int32_t> & staged_ids = spec_stage_ids_;
+    std::vector<int> & staged_counts = spec_stage_counts_;
+    staged.clear();
+    staged_ids.clear();
+    staged_counts.clear();
     for (int i = 0; i < n_ids; ++i) {
         const int e = ids[i];
         if (e < 0 || e >= n_expert_) continue;
         const int32_t id = il * n_expert_ + e;
-        if (cvalid_[id] || spec_remaining_[id] != 0) continue; // already resident or already queued
+        {
+            std::lock_guard<std::mutex> lk(io_mtx_);
+            if (cvalid_[id] || spec_remaining_[id] != 0) continue; // already resident or already queued
+        }
+        const size_t mark = staged.size();
         int njobs = 0;
+        bool ok = true;
         for (int p = 0; p < MoeRecipe::max_exps; ++p) {
             const uint64_t slice = L.proj[p].nb2;
             if (slice == 0) continue;
             char * dst = (char *) lbuf_[p][il] + (uint64_t) e * slice;
             uintptr_t a0 = (uintptr_t) dst & ~(uintptr_t) (page_ - 1);
             uintptr_t a1 = ((uintptr_t) dst + slice + page_ - 1) & ~(uintptr_t) (page_ - 1);
-            if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) return; // low on memory — stop quietly
-            spec_jobs_.push_back(
+            if (!pio::vm_commit((void *) a0, (size_t) (a1 - a0))) { // low on memory — stop quietly
+                ok = false;
+                break;
+            }
+            staged.push_back(
                 {dst, L.proj[p].file_off + (uint64_t) e * slice, slice, id, e, (int16_t) il, (int8_t) p, 1});
             ++njobs;
         }
+        if (!ok) {
+            // Hand back what this expert already committed and drop its jobs: an entry is queued
+            // whole or not at all.
+            staged.resize(mark);
+            release_entry_pages(id);
+            break;
+        }
         if (njobs == 0) continue;
-        spec_remaining_[id] = njobs;
-        spec_touched_.push_back(id);
+        staged_ids.push_back(id);
+        staged_counts.push_back(njobs);
         any = true;
     }
     if (!any) return;
+
+    std::lock_guard<std::mutex> lk(io_mtx_);
+    for (size_t s = 0; s < staged_ids.size(); ++s) {
+        spec_remaining_[staged_ids[s]] = staged_counts[s];
+        spec_touched_.push_back(staged_ids[s]);
+    }
+    spec_jobs_.insert(spec_jobs_.end(), staged.begin(), staged.end());
     if (prefetch_sync_) {
         // Test path: read the queued slices now on lane 0 (free on the eval thread in serial mode),
         // so the next quiesce integrates them deterministically. Mirrors drain_spec's accounting.
@@ -916,12 +962,19 @@ void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
         }
         std::this_thread::yield();
     }
-    {
+    // Register as a waiter BEFORE the last look at the flag. The publisher sets the flag before it
+    // reads this count, and both sides are seq_cst, so one of the two must observe the other: either
+    // the flag is already set here and this thread never sleeps, or the publisher sees a non-zero
+    // count and notifies. That is what lets io_drain skip the mutex and the notify_all when no
+    // compute thread is blocked, which is the usual case.
+    ready_waiters_.fetch_add(1, std::memory_order_seq_cst);
+    if (ready_[idx].gen.load(std::memory_order_seq_cst) != want && !fatal_.load(std::memory_order_acquire)) {
         std::unique_lock<std::mutex> lk(ready_mtx_);
         ready_cv_.wait(lk, [&] {
             return ready_[idx].gen.load(std::memory_order_acquire) == want || fatal_.load(std::memory_order_acquire);
         });
     }
+    ready_waiters_.fetch_sub(1, std::memory_order_seq_cst);
     stall_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
 }
 

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -247,6 +247,13 @@ private:
     std::vector<int32_t> spec_done_;      // entry ids whose every projection read completed
     std::vector<int32_t> spec_touched_;   // entry ids queued this round (for cleanup at quiesce)
     std::vector<int32_t> spec_remaining_; // per entry id: projection reads still pending (0 = none)
+    // Scratch for prefetch(): an expert's jobs are built here and published only once all of its
+    // projections have been committed, so a commit that fails part-way can never leave jobs queued
+    // against accounting that was never set up. Members rather than locals so the path stays
+    // allocation-free after the first call, like the other per-load scratch.
+    std::vector<IoJob> spec_stage_;
+    std::vector<int32_t> spec_stage_ids_;
+    std::vector<int> spec_stage_counts_;
     std::atomic<long long> spec_read_bytes_{0};
     std::atomic<long long> spec_experts_{0};
     std::atomic<long long> spec_useful_{0};
@@ -279,6 +286,12 @@ private:
     std::atomic<bool> fatal_{false};
     std::mutex ready_mtx_;
     std::condition_variable ready_cv_;
+    // How many compute threads are currently registered to block on a readiness flag. A completing
+    // read consults this before taking ready_mtx_: with no waiter there is nothing to wake, and
+    // notifying anyway woke every blocked compute thread on every slice completion so each could
+    // re-check a predicate that was almost never its own. Registration and publication are both
+    // seq_cst so the two cannot miss each other — see on_expert_ready.
+    std::atomic<int> ready_waiters_{0};
     std::atomic<long long> stall_ns_{0};              // summed across all stalling compute threads
     std::unordered_map<const void *, uint32_t> texp_; // expert tensor* -> (il<<8)|p, built in init
     std::vector<int> staged_;                         // per-load sorted unique expert scratch


### PR DESCRIPTION
Two defects in the overlap and speculation paths.

### A failed commit could blacklist an expert from speculation permanently

`prefetch()` pushed a speculative read job **per projection as it built them**, and set the entry's pending count only after the last one succeeded:

```cpp
for (p : projections) {
    if (!vm_commit(...)) return;      // <-- jobs for p-1, p-2 … are already queued
    spec_jobs_.push_back(...);
}
spec_remaining_[id] = njobs;          // <-- never reached
spec_touched_.push_back(id);
```

A commit failing part-way therefore returned with jobs queued against a count that was never set. The consequences compound:

1. A worker draining one of those orphans does `--spec_remaining_[id]`, taking it from 0 to **-1**.
2. It can never reach 0, so the entry never completes and never integrates.
3. `quiesce_spec` cleans up via `spec_touched_`, which the entry never made it into — so its committed pages are never released.
4. The `spec_remaining_[id] != 0` guard at the top of `prefetch` now skips that expert **for the rest of the run**.

One transient failure, permanent damage — in exactly the low-memory situation this path exists to degrade gracefully in. (It is reachable only where page commit can actually fail; on POSIX `vm_commit` is a no-op returning true, so this is Windows-and-prefetch-only today. It is still a real state-corruption bug in the accounting.)

**Fix:** stage an expert's jobs and publish them as a unit once every projection is committed; on a part-way failure, release the pages it did commit and stop. The staging vectors are members, so the path stays allocation-free after the first call, matching the other per-load scratch.

### `prefetch()` held the I/O mutex across its page commits

The whole function ran under one `lock_guard(io_mtx_)`, spanning a `vm_commit` syscall per projection per speculated expert. `prefetch` is invoked from `predict_after_load` — on the eval thread, immediately after a real batch was published — which is exactly when the worker lanes are contending on that same mutex to pull real read indices. Every commit inside the lock delayed real work, undercutting the one invariant speculation must keep.

Commits now happen before the lock; the lock covers only the bookkeeping. (The `prefetch_sync_` test path still reads under the lock — it is the deterministic ordering gate `G5c` depends on, and it is not a shipping path.)

### Every slice completion woke every compute thread

```cpp
ready_[j.flag].gen.store(batch_flag_gen_);
{ std::lock_guard lk(ready_mtx_); ready_cv_.notify_all(); }   // every job, unconditionally
```

With the compute threads parked past the spin window, each of the ~3×k slice completions per layer woke *all* of them, so each could evaluate its own predicate and — usually — go back to sleep. And the common case pays too: when the slice lands inside the spin nobody is blocked at all, yet the mutex is still taken and the notify still issued.

**Fix:** waiters register in an atomic count; the publisher consults it and skips the mutex entirely when it is zero. The ordering is the load-bearing part — `on_expert_ready` registers **before** its last look at the flag, `io_drain` publishes the flag **before** reading the count, and both are `seq_cst`. In the total order one must observe the other: either the waiter sees the flag already set and never sleeps, or the publisher sees the registration and notifies. The `wait` predicate is unchanged and still covers `fatal_`.

### Considered and declined

Folding the `done_cnt_` increment into the same critical section as the next-index fetch. It removes one uncontended mutex acquisition per job, against reads that cost ~100 µs — not worth perturbing the drain protocol for.

### Verification

Gates 7/7. The overlap set (`G4a`/`G4b`/`G4c`) was run five times over so a missed wakeup would have a chance to hang rather than hide; the speculation gates (`G5a`–`G5c`, `G10a`) cover the prefetch changes. Format gate clean.

No on-device A/B — no phone attached to this session — so no throughput claim is made here or in the changelog; it is tracked with the other audit follow-ups.
