### PR TITLE
chore(release): 0.17.0 (versionCode 31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-28
+
 ### Added
 - **`loop_overhead_ms` — the time the reported `tok/s` never counted.** `wall_ms` brackets
   `llama_decode` and nothing else, which is what makes `compute_ms` a clean residual; it also means

--- a/README.md
+++ b/README.md
@@ -349,7 +349,14 @@ What makes it worth reading is that the engine is candid about its own numbers. 
 particular, isn't measured: it's whatever time is left once the measured parts come out, so it
 silently absorbs page faults and throttled cores. Rather than let that pass, the engine ships the
 counters that pull the residual apart, and marks anything it couldn't measure as unmeasured instead
-of quietly reporting zero.
+of quietly reporting zero. That candour extends to the headline: tok/s times the decode and nothing
+else, so the sampling, detokenizing and rendering between one token and the next fall outside it —
+the engine reports that time too, rather than letting work hide in the gap.
+
+Every metrics file also states the run that produced it — the engine version and the full resolved
+configuration, including whether the run was instrumented or sampled, because such a run is not a
+benchmark run. Two files put side by side answer "which is faster" only if something says what
+differed between them, and by the time a file is read the command line that made it is long gone.
 
 When the per-token split isn't enough, two diagnostics go further: one records what the router
 asked for on every token, the other times the compute graph node by node. Both perturb the run they

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -50,8 +50,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 30
-        versionName '0.16.0'
+        versionCode 31
+        versionName '0.17.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.


### PR DESCRIPTION
Carves the accumulated `[Unreleased]` section into `## [0.17.0] - 2026-07-28`, bumps the app to `versionCode 31` / `versionName 0.17.0`, and updates the README's Telemetry section to describe what changed about how a run reports itself.

0.17.0 is the engine/core audit — no new capability, so nothing is added to Features (per #109, that list stays functional). What landed:

**Correctness, all latent rather than active:**
- #113 — router weights located by the routing's shape; the old `ne[0] == 1` test is defeated by a top-1 routing.
- #114 — a speculated expert is queued whole; a part-way commit failure used to blacklist it from prefetch for the rest of the run.
- #111 — a failed bounce reallocation no longer kills a reader lane permanently.

**Per-token work that ran for readers that did not exist:**
- #112 — the ask pass matches node names with a prefix compare instead of `sscanf`, and remembers a terminal weight node as an index instead of a heap-allocated string.
- #115 — the rendered answer is built only when something reads it (it was re-parsing the whole generation every token, for benchmark runs too).
- #114 — a completed slice read wakes a compute thread only when one is waiting.

**Measurement, which is why the rest is now judgeable:**
- #116 — the metrics CSV records the whole resolved configuration and the engine version, and `loop_overhead_ms` reports the between-decode time that `tok/s` excludes by construction.

**Refuted and recorded:**
- #117 — reading a slice straight into its cache slot is blocked by the gguf's own tensor offsets, measured across all three shipped models.

### Not measured on device

No phone was attached to the session that produced these. Every change removes work rather than trading it, and all are covered by the byte-identity gates, so **no throughput claim appears anywhere in this release** — the changelog states mechanisms, not numbers. The A/B is tracked in #120, and #116 exists partly so that #115 is measurable at all.

Open follow-ups: #118 (two-wave batch publish), #119 (the `BMOE_PROGRESS` O(n²) protocol).

### After merge

Tag `v0.17.0` to fire the Windows build and the APK attach.
