### PR TITLE
perf(engine): build a token's rendered view only when something reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Semantic Versioning.
   byte plus a leading partial-block over-read, in the mode that is already the slow one. Buffered
   reads now go straight into the caller's memory, and report the bytes they actually moved rather
   than a window they never pulled.
+- **`--compute-trace` and `--io-trace` are no longer ignored in `--session` mode.** The CLI parsed
+  the flags, opened the files and wrote their headers, then dropped both sinks on the floor when it
+  entered the session loop — leaving an empty trace and nothing saying why. Both are now passed
+  through, so they work in a session exactly as in a one-shot run.
 - **A missing buffered tail fd is reported where it happens.** Its open was unchecked, and a read
   reaching the file's sub-alignment EOF tail then fell back to the O_DIRECT fd — which must reject a
   length that short — surfacing fd exhaustion as an unexplained read failure. It is now reported at
@@ -65,6 +69,16 @@ Semantic Versioning.
   Registration and publication are both sequentially consistent, so the two cannot miss each other:
   either the waiter sees the flag already set and never sleeps, or the publisher sees the
   registration and notifies.
+- **The generation loop stops re-parsing the whole answer for readers that do not exist.** Building
+  a token's rendered view means parsing everything generated so far — the chat parser cannot resume
+  — so it costs O(n) per token, O(n²) over a turn, and off the chat path it was a full copy of the
+  generation on top. It ran unconditionally, including for the plain CLI output that writes only
+  `piece` and for every benchmark run, which read neither field. `GenerateRequest::render_text` now
+  says whether anything will read it: the line protocol sets it (a UI renders a running answer), the
+  default CLI path and `run()` without `--progress` do not. It defaults to on, so an embedder that
+  has never heard of the flag keeps the previous behaviour.
+- **The finished answer is parsed once instead of twice.** The returned text and the history commit
+  asked the same question of the same string and each paid its own full non-partial parse.
 - `vm_reserve` maps with `MAP_NORESERVE`, making the address-only contract true rather than
   true-by-default: the expert cache reserves each span at full size and commits only resident
   slices, so the untouched remainder should never be charged against a strict overcommit limit.

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -194,11 +194,15 @@ struct SessionCmd {
 // Interactive session: keep the model loaded and the expert cache warm across prompts, reading
 // one JSON request per line from stdin and emitting the BMOE_* line protocol on stdout. See
 // docs/telemetry.md. Returns the process exit code.
-static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTraceSink * route_trace) {
+static int run_session_loop(const RunConfig & cfg,
+                            IMetricsSink * sink,
+                            IRouteTraceSink * route_trace,
+                            IComputeTraceSink * compute_trace,
+                            IIoTraceSink * io_trace) {
     const SessionConfig sc = session_config_from(cfg);
 
     std::string error;
-    std::unique_ptr<Session> session = Session::open(sc, error, route_trace);
+    std::unique_ptr<Session> session = Session::open(sc, error, route_trace, compute_trace, io_trace);
     if (!session) {
         std::printf("BMOE_ERROR {\"id\":0,\"fatal\":true,\"msg\":\"%s\"}\n", json_escape(error).c_str());
         std::fflush(stdout);
@@ -278,6 +282,7 @@ static int run_session_loop(const RunConfig & cfg, IMetricsSink * sink, IRouteTr
         req.n_predict = cmd.n_predict;
         req.think = cmd.think;
         req.clear_kv = cmd.clear_kv;
+        req.render_text = true; // the line protocol carries the parsed answer on every token
 
         RunResult r = session->generate(req, emit_progress_line, sink);
         if (!r) {
@@ -657,7 +662,7 @@ int main(int argc, char ** argv) {
     // Interactive session: one persistent process serves many prompts over stdin, keeping the
     // model loaded and the expert cache warm between them. Prompts arrive as JSON requests, not
     // via -p. This is a superset of --progress output (BMOE_* lines), so it never streams inline.
-    if (session_mode) return run_session_loop(cfg, sink.get(), route_trace.get());
+    if (session_mode) return run_session_loop(cfg, sink.get(), route_trace.get(), compute_trace.get(), io_trace.get());
 
     if (!cfg.progress) {
         std::printf("%s", cfg.prompt.c_str());

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -82,6 +82,13 @@ struct GenerateRequest {
     int n_predict = 32;
     bool think = true;
     bool clear_kv = true;
+    // Populate TokenMetrics::text / ::reasoning on every token. Building them means parsing the
+    // WHOLE generation so far — the chat parser cannot resume — so it is O(n) per token and O(n²)
+    // over a turn, and in chat mode it also allocates a copy of everything generated. A UI that
+    // renders a running answer needs it; a consumer that only concatenates `piece` (the CLI's
+    // default output, and every benchmark run) does not, and should turn it off. Default on so an
+    // embedder that does not know about this flag keeps the old behaviour.
+    bool render_text = true;
 };
 
 class Session {

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -53,6 +53,10 @@ RunResult run(const RunConfig & cfg,
     req.n_predict = cfg.n_predict;
     req.think = cfg.think;
     req.clear_kv = true;
+    // Only --progress reads the per-token parsed answer; the plain path writes `piece` as it goes,
+    // and a benchmark run reads neither. Building it re-parses the whole generation every token, so
+    // an unread one is O(n²) of nothing. The final answer is parsed once at the end either way.
+    req.render_text = cfg.progress;
 
     return session->generate(req, on_token, sink);
 }

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -880,9 +880,10 @@ RunResult Session::generate(const GenerateRequest & req,
         tally.prev_mgmt_s = st0.mgmt_seconds;
         tally.prev_stall_s = st0.stall_seconds;
     }
-    long long prev_spec_bytes = moe.enabled ? (long long) im.source.stats().spec_read_bytes : 0;
-    long long prev_spec_experts = moe.enabled ? im.source.stats().spec_experts : 0;
-    long long prev_spec_useful = moe.enabled ? im.source.stats().spec_useful : 0;
+    const IExpertSource::Stats st_spec0 = moe.enabled ? im.source.stats() : IExpertSource::Stats{};
+    long long prev_spec_bytes = (long long) st_spec0.spec_read_bytes;
+    long long prev_spec_experts = st_spec0.spec_experts;
+    long long prev_spec_useful = st_spec0.spec_useful;
     // Taken after prefill, so the drop counters describe generation — the phase the policy is armed
     // for and the one the tok/s number is about.
     const long long prev_routed = im.hook->experts_routed();
@@ -931,7 +932,9 @@ RunResult Session::generate(const GenerateRequest & req,
         m.step = n_gen;
         m.steps = req.n_predict;
         m.piece = delta;
-        {
+        // Only when someone will read it: the parser cannot resume, so this re-parses everything
+        // generated so far on every token, and off the chat path it is a full copy of the same.
+        if (req.render_text) {
             ShownView sv = shown_view(gen, /*partial*/ true);
             m.text = std::move(sv.content);
             m.reasoning = std::move(sv.reasoning);
@@ -992,10 +995,26 @@ RunResult Session::generate(const GenerateRequest & req,
     }
     if (sink) sink->on_summary(s);
 
-    {
-        ShownView sv = shown_view(gen, /*partial*/ false);
-        res.generated_text = std::move(sv.content);
-        res.reasoning_text = std::move(sv.reasoning);
+    // One non-partial parse of the finished generation, shared by the returned text and the history
+    // commit below. They asked the same question of the same string and each paid a full parse for
+    // it; a reasoning model's answer is the whole turn's output, so that was not a small double.
+    common_chat_msg final_msg;
+    bool final_parsed = false;
+    if (chat_on && !prefilled_answer) {
+        try {
+            final_msg = common_chat_parse(gen, /*is_partial*/ false, parse_params);
+            final_parsed = true;
+        } catch (const std::exception & e) {
+            detail::warn_parse_failed_once(e.what());
+        }
+    }
+    if (final_parsed) {
+        res.generated_text = final_msg.content;
+        res.reasoning_text = final_msg.reasoning_content;
+    } else {
+        // Not chat, a prefilled turn (the stream IS the answer), or a parse that threw: the raw
+        // generation stands on its own, exactly as shown_view would have reported it.
+        res.generated_text = gen;
     }
 
     if (res.cancelled) {
@@ -1005,20 +1024,15 @@ RunResult Session::generate(const GenerateRequest & req,
     } else if (chat_on) {
         // Commit the assistant turn to the running conversation. Parsing separates a thinking
         // model's reasoning from the answer; the next turn re-renders history from these messages.
+        // Reuses the parse above. A prefilled turn has no turn header in the stream to parse — the
+        // generation is the answer verbatim — and is committed without the prefill, so history holds
+        // a normal assistant message and the next turn re-renders cleanly whatever this turn's think
+        // setting was. A parse that threw falls back the same way.
         common_chat_msg assistant;
-        if (prefilled_answer) {
-            // Prefilled turn: no turn header in the stream to parse; the generation is the answer
-            // verbatim. It is committed without the prefill, so history holds a normal assistant
-            // message and the next turn re-renders cleanly whatever this turn's think setting was.
+        if (final_parsed)
+            assistant = std::move(final_msg);
+        else
             assistant.content = gen;
-        } else {
-            try {
-                assistant = common_chat_parse(gen, /*is_partial*/ false, parse_params);
-            } catch (const std::exception & e) {
-                detail::warn_parse_failed_once(e.what());
-                assistant.content = gen;
-            }
-        }
         assistant.role = "assistant";
         im.chat_history.push_back(assistant);
     }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -364,6 +364,8 @@ stalls, the matmuls) is pooled into it.
 Both are **diagnostics, not telemetry**, and both perturb what they measure. **A traced run is not
 a benchmark run.** Read the shares, not the absolutes.
 
+Both work in `--session` mode too, appending across turns like the per-token CSV.
+
 ### `--compute-trace` — one row per graph node
 
 Returning `true` from the eval callback makes ggml compute exactly up to that node, synchronize,


### PR DESCRIPTION
### The per-token rendered view was built whether or not anything read it

`TokenMetrics::text` is the answer as a UI should show it — the raw stream with a reasoning model's thinking span split out. Producing it calls `common_chat_parse` on **the entire generation so far**: the parser takes the whole string and cannot resume, so the cost is O(n) per token and **O(n²) across a turn**, growing as the answer grows. Off the chat path it was not free either — `shown_view` returns the raw string, so every token copied everything generated so far into the metrics struct.

It ran unconditionally. The consumers:

| path | reads `m.text`? |
|---|---|
| `--session` line protocol | yes |
| `--progress` line protocol | yes |
| plain CLI output | no — writes `m.piece` |
| CSV metrics sink | no — numeric columns only |
| benchmark runs | no |

`GenerateRequest::render_text` now carries that decision: the session loop sets it, `run()` ties it to `--progress`, and it **defaults to true** so an embedder that has never heard of the flag keeps the old behaviour exactly.

Worth stating plainly: this cost sits **outside** the `s0..s1` bracket that feeds `gen_seconds`, so it never appeared in the reported tok/s — while being paid on every benchmark run.

### The finished answer was parsed twice

`RunResult::generated_text` and the assistant message committed to history each ran their own full non-partial `common_chat_parse` over the same string with the same parameters. Now parsed once and used twice; the prefilled-turn case and the parse-failure fallback are unchanged and stated in one place instead of two.

### `--compute-trace` / `--io-trace` were silently ignored in `--session`

The CLI parsed both flags, opened the files, wrote their headers — and then called `run_session_loop(cfg, sink, route_trace)`, dropping both sinks. The user got an empty trace with a header and nothing saying why. Both are passed through now; `docs/telemetry.md` says they work in a session.

### Also

Three back-to-back `stats()` snapshots taken to read three fields become one.

### Not in this PR

The `BMOE_PROGRESS` line still carries the **cumulative** parsed text on every token, so the protocol itself remains O(n²) on the pipe, in the JSON escaping and in the app's parse. Fixing that means a delta protocol, which changes what the Android app consumes — a coordinated engine+app change that wants a device to validate against. Tracked separately.

### Verification

Gates 7/7. Both CLI output paths checked by hand against the tiny gate model: `--progress` still accumulates the parsed text line by line, the plain path still streams pieces inline. The gates themselves run with `render_text` off (no `--progress`) and still compare `generated_text`, so the final-parse path is covered by every byte-identity gate.
