### PR TITLE
feat(metrics): record the whole run configuration, and what tok/s omits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+- **`loop_overhead_ms` — the time the reported `tok/s` never counted.** `wall_ms` brackets
+  `llama_decode` and nothing else, which is what makes `compute_ms` a clean residual; it also means
+  everything *between* two decodes — sampling, detokenization, rendering the answer for a UI, the
+  sink writes — falls outside `wall_ms`, outside `gen_seconds` and so outside `tok/s` entirely. A
+  change that moved only that region was invisible in `s/tok` while being paid on every token. It is
+  now a CSV column, plus `loop_overhead_s/tok` in the summary (which also carries the tail after the
+  last token that no row can hold). Read next to `s/tok`: the two together are what a caller waits
+  through.
+- **The metrics CSV records the whole run configuration, and says which engine produced it.** The
+  preamble had 18 keys and had gone stale against the last several releases: `--ubatch` (which sets
+  the compute-buffer reservation, and so moves the very memory columns underneath it),
+  `--predict-log`, `--predict-spec-max`, `--prefetch-sync`, `--drop-no-renorm`, `--drop-in-prefill`,
+  `--cache-floor-mb`, `--load-all`, every sampling parameter and the trace granularity were all
+  absent — so a file could not tell a probed run from a benchmark run, or a stochastic run from a
+  greedy one. All are now recorded (`# bmoe_metrics v2`), along with `engine=<version>`.
+  `think` is deliberately still absent: it belongs to a request, not a session.
+  The preamble itself is now documented in [docs/telemetry.md](docs/telemetry.md), which described
+  every other `#` block but not this one.
+- **`bmoe-cli --version`**, and a project version in CMake for it to report. There was no version
+  string anywhere in the engine; a committed benchmark CSV could only be dated by the commit that
+  copied it in.
+
 ### Fixed
 - **Router weights are located by the routing's shape, not by a test a top-1 routing defeats.** The
   helper that finds token `j`'s slot `k` inside a weight node told the 3-D `[1, nu, nt]` node from

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,10 @@
 # of CI stay green before the native dependency is fetched.
 cmake_minimum_required(VERSION 3.21)
 
-project(bigmoeonedge LANGUAGES CXX)
+# The version is declared here and nowhere else in the build: the engine reports it (bmoe-cli
+# --version, and the run-parameter preamble of every metrics CSV), so a committed benchmark file
+# says which engine produced it. Keep it in step with CHANGELOG.md and the app's versionName.
+project(bigmoeonedge VERSION 0.17.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -14,6 +14,7 @@
 #include "bmoe/metrics.h"
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
+#include "bmoe/version.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -584,6 +585,9 @@ int main(int argc, char ** argv) {
             return 0;
         } else if (a == "-h" || a == "--help") {
             print_usage(argv[0]);
+            return 0;
+        } else if (a == "--version") {
+            std::printf("%s\n", bmoe::version());
             return 0;
         } else {
             std::fprintf(stderr, "unknown arg: %s\n", a.c_str());

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,6 +15,9 @@ target_include_directories(bmoe_core PUBLIC
 
 target_compile_features(bmoe_core PUBLIC cxx_std_17)
 
+# One source of truth for the version: the CMake project version reaches the code only here.
+target_compile_definitions(bmoe_core PUBLIC BMOE_VERSION="${PROJECT_VERSION}")
+
 if(BMOE_HAVE_LLAMA)
     target_sources(bmoe_core PRIVATE
         src/io/platform_io.cpp

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -15,13 +15,19 @@
 namespace bmoe {
 
 struct TokenMetrics {
-    int step = 0;               // 1-based index of this token
-    int steps = 0;              // n_predict target
-    double wall_ms = 0.0;       // total wall time for this token
-    double io_ms = 0.0;         // flash read time this token (serial: subset of wall; overlap: lane-busy sum)
-    double mgmt_ms = 0.0;       // cache-management time (vm commit + evict + LRU bookkeeping) this token
-    double compute_ms = 0.0;    // residual: serial wall - io - mgmt; overlap wall - stall - mgmt
-    double stall_ms = 0.0;      // overlap only: wall time the FFN kernel blocked on flash (0 when serial)
+    int step = 0;            // 1-based index of this token
+    int steps = 0;           // n_predict target
+    double wall_ms = 0.0;    // total wall time for this token
+    double io_ms = 0.0;      // flash read time this token (serial: subset of wall; overlap: lane-busy sum)
+    double mgmt_ms = 0.0;    // cache-management time (vm commit + evict + LRU bookkeeping) this token
+    double compute_ms = 0.0; // residual: serial wall - io - mgmt; overlap wall - stall - mgmt
+    double stall_ms = 0.0;   // overlap only: wall time the FFN kernel blocked on flash (0 when serial)
+    // Wall time between the PREVIOUS token's decode and this one's: sampling, detokenization,
+    // rendering the answer for a UI, this struct, and the sinks. None of it is inside wall_ms, so
+    // none of it reaches the reported tok/s — which is exactly why it is worth a column. A change
+    // that moves only this number is invisible in s/tok while being paid on every token.
+    // On the first token it is the gap from the end of prefill to the first decode.
+    double loop_overhead_ms = 0.0;
     uint64_t read_bytes = 0;    // expert bytes pulled from flash this token
     double cache_hit_pct = 0.0; // cumulative cache hit rate (-1 if no cache)
     // Compute-decomposition counters, measured around llama_decode (0 if the platform can't report
@@ -100,6 +106,10 @@ struct RunSummary {
     // well below 1 is a throttled/preempted core. 0 when the platform can't measure them.
     double majflt_per_token = 0.0;
     double cpu_s_per_token = 0.0;
+    // Everything between the decodes, per token: the region gen_seconds (and so tok/s) excludes.
+    // Includes the tail after the last token, which no row can carry. Read next to s_per_token: the
+    // two together are what a caller actually waits through.
+    double loop_overhead_s_per_token = 0.0;
     double cache_resident_mib = 0.0;
     double cache_budget_mib = 0.0; // the fixed cache budget the run used (explicit, or auto-sized at load)
     long long cache_resizes = 0;   // runtime budget changes — now only an app's explicit set_cache_budget
@@ -152,28 +162,54 @@ struct RunSummary {
 // something says what differed between them — and by the time a file is read, the argv that made
 // it is long gone. The engine states it once, in the file, next to the numbers it explains.
 struct RunInfo {
-    std::string model; // file name, not the full path: the path is the reader's machine, not the run's
+    std::string engine_version; // the build that produced the rows; see bmoe/version.h
+    std::string model;          // file name, not the full path: the path is the reader's machine, not the run's
     std::string arch;
     int n_layer = 0;
     int n_expert = 0;
     int n_expert_used = 0; // effective top-k, after any override
     int n_threads = 0;
     int n_ctx = 0;
+    int n_ubatch = 0;    // widest graph computed at once; 0 = follow n_batch. Sets the compute-buffer
+                         // reservation, so it moves the very memory columns these rows record.
+    bool chatml = false; // a chat-templated prompt is not the prompt that was typed
+    // Deliberately absent: `think`. It is a property of a REQUEST, not of the session, so a session
+    // preamble stating one value would be wrong for every turn that asked for the other. The `turn`
+    // column is where per-turn facts belong.
 
     // The streaming configuration, as resolved (not as typed): cache_mb is what the engine settled
     // on, which under auto-sizing is a number no flag mentioned.
     bool moe_stream = false;
     int cache_mb = 0;
     bool cache_auto = false;
+    int cache_floor_mb = 0; // the RAM auto-sizing was told to leave free — the input behind cache_mb
     int cache_ceil_mb = 0;
     bool force_cache = false;
+    bool load_all = false; // whole-expert-set baseline: reads everything, so its bytes mean something else
     int io_threads = 0;
     bool o_direct = false;
     bool overlap = false;
     int prefetch_layers = 0;
     bool predict_prefetch = false;      // stale-gate predictive prefetch (see MoeStreamConfig)
-    std::string dense_weights = "anon"; // dense (non-expert) policy: "mmap" | "warm" | "anon"
+    bool predict_log = false;           // the accuracy probe: costs a barrier and two GEMVs per layer
+    int predict_spec_max = 0;           // how many predicted misses a layer may speculate (0 = retention only)
+    bool prefetch_sync = false;         // test path: speculative reads served inline, no latency hiding
+    std::string dense_weights = "anon"; // dense (non-expert) policy: "mmap" | "warm" | "anon" | "ahwb"
     float drop_cold_frac = 0.0f;        // cache-aware expert dropping threshold (0 = off)
+    bool drop_renorm = true;            // survivors rescaled to keep the routing's total mass
+    bool drop_prefill = false;          // dropping armed during prefill too, where it discards far more
+
+    // Sampling. Greedy (temp <= 0) is the default and the only deterministic one; the byte-identity
+    // gates depend on it. A stochastic run and a greedy one are not comparable, and until these were
+    // recorded the file could not tell them apart.
+    float temp = 0.0f;
+    int top_k = 40;
+    float top_p = 0.95f;
+    uint32_t seed = 0xFFFFFFFFu;
+
+    // Diagnostics that perturb what they measure. A traced run is not a benchmark run — recorded so
+    // a file cannot be mistaken for one.
+    int compute_trace_layers = 0;
 };
 
 // Optional per-token sink (e.g. CSV for benchmarks). The engine calls on_run_info once before the

--- a/core/include/bmoe/version.h
+++ b/core/include/bmoe/version.h
@@ -1,0 +1,25 @@
+// The engine's version, as a string.
+//
+// It exists so a benchmark file can name the engine that produced it. A committed CSV outlives the
+// checkout that made it, and "which build was this?" is otherwise answerable only by the commit
+// date next to the file — which is the date it was COPIED, not the date it was RUN. The run-parameter
+// preamble records this next to the configuration, and `bmoe-cli --version` prints it.
+//
+// BMOE_VERSION is defined by the build from the CMake project version, so there is one source of
+// truth. A build without that define (an unusual embedding) reports "unknown" rather than a number
+// it cannot vouch for.
+#pragma once
+
+namespace bmoe {
+
+#ifdef BMOE_VERSION
+inline const char * version() {
+    return BMOE_VERSION;
+}
+#else
+inline const char * version() {
+    return "unknown";
+}
+#endif
+
+} // namespace bmoe

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -2,6 +2,7 @@
 #include "bmoe/recipe.h"
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
+#include "bmoe/version.h"
 #include "chat_parse.h"
 #include "thinking_control.h"
 #include "../moe/router_hook.h"
@@ -561,18 +562,33 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.model = slash == std::string::npos ? p : p.substr(slash + 1);
         ri.arch = im.arch;
         ri.n_layer = im.n_layer;
+        ri.engine_version = version();
         ri.n_threads = cfg.n_threads;
         ri.n_ctx = cfg.n_ctx;
+        ri.n_ubatch = cfg.n_ubatch;
+        ri.chatml = cfg.chatml;
+        ri.compute_trace_layers = cfg.compute_trace_layers;
+        ri.temp = cfg.sampling.temp;
+        ri.top_k = cfg.sampling.top_k;
+        ri.top_p = cfg.sampling.top_p;
+        ri.seed = cfg.sampling.seed;
         ri.moe_stream = cfg.moe.enabled;
         ri.cache_auto = cfg.moe.cache_auto;
+        ri.cache_floor_mb = cfg.moe.cache_floor_mb;
         ri.cache_ceil_mb = cfg.moe.cache_ceil_mb;
         ri.force_cache = cfg.moe.force_cache;
+        ri.load_all = cfg.moe.enabled && cfg.moe.load_all;
         ri.io_threads = cfg.moe.enabled ? cfg.moe.io_threads : 0;
         ri.o_direct = cfg.moe.enabled && cfg.moe.o_direct;
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;
         ri.predict_prefetch = cfg.moe.enabled && cfg.moe.predict_prefetch;
+        ri.predict_log = cfg.moe.enabled && cfg.moe.predict_log;
+        ri.predict_spec_max = cfg.moe.enabled ? cfg.moe.predict_spec_max : 0;
+        ri.prefetch_sync = cfg.moe.enabled && cfg.moe.prefetch_sync;
         ri.drop_cold_frac = cfg.moe.enabled ? cfg.moe.drop_cold_frac : 0.0f;
+        ri.drop_renorm = cfg.moe.drop_renorm;
+        ri.drop_prefill = cfg.moe.drop_prefill;
         // The CSV keeps the two familiar flags, derived from the resolved dense-weights policy.
         ri.dense_weights = cfg.moe.dense_weights == DenseWeightsMode::Mmap        ? "mmap"
                            : cfg.moe.dense_weights == DenseWeightsMode::Anonymous ? "anon"
@@ -888,6 +904,13 @@ RunResult Session::generate(const GenerateRequest & req,
     const long long prev_routed = im.hook->experts_routed();
     const long long prev_dropped = im.hook->experts_dropped();
 
+    // The decode bracket below measures llama_decode and nothing else, which is what makes
+    // compute_ms a clean residual — but it also means everything BETWEEN two decodes (sampling,
+    // detokenization, rendering, the sinks) is charged to nobody and disappears from tok/s. Mark
+    // where the last decode ended so each token can report the gap it actually waited through.
+    auto loop_mark = clock_t_::now();
+    double loop_overhead_s = 0.0;
+
     for (int t = 0; t < req.n_predict; ++t) {
         // Greedy stays argmax (byte-identical to the resident reference the gates check); with a
         // sampling chain, draw from the context's last-position logits, which llama_sampler_sample
@@ -905,10 +928,13 @@ RunResult Session::generate(const GenerateRequest & req,
         const uint64_t f0 = pio::major_faults();
         const double c0 = pio::process_cpu_seconds();
         auto s0 = clock_t_::now();
+        const double overhead = secs(loop_mark, s0); // everything since the previous decode returned
+        loop_overhead_s += overhead;
         llama_batch step = llama_batch_get_one(&tok, 1);
         trace_begin(n_prompt + t, /*n_tokens*/ 1, /*phase*/ 1); // decodes at the position after the prompt
         int dec = llama_decode(ctx, step);
         auto s1 = clock_t_::now();
+        loop_mark = s1; // the next token's overhead is measured from here
         const uint64_t f1 = pio::major_faults();
         const double c1 = pio::process_cpu_seconds();
         if (dec != 0) {
@@ -930,6 +956,7 @@ RunResult Session::generate(const GenerateRequest & req,
         TokenMetrics m;
         m.step = n_gen;
         m.steps = req.n_predict;
+        m.loop_overhead_ms = overhead * 1000.0;
         m.piece = delta;
         {
             ShownView sv = shown_view(gen, /*partial*/ true);
@@ -950,6 +977,9 @@ RunResult Session::generate(const GenerateRequest & req,
     s.gen_seconds = gen_seconds;
     s.s_per_token = n_gen ? gen_seconds / n_gen : 0.0;
     s.tokens_per_second = gen_seconds > 0 ? n_gen / gen_seconds : 0.0;
+    // Close the accounting: the tail after the last decode belongs to no row, so add it here.
+    loop_overhead_s += secs(loop_mark, clock_t_::now());
+    s.loop_overhead_s_per_token = n_gen ? loop_overhead_s / n_gen : 0.0;
     s.n_prompt = n_prompt - (int) n_common; // tokens actually prefilled this turn (after KV reuse)
     s.n_past = chat_on ? (int) im.kv_tokens.size() : n_prompt + n_gen; // total context length now
     s.load_seconds = im.load_seconds;

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -18,16 +18,33 @@ public:
     // parsers ignore what they do not know.
     void on_run_info(const RunInfo & r) override {
         if (header_) return; // a session sends this once; a second call would interleave a preamble
-        std::fprintf(f_, "# bmoe_metrics v1\n");
-        std::fprintf(f_, "# model=%s arch=%s n_layer=%d n_expert=%d n_expert_used=%d threads=%d n_ctx=%d\n",
-                     r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx);
+        // v2 adds the engine version and every knob v1 left out — the compute-buffer width, the
+        // prediction settings, the drop variants, the sampling parameters. A file that does not
+        // record a setting cannot be compared against one that changed it, and several of these
+        // move the very columns below (n_ubatch sets the compute-buffer reservation; a probed or
+        // sampled run is not a benchmark run at all).
+        std::fprintf(f_, "# bmoe_metrics v2\n");
+        // The engine version gets its own line, and the model line keeps starting with `model=`:
+        // the app's CSV reader finds the run's name by looking for a line that BEGINS with
+        // "# model=", so prefixing that line with anything would have cost every already-installed
+        // build its run titles. A new key on a new line is invisible to a parser that ignores it.
+        std::fprintf(f_, "# engine=%s\n", r.engine_version.c_str());
         std::fprintf(f_,
-                     "# moe_stream=%d cache_mb=%d cache_auto=%d cache_ceil_mb=%d force_cache=%d "
-                     "io_threads=%d o_direct=%d overlap=%d prefetch=%d predict_prefetch=%d dense_weights=%s "
-                     "drop_cold_frac=%.4g\n",
-                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_ceil_mb, r.force_cache, r.io_threads, r.o_direct,
-                     r.overlap, r.prefetch_layers, r.predict_prefetch, r.dense_weights.c_str(),
-                     (double) r.drop_cold_frac);
+                     "# model=%s arch=%s n_layer=%d n_expert=%d n_expert_used=%d threads=%d "
+                     "n_ctx=%d n_ubatch=%d chatml=%d\n",
+                     r.model.c_str(), r.arch.c_str(), r.n_layer, r.n_expert, r.n_expert_used, r.n_threads, r.n_ctx,
+                     r.n_ubatch, r.chatml);
+        std::fprintf(f_,
+                     "# moe_stream=%d cache_mb=%d cache_auto=%d cache_floor_mb=%d cache_ceil_mb=%d "
+                     "force_cache=%d load_all=%d io_threads=%d o_direct=%d overlap=%d prefetch=%d "
+                     "predict_prefetch=%d predict_log=%d predict_spec_max=%d prefetch_sync=%d "
+                     "dense_weights=%s drop_cold_frac=%.4g drop_renorm=%d drop_prefill=%d\n",
+                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_floor_mb, r.cache_ceil_mb, r.force_cache,
+                     r.load_all, r.io_threads, r.o_direct, r.overlap, r.prefetch_layers, r.predict_prefetch,
+                     r.predict_log, r.predict_spec_max, r.prefetch_sync, r.dense_weights.c_str(),
+                     (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
+        std::fprintf(f_, "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d\n", (double) r.temp, r.top_k,
+                     (double) r.top_p, r.seed, r.compute_trace_layers);
         write_header();
     }
 
@@ -35,11 +52,12 @@ public:
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f,%.1f,%.1f\n",
+                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms,
                      m.dense_resident_frac, m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib,
-                     m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib);
+                     m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib,
+                     m.loop_overhead_ms);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -52,13 +70,14 @@ public:
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
                      "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
-                     "experts_routed=%lld experts_dropped=%lld\n",
+                     "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
                      s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
-                     s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped);
+                     s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped,
+                     s.loop_overhead_s_per_token);
         std::fflush(f_);
     }
 
@@ -74,7 +93,7 @@ private:
         // then the memory block. Consumers read columns by name, so order is not a contract.
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
                          "dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,"
-                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib\n");
+                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -32,6 +32,11 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
   that recovers the flash-wait term as `wall_ms − compute_ms − mgmt_ms` gets `wall_ms − mgmt_ms`
   when the clamp fires, over-attributing to flash. Read the wall-additive flash term straight from
   `io_ms` (serial) / `stall_ms` (overlap) instead of inverting the residual.
+  Precisely: `stall_ms` is the summed per-thread block time divided by `n_threads`, which equals the
+  wall stall only if every compute thread blocks together. When one thread waits on an expert while
+  the others keep working it **under**-states the stall, and `compute_ms` — being the residual —
+  absorbs the difference. Read an attribution between compute and flash as approximate, and reach
+  for `--compute-trace` when the split itself is the question.
   In serial mode `io_ms` is the wall time blocked on reads (a subset of `wall_ms`). Under
   `--overlap` its meaning changes: it is the **sum of per-lane busy time**, so it can exceed
   `wall_ms` because lanes read in parallel with compute. Use `stall_ms` for the wall time
@@ -145,15 +150,58 @@ prints just the summary lines.
 
 ## CSV sink
 
-`--csv PATH` additionally writes one row per token:
+`--csv PATH` additionally writes a `#` preamble describing the run, then one row per token, then a
+`# summary ...` trailer. Intended for the benchmark sweep.
+
+### Run-parameter preamble
+
+```
+# bmoe_metrics v2
+# engine=<ver>
+# model=<file> arch=<arch> n_layer=<n> n_expert=<n> n_expert_used=<k> threads=<n>
+  n_ctx=<n> n_ubatch=<n> chatml=<0|1>
+# moe_stream=<0|1> cache_mb=<n> cache_auto=<0|1> cache_floor_mb=<n> cache_ceil_mb=<n>
+  force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1> overlap=<0|1> prefetch=<n>
+  predict_prefetch=<0|1> predict_log=<0|1> predict_spec_max=<n> prefetch_sync=<0|1>
+  dense_weights=<mmap|warm|anon|ahwb> drop_cold_frac=<f> drop_renorm=<0|1> drop_prefill=<0|1>
+# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n>
+```
+
+Rows without this are not evidence: two files answer "which is faster" only if something says what
+differed between them, and by the time a CSV is read the argv that produced it is gone. Written once
+per session (a second `generate()` does not repeat it). Keys are whitespace-separated `key=value`
+and **order-independent**; new keys are appended freely and older parsers ignore what they do not
+know.
+
+Values are the **resolved** configuration, not what was typed — `cache_mb` is what the streamer
+settled on, which under `--cache-mb auto` is a number no flag mentioned, and `n_expert_used` is the
+effective top-k after any override. Fields to read carefully:
+
+- `engine` is the version that produced the rows (`bmoe-cli --version`), so a committed file still
+  names its build after the checkout has moved on. `unknown` if the build did not define it. It sits
+  on its own line so the `model=` line keeps starting with `model=`, which is how the app's CSV
+  reader finds a run's name.
+- `n_ubatch` sets the compute-buffer reservation, so it moves the very memory columns below;
+  `0` means it follows `n_batch`.
+- `predict_log=1`, `prefetch_sync=1` or `compute_trace_layers>0` mean **the run was instrumented**.
+  A probed or traced run is not a benchmark run — see the warning under [Decode
+  traces](#decode-traces).
+- `temp>0` means the run was **stochastic**: not comparable token-for-token with a greedy one, and
+  not reproducible except through `seed`.
+- `load_all=1` reads the whole expert set, so its `read_bytes` means something different from a
+  selective run's.
+
+`think` is deliberately absent: it is a property of a *request*, not of the session, so one value in
+a session-wide preamble would be wrong for every turn that asked for the other. Per-turn facts belong
+next to the `turn` column.
+
+### Per-token rows
 
 ```
 step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,
 dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,
-mem_available_mib,mem_free_mib,swap_free_mib
+mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms
 ```
-
-followed by a `# summary ...` comment line. Intended for the benchmark sweep.
 
 `stall_ms`, `mgmt_ms`, `majflt`, `cpu_ms` and `dense_resident_frac` are trailing columns appended
 after the original seven. `stall_ms` is the wall time compute threads waited for expert reads that
@@ -168,7 +216,8 @@ floor to defend; see [pressure.md](pressure.md)), `experts_routed=<n>` / `expert
 [cache-aware dropping](expert-dropping.md) actually discarded during generation — the flag sets a
 threshold, not a rate, so this is the only record of the trade a run made) and
 `layer_demand_MiB=<f>` (the widest layer's routed
-bytes: the mechanical floor the cache must be able to stage); see the `io_ms` note above for how the
+bytes: the mechanical floor the cache must be able to stage) and `loop_overhead_s/tok=<s>` (see
+[below](#what-toks-does-not-include)); see the `io_ms` note above for how the
 read-time columns are reinterpreted under overlap.
 
 The trailing block is the memory picture, added so a run can be diagnosed from its own file:
@@ -184,8 +233,20 @@ The trailing block is the memory picture, added so a run can be diagnosed from i
 | `swap_mib` | anonymous memory already lost to zram (`VmSwap`). |
 | `rss_mib` | total resident (`VmRSS`). |
 | `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |
+| `loop_overhead_ms` | wall time between the **previous** token's decode and this one's: sampling, detokenization, rendering the answer for a UI, and the sink writes. On the first token, the gap from the end of prefill to the first decode. |
 
 All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split).
+
+### What `tok/s` does not include
+
+`wall_ms` brackets `llama_decode` and nothing else — that is what makes `compute_ms` a clean
+residual. It also means everything *between* two decodes is outside `wall_ms`, outside `gen_seconds`
+and therefore **outside the reported `tok/s`**. `loop_overhead_ms` is that region, measured, so a
+change that moves only it is visible instead of free.
+
+Read it next to `wall_ms`: the two together are what a caller actually waits through. The summary's
+`loop_overhead_s/tok` is the same figure averaged, and includes the tail after the last token that
+no row can carry.
 
 ## Route trace
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
@@ -90,8 +90,13 @@ internal class Csv(
  */
 internal fun runTitle(file: File): String {
     val lines = runCatching { file.readLines() }.getOrElse { return "" }
-    val model = lines.firstOrNull { it.startsWith("# model=") }
-        ?.substringAfter("model=", "")?.substringBefore(" ").orEmpty()
+    // Find the `model=` token wherever it sits in the preamble, rather than requiring the line to
+    // begin with it: the preamble grows by appending keys and lines, and a title should not be the
+    // one thing that depends on their order.
+    val model = lines.filter { it.startsWith("# ") && !it.startsWith("# summary") }
+        .flatMap { it.removePrefix("# ").trim().split(" ") }
+        .firstOrNull { it.startsWith("model=") }
+        ?.substringAfter("model=", "").orEmpty()
     if (model.isEmpty()) return ""
     val initial = model.first().uppercaseChar()
     val tps = lines.filter { it.startsWith("# summary") }


### PR DESCRIPTION
Two gaps, both about a benchmark file being unable to explain itself.

### The run-parameter preamble had gone stale against several releases

The CSV opens with a `#` block naming what the run *was*, because rows without it are not evidence — two files answer "which is faster" only if something says what differed. It had 18 keys and had not kept up:

| missing | why it matters |
|---|---|
| `n_ubatch` | sets the compute-buffer reservation — it moves the very memory columns printed underneath it |
| `predict_log`, `prefetch_sync`, `compute_trace_layers` | an instrumented run was indistinguishable from a benchmark run the docs explicitly say it is not |
| `predict_spec_max` | spec-max 0 and spec-max 2 are different experiments |
| `drop_renorm`, `drop_prefill` | change how much mass dropping discards, and in which phase |
| `cache_floor_mb` | the input behind an auto-sized `cache_mb` |
| `load_all` | its `read_bytes` mean something else entirely |
| `temp`, `top_k`, `top_p`, `seed` | a stochastic run read exactly like a greedy one |

All recorded now, under a bumped `# bmoe_metrics v2`.

`think` is deliberately **not** added: it is a property of a *request*, not of a session, so one value in a session-wide preamble would be wrong for every turn that asked for the other. The `turn` column is where per-turn facts belong.

### The file did not name the engine that wrote it

There was no version string anywhere — `project(bigmoeonedge)` had no `VERSION`, no `version.h`, no `--version`. A committed CSV could only be dated by the commit that copied it in, which is the date it was *filed*, not the date it was *run*.

Added as a CMake project version → `BMOE_VERSION` → `bmoe::version()` → `bmoe-cli --version` and `engine=` in the preamble. One source of truth; a build without the define reports `unknown` rather than a number it cannot vouch for.

**Compatibility detail worth calling out:** `engine=` went on its own line rather than at the front of the model line, because the Android app's CSV reader finds a run's name with `lines.firstOrNull { it.startsWith("# model=") }`. Prefixing that line would have cost every already-installed build its run titles for a cosmetic reason. The app's lookup is also made order-independent in this PR, so the next appended key cannot break it again.

### `tok/s` never counted the work between decodes

`wall_ms` brackets `llama_decode` and nothing else. That is deliberate and it is what makes `compute_ms` a clean residual — but it also means sampling, detokenization, rendering the answer for a UI and the sink writes all fall outside `wall_ms`, outside `gen_seconds`, and therefore **outside the reported `tok/s`**.

So work moved into or out of that region was unmeasurable by the one number this project optimizes. `loop_overhead_ms` now reports it per token; `loop_overhead_s/tok` in the summary closes the accounting, including the tail after the last token that no row can carry.

This is a measurement fix, and it is deliberately in its own PR ahead of the changes it lets you evaluate.

### Docs

`docs/telemetry.md` specified the route-trace and compute-trace preambles but **not the metrics one** — the block this PR doubles in size. It is now documented, along with the new column and a precision note on `stall_ms`: it is a summed per-thread block time divided by `n_threads`, so a stall that is not simultaneous across threads is under-stated, and `compute_ms`, being the residual, absorbs the difference. That caveat shapes every compute-vs-flash attribution the project quotes.

### Verification

Gates 7/7. Preamble, new column and `--version` checked against the tiny gate model. Both downstream readers verified: `scripts/bench-analyze.py` reads columns by name and skips `#` lines it cannot parse; the app's `Csv.read` keeps unknown keys and picks the new column up automatically (it will now also chart it).
