### PR TITLE
perf(moe): isolate only the weight node the drop policy decides on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Changed
+- **With the drop policy armed, only the weight node that decides is isolated.** The router-weight
+  chain is `ffn_moe_weights → (_softmax | _norm) → (_scaled)`, and the engine asked for **every**
+  node of it so it could learn which one comes last. But once a layer's terminal node is known,
+  that is the only one either consumer reads — the drop policy decides there, and the route trace's
+  last-wins gather lands there — so the other two or three asks per layer bought nothing and cost a
+  graph split plus a full compute-thread synchronization each, per layer, per token. They are now
+  asked for only while a layer is still learning its chain shape (the first graph of a run, and any
+  graph after a terminal that stopped appearing is forgotten), so the learning stays self-correcting
+  and a graph that moves is detected exactly as before. This ran inside every `--drop-cold-experts`
+  measurement to date, including the shipping app default.
+
 ## [0.17.0] - 2026-07-28
 
 ### Added

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -865,6 +865,18 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     const bool want_weights = trace_on_ || drop_armed();
     const int weight_variant = (moe_node && want_weights) ? match_weights(t->name, wl) : -1;
     const bool is_weights = weight_variant >= 0;
+    // Which of them is worth a BARRIER is a narrower question than which of them we recognise. The
+    // chain's earlier nodes exist only so the terminal one can be identified; once a layer's
+    // terminal is known, both consumers — the drop policy's decision point and the trace's
+    // last-wins gather — read that node and no other. Isolating the rest costs a graph split and a
+    // full compute-thread synchronization each, per layer, per token, on tensors of a few floats.
+    //
+    // Ask for the whole chain only while the layer is still learning its shape (term_variant_ < 0),
+    // which is the first graph of a run and any graph after close_drop_layer forgets a terminal
+    // that stopped appearing. That re-widening is what keeps this self-correcting: a graph that
+    // moves is detected exactly as before, because the deferral still fails to be honoured.
+    const bool weights_iso = is_weights && (wl < 0 || wl >= (int) term_variant_.size() || term_variant_[wl] < 0 ||
+                                            term_variant_[wl] == weight_variant);
     // The gate matmul. The probe ISOLATES it (a barrier per layer — a probed run is not a
     // benchmark run); the prefetch only wants its source pointers, which the ask pass hands over
     // for free, so it asks for nothing and validates its barrier-less read with the watchdog
@@ -896,7 +908,7 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 }
             }
         }
-        return ctrace_iso || is_topk || is_weights || (is_logits && predict_log_);
+        return ctrace_iso || is_topk || weights_iso || (is_logits && predict_log_);
     }
 
     // The probe attaches to the gate matmul rather than to the topk node because this is where the

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -17,8 +17,9 @@
 // Streaming carries an optional third job, the route trace (set_trace): the same pass also
 // asks for each layer's router-weight node and records which experts were routed, how the
 // router weighted them, and whether they were already resident. It observes only — the ids
-// handed to load_layer are the same traced or not — but it costs a barrier per weight node,
-// so it stays off unless asked for. See bmoe/route_trace.h.
+// handed to load_layer are the same traced or not — but it costs a barrier per layer (the whole
+// weight chain on the first graph, then only its terminal node), so it stays off unless asked
+// for. See bmoe/route_trace.h.
 //
 // And an optional fourth (set_predict_log): the expert-prediction probe, which asks for each
 // layer's gate matmul so it can rank the NEXT layer's experts before that layer runs, and reports
@@ -338,6 +339,11 @@ private:
     // four chain names are mutually exclusive, so the index identifies it exactly, and recording it
     // costs neither an allocation nor a string compare on a path that runs for every weight node of
     // every layer of every token.
+    //
+    // Once it IS known, only that node is asked for. The rest of the chain exists to identify it,
+    // and each extra ask is a graph split plus a compute-thread synchronization — per layer, per
+    // token, on tensors of a few floats. A layer whose terminal is forgotten (below) goes back to
+    // asking for the whole chain, so the learning is never one-way.
     float drop_frac_ = 0.0f;
     bool drop_renorm_ = true;
     bool drop_prefill_ = false;


### PR DESCRIPTION
This is the half of the audit's highest-rated finding that did not ship in 0.17.0. (#113 carried the `weight_at` fix out of the same audit item; this is the isolation change it was split from.)

### What was happening

`build_moe_ffn` emits a **chain** of router-weight nodes per layer: `ffn_moe_weights`, then optionally `_softmax` or `_norm`, then optionally `_scaled`, each refining the last. Which one is terminal depends on the model's gating, so the engine learns it from the graph rather than tabulating it per architecture — the ask pass isolates **every** node of the chain and takes last-wins.

That learning completes on the first graph. After it, only the terminal node is ever read: the drop policy makes its decision there (`apply_drop` fires on `term_variant_[wl] == weight_variant` and nowhere else), and the route trace's last-wins gather lands there by definition.

The other two or three asks per layer went on being made anyway. **Each ask is a graph split plus a full compute-thread synchronization**, on a tensor of a few floats — per layer, per token, for the whole run. The header already prices one extra isolated node per layer at roughly 20 ms/token for the prediction probe, which is the order of magnitude at stake.

The drop policy is the app's default, so this sat inside **every `--drop-cold-experts` measurement taken so far**, including the +55% that shipped in 0.15.0.

### The change

Ask for the rest of the chain only while `term_variant_[il]` is unlearned:

```cpp
const bool weights_iso = is_weights && (wl < 0 || wl >= (int) term_variant_.size() ||
                                        term_variant_[wl] < 0 || term_variant_[wl] == weight_variant);
```

That covers the first graph of a run, and any graph after `close_drop_layer` forgets a terminal that stopped appearing — so the widening is automatic and the learning is never one-way.

### Why the recovery path still works

If a graph moves and the learned terminal no longer appears, the sequence is unchanged: it is not offered, `chain_last_` stays unset, the deferral is never honoured, `close_drop_layer` notices, loads the routing to keep the cache's accounting straight, and **forgets** the terminal. The next graph then sees `term_variant_[il] < 0` and asks for the whole chain again.

The narrower ask does not add an assumption either. The engine already bet that a layer's terminal node is stable across graphs — `term_variant_` was learned once and reused — so this changes what is *asked for*, not what is *believed*.

### Verification

- Gates 7/7, run three times, including the two that exercise the deferral: `G8a` (drop with a threshold below any weight, which proves the deferral is correct while the policy is inert) and `G8c` (full strength at top-k 1).
- **Route trace checked by hand** on Qwen3-30B-A3B, since this changes which nodes the trace is offered: 1920/1920 rows still carry a non-zero router weight, range 0.0011–0.9862. The terminal-only gather sees exactly what the full-chain one did — which follows, since last-wins always resolved to the terminal anyway.

### No throughput claim

Still no device attached. This removes synchronization rather than trading it, so the expected direction is positive, but it is not measured and the changelog says nothing about speed. Folded into the owed A/B (#120) — and it is the entry on that list most likely to show a real number.
