### PR TITLE
ci: build and attach release APKs from a clean checkout of the tag

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,126 @@
+# Builds the example-app APKs for a published release and attaches them to it.
+#
+# Runs from a clean checkout of the release tag, so no local build residue can ride into a
+# published artifact (a stale cmake cache once shipped an OpenCL backend nobody chose — see
+# CHANGELOG 2026-07-28). Signing uses the stable release keystore from repository secrets:
+# the same key every release, so an APK update installs over the previous one without an
+# uninstall (which would wipe downloaded models).
+#
+# Secrets:
+#   RELEASE_KEYSTORE_B64      base64 of bmoe-release.jks
+#   RELEASE_KEYSTORE_PASSWORD store password
+#   RELEASE_KEY_ALIAS         key alias
+#   RELEASE_KEY_PASSWORD      key password
+name: release-apk
+
+on:
+  release:
+    types: [published]
+  # Manual re-run for an existing release (e.g. to rebuild assets for an old tag).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and upload assets for"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  NDK_VERSION: "27.2.12479018"
+
+jobs:
+  apk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          submodules: recursive
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install NDK and ninja
+        run: |
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;$NDK_VERSION" > /dev/null
+          sudo apt-get update -q && sudo apt-get install -y -q ninja-build
+
+      # Mirrors scripts/build-android.ps1: same flags, same explicit staging list.
+      # Keep the two in sync — this one produces what users actually install.
+      - name: Build bmoe-cli (arm64)
+        run: |
+          NDK="$ANDROID_HOME/ndk/$NDK_VERSION"
+          cmake -S . -B build-android -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=android-29 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBMOE_BUILD_TESTS=OFF \
+            -DGGML_NATIVE=OFF \
+            -DGGML_OPENCL=OFF \
+            -DGGML_OPENMP=OFF \
+            -DGGML_CPU_ARM_ARCH="armv8.2-a+dotprod+fp16" \
+            -DLLAMA_CURL=OFF
+          cmake --build build-android -j
+
+      - name: Stage jniLibs
+        run: |
+          NDK="$ANDROID_HOME/ndk/$NDK_VERSION"
+          JNI=examples/android/app/src/main/jniLibs/arm64-v8a
+          mkdir -p "$JNI" && rm -f "$JNI"/*.so
+          cp build-android/cli/bmoe-cli "$JNI/libbmoe-cli.so"
+          for f in libggml.so libggml-base.so libggml-cpu.so libllama.so libllama-common.so; do
+            src=$(find build-android -name "$f" | head -1)
+            test -n "$src" || { echo "$f not found"; exit 1; }
+            cp "$src" "$JNI/$f"
+          done
+          cp "$NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" "$JNI/"
+
+      - name: Materialize signing keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.RELEASE_KEYSTORE_B64 }}
+        run: |
+          echo "$KEYSTORE_B64" | base64 -d > examples/android/bmoe-release.jks
+          cat > examples/android/keystore.properties <<EOF
+          storeFile=bmoe-release.jks
+          storePassword=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          keyAlias=${{ secrets.RELEASE_KEY_ALIAS }}
+          keyPassword=${{ secrets.RELEASE_KEY_PASSWORD }}
+          EOF
+
+      - name: Build APKs
+        run: |
+          cd examples/android
+          chmod +x gradlew
+          ./gradlew --no-daemon assembleDevRelease assembleDevDebug
+
+      # The whole point of building on CI: fail if anything but the chosen libraries is inside.
+      - name: Verify APK contents
+        run: |
+          APK=examples/android/app/build/outputs/apk/dev/release/app-dev-release.apk
+          unzip -l "$APK" | grep 'lib/arm64-v8a/'
+          if unzip -l "$APK" | grep -q libggml-opencl; then
+            echo "stray OpenCL backend in APK"; exit 1
+          fi
+
+      - name: Upload assets to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          OUT=examples/android/app/build/outputs/apk/dev
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            "$OUT/release/app-dev-release.apk" \
+            "$OUT/debug/app-dev-debug.apk" \
+            --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+- **Release APKs are built by CI, not uploaded by hand.** A `release-apk` workflow runs when a
+  release is published: clean checkout of the tag, NDK build of the CLI with the same flags and
+  explicit staging list as `scripts/build-android.ps1`, APK build signed with the stable release
+  key from repository secrets, a content check that fails on any stray library, and the assets
+  attached to the release. Both build types now sign with the stable key when it is available, so
+  the debug APK also updates in place instead of demanding an uninstall that wipes downloaded
+  models.
+
 ### Fixed
 - **The Android build script can no longer ship a backend nobody chose.** Staging swept every
   `libggml*.so` it found in the build tree into the app's `jniLibs`, and the build directory's cmake

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -28,10 +28,12 @@ research harness and keeps the app a thin driver over the CLI.
    adb install app/build/outputs/apk/dev/debug/app-dev-debug.apk
    ```
 
-   Published sideload builds are release-signed with a stable key instead, so an update installs
-   over the previous one rather than being refused. That needs a `keystore.properties` next to
-   `app/` (gitignored — it points at the keystore and holds its passwords); without it the release
-   build falls back to debug signing.
+   Published sideload builds are signed with a stable key instead, so an update installs over
+   the previous one rather than being refused. That needs a `keystore.properties` next to `app/`
+   (gitignored — it points at the keystore and holds its passwords); without it, builds fall back
+   to debug signing. The APKs attached to a GitHub release are built by the `release-apk`
+   workflow from a clean checkout of the tag when the release is published, signed with the same
+   stable key from repository secrets — no locally built artifact is uploaded by hand.
 
 ## Flavors
 

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -21,12 +21,13 @@ def gitSha = {
     }
 }()
 
-// Release signing. The secrets live in keystore.properties (gitignored) next to gradlew; the
-// keystore is a stable key kept off the repo. A release APK signed with it installs over the
-// previous release without an uninstall — a debug-signed one forces a reinstall (per-machine
-// debug key) and wipes downloaded models. When the properties file is absent (fresh clone, CI),
-// the release build falls back to debug signing so it still builds; only a machine holding the
-// keystore produces a distributable, stably-signed APK.
+// Signing. The secrets live in keystore.properties (gitignored) next to gradlew; the
+// keystore is a stable key kept off the repo (CI receives it through repository secrets).
+// An APK signed with it installs over the previous one without an uninstall — a debug-signed
+// one forces a reinstall (per-machine debug key) and wipes downloaded models, which is why
+// BOTH build types use the stable key when it is available. When the properties file is
+// absent (fresh clone), builds fall back to debug signing so they still build; only a holder
+// of the keystore produces a distributable, stably-signed APK.
 def keystorePropsFile = rootProject.file('keystore.properties')
 def keystoreProps = new Properties()
 if (keystorePropsFile.exists()) keystoreProps.load(new FileInputStream(keystorePropsFile))
@@ -95,6 +96,10 @@ android {
         release {
             minifyEnabled false
             // Stable release key when available; otherwise Gradle leaves the default (debug) signing.
+            if (keystorePropsFile.exists()) signingConfig signingConfigs.release
+        }
+        debug {
+            // Same stable key: a debug APK from any machine (or CI) then updates in place.
             if (keystorePropsFile.exists()) signingConfig signingConfigs.release
         }
     }


### PR DESCRIPTION
## What

Release APKs were built on a developer machine and uploaded by hand — which is how a stale cmake cache shipped an OpenCL backend into two releases (#124 fixed the script hole).

This adds a `release-apk` workflow that runs when a release is published:

- clean checkout of the release tag, submodules included — no local residue possible;
- NDK build of `bmoe-cli` with the same flags and the same explicit staging list as `scripts/build-android.ps1` (the two must stay in sync);
- APK build signed with the **stable release key** from repository secrets (`RELEASE_KEYSTORE_B64` + passwords, already set), so a CI-built APK installs over any previous one without an uninstall;
- a content check that fails the run if any library outside the chosen list is inside the APK;
- assets attached to the release with `--clobber`.

`workflow_dispatch` takes a tag input so assets of an existing release can be rebuilt.

Both build types now sign with the stable key when it is available, so the debug APK also updates in place instead of demanding an uninstall that wipes downloaded models. (One-time caveat: a currently installed debug-key-signed debug APK needs one last reinstall before updates flow.)

## Validation

The build recipe is the one just used to rebuild the v0.16.0/v0.17.0 assets locally from their tags (same flags, same allowlist, verified: same signing cert, right versionCode, no stray libraries). First CI run: workflow_dispatch on the existing tags after merge.
