### PR TITLE
docs(roadmap): record why a slice cannot be read straight into its cache slot

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,23 @@ What follows from that:
   slice, so the pipeline stalls. Bandwidth is not the binding constraint; latency-to-ready is.
   Closed unmerged (PR #90, tag `expert-sidecar-refuted`); full data in
   [bench-data/2026-07-20-sidecar/findings.md](bench-data/2026-07-20-sidecar/findings.md).
+- **Reading a slice straight into the cache buffer — blocked by the gguf's own offsets
+  (2026-07-28).** Every streamed byte is pulled into a per-lane bounce buffer and then memcpy'd to
+  its cache slot, so the CPU touches it twice; at 100-200 MB/token that copy is not free, and it
+  lands on the I/O lanes, which under overlap run alongside a decode that is already compute-bound.
+  Skipping it needs the read to be block-aligned at all three of offset, length and destination.
+  Measured on the three shipped models: **bytes-per-expert is 4096-aligned, the tensor's file
+  offset is not** — 512 (Qwen3-30B), 1152 (Qwen3.6-35B), 2272 (gpt-oss-120b) — because gguf aligns
+  tensor data to `general.alignment` (32), not to a device block. So an O_DIRECT window must round
+  outward and always spills one block into the *neighbouring experts'* bytes.
+
+  Writing that spill is content-identical (the cache buffer mirrors the file layout), but it is not
+  safe here: those pages belong to other cache entries, which may have been evicted, and touching
+  them would fault a page back with nothing accounting for it — putting the residency budget out of
+  step with what is actually resident. The trick that would make it work (offsetting each buffer's
+  base by `file_off % align` so the destination inherits the file's misalignment) does not remove
+  the spill, only its size. Not built: the win is a memcpy, the risk is the memory accounting the
+  whole engine's budget rests on, and it cannot be judged without a device.
 - The remaining gap between the engine's effective rate and the drive's is **duty cycle, not
   bandwidth**, and is not yet honestly sized: the ceiling itself falls by a third once the device
   is hot, so engine and microbench must be measured interleaved at matched entry state. Owed.


### PR DESCRIPTION
The audit named the bounce buffer as the largest avoidable CPU cost on the read path: every streamed byte is pulled into a per-lane staging buffer and then `memcpy`'d into its cache slot. At 100–200 MB/token that is the CPU touching every byte twice, on the I/O lanes, alongside a decode that the measurements already call compute-bound.

I went to remove it. It cannot be removed, and this PR records why rather than leaving the idea to be re-proposed.

### What it would take

A read can go straight into the destination only if **offset, length and destination are all on the device block size** — otherwise O_DIRECT rejects it, and the window has to round outward into a staging buffer.

Measured against every model in the catalog:

| model | `file_off % 4096` | `nb2 % 4096` |
|---|---|---|
| Qwen3-30B-A3B | **512** | 0 |
| Qwen3.6-35B-A3B | **1152** | 0 |
| gpt-oss-120b | **2272** | 3200 |

Bytes-per-expert is block-aligned on the Qwen models. **The tensor's file offset never is** — gguf aligns tensor data to `general.alignment`, which is 32, not to a device block. So the window always rounds outward, and always spills one block into the *neighbouring experts'* bytes.

### Why the spill is not acceptable

It is content-identical: the cache buffer mirrors the file layout exactly, so those bytes get written with the values they already hold. That is not the problem.

The problem is that the spilled-into pages belong to **other cache entries**, and those entries may have been evicted — their pages handed back with `MADV_DONTNEED` and subtracted from `cresident_`. A direct read spilling into them faults a page back in with nothing accounting for it. The residency budget then stops matching what is actually resident, and that budget is the thing keeping a >RAM model alive on the device.

The trick that would make the destination inherit the file's misalignment — offsetting each `(layer, projection)` buffer's base by `file_off % align` — makes the window *tighter*, not exact: it still overhangs by one block. It shrinks the hazard; it does not remove it.

### What I did with the code

I wrote the safe subset — take the direct path only when all three are already aligned, fall back otherwise — and threw it away. On every model in the catalog the condition is false, so it is a branch on the hot read path that never fires, plus a startup line that would always report the fallback. Dead code that looks like an optimization is worse than a note saying the optimization does not apply.

### What would change the verdict

A gguf whose expert tensors start on a 4096 boundary. That is a writer-side property, not something this engine can arrange without repacking — and [repack stays off](../CLAUDE.md), because the streamer rebinds `tensor->data` to the native layout.

Docs-only change; no code, no gates affected.
