### PR TITLE
build(android): stage an explicit library list, and force GGML_OPENCL off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+- **The Android build script can no longer ship a backend nobody chose.** Staging swept every
+  `libggml*.so` it found in the build tree into the app's `jniLibs`, and the build directory's cmake
+  cache still carried `GGML_OPENCL=ON` from a GPU experiment — so a `libggml-opencl.so` no shipped
+  configuration loads rode along into the v0.16.0 and v0.17.0 APKs (the release assets have been
+  rebuilt without it). The script now forces `GGML_OPENCL=OFF`, wipes `jniLibs` before staging, and
+  copies an explicit list of libraries; a missing one fails the build instead of a stray one
+  shipping.
+
 ### Changed
 - **With the drop policy armed, only the weight node that decides is isolated.** The router-weight
   chain is `ffn_moe_weights → (_softmax | _norm) → (_scaled)`, and the engine asked for **every**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,9 @@ Android CLI: `pwsh scripts/build-android.ps1` (needs the NDK), then build the AP
 - **Commits:** Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
   `build:`, `ci:`, `chore:`). Author is **Helldez only** — do NOT add AI co-author or
   session trailers to commits.
+- **Group commits.** One commit = one coherent change. Never a commit for a trivial
+  tweak on its own — fold small fixes, doc touches and follow-ups into the change they
+  belong to. If several small things accumulate, batch them into one commit.
 - **Language:** all code, comments, docs, and commit messages in English.
 - **Style:** `.clang-format` (LLVM base, 4-space, 120 col). Comments explain *why* /
   invariants, not *what*.

--- a/scripts/build-android.ps1
+++ b/scripts/build-android.ps1
@@ -62,6 +62,7 @@ Invoke-Native "cmake configure" {
         -DCMAKE_BUILD_TYPE="$BuildType" `
         -DBMOE_BUILD_TESTS=OFF `
         -DGGML_NATIVE=OFF `
+        -DGGML_OPENCL=OFF `
         -DGGML_OPENMP=OFF `
         -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" `
         -DLLAMA_CURL=OFF
@@ -70,14 +71,23 @@ Invoke-Native "cmake configure" {
 Invoke-Native "cmake build" { cmake --build $buildPath -j }
 
 # Stage the CLI and the shared libs it needs into the app's jniLibs as lib*.so.
+# The list is explicit, and jniLibs is wiped first: a recursive sweep of the build tree once
+# staged a libggml-opencl.so left over from a GPU experiment's cmake cache, and it rode along
+# into two published APKs. If a submodule bump adds a library, the app fails at dlopen — loud —
+# instead of the APK silently growing a binary nobody chose to ship.
+$libs = @("libggml.so", "libggml-base.so", "libggml-cpu.so", "libllama.so", "libllama-common.so")
+
 $jni = Join-Path $root "examples\android\app\src\main\jniLibs\$Abi"
 New-Item -ItemType Directory -Force -Path $jni | Out-Null
+Get-ChildItem $jni -Filter "*.so" | Remove-Item -Force
 
 $cli = Join-Path $buildPath "cli\bmoe-cli"
 Copy-Item $cli (Join-Path $jni "libbmoe-cli.so") -Force
-Get-ChildItem -Path $buildPath -Recurse -Filter "*.so" |
-    Where-Object { $_.Name -like "libggml*" -or $_.Name -like "libllama*" } |
-    ForEach-Object { Copy-Item $_.FullName (Join-Path $jni $_.Name) -Force }
+foreach ($name in $libs) {
+    $src = Get-ChildItem -Path $buildPath -Recurse -Filter $name | Select-Object -First 1
+    if (-not $src) { throw "$name not found in $buildPath" }
+    Copy-Item $src.FullName (Join-Path $jni $name) -Force
+}
 
 # bmoe-cli links the c++_shared STL, so its runtime must ride along in the APK —
 # it lives in the NDK sysroot, not the build tree.


### PR DESCRIPTION
## What

The APKs published with v0.16.0 and v0.17.0 contain a `libggml-opencl.so` that no shipped configuration loads. Two holes in `scripts/build-android.ps1` let it in:

- the staging step swept **every** `libggml*.so` it found anywhere in the build tree into the app's `jniLibs`, and never cleaned `jniLibs` between builds;
- the configure step did not pin `GGML_OPENCL`, so the build directory's cmake cache still carried `ON` from a GPU experiment, and every rebuild kept producing the backend.

## Fix

- `GGML_OPENCL=OFF` is now forced at configure time — a cached `ON` from an old experiment no longer survives.
- `jniLibs/*.so` is wiped before staging.
- Staging copies an **explicit list** of libraries. If a submodule bump adds a library the CLI needs, the copy fails the build loudly instead of a stray binary shipping silently.

The v0.16.0 and v0.17.0 release assets are being rebuilt from their tags without the stray binary.

Also adds the commit-grouping convention to the agent guide.
