### PR TITLE
perf(moe): retire the audit leftovers on the overlap hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Semantic Versioning.
 
 ## [Unreleased]
 
+### Changed
+- **The overlap hook's per-expert bookkeeping got out of the kernel's way.** Three findings from
+  the audit's leftovers (#123): the readiness lookup every compute thread ran for every routed
+  expert was a hash-map probe — now a binary search over a flat sorted array, static after init;
+  the pre-block spin was 2048 `sched_yield` syscalls — up to a millisecond of scheduler churn per
+  genuinely slow slice, stealing CPU from the I/O lanes — now 256 single-instruction pauses
+  (`isb`/`pause`) before registering as a waiter; and a cache hit on the overlap path no longer
+  pays an LRU promotion that the token-major promote loop overwrote unconditionally two steps
+  later. LRU order, readiness semantics and the gates are unchanged.
+- **The gguf header is parsed once per run, not once per consumer.** The tensor-offset read and
+  the model-info read each ran `gguf_init_from_file` — a full KV walk of a multi-GB file's
+  header. One lazy parse now serves the top-k override, the route trace, the run info and the
+  streamer's offsets.
+
 ### Added
 - **Release APKs are built by CI, not uploaded by hand.** A `release-apk` workflow runs when a
   release is published: clean checkout of the tag, NDK build of the CLI with the same flags and

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -293,20 +293,22 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
 
     const auto t_load0 = clock_t_::now();
 
-    // The gguf header answers three separate questions below — the arch-prefixed key for a top-k
-    // override, the route trace's effective top-k, and the run info's top-k/expert count — and each
-    // used to reopen and reparse the file for its own answer. Read it at most once, lazily: the
-    // callers are conditional (a run with no override and no trace asks nothing), so an eager read
-    // would be work the common path never needs.
-    GgufModelInfo gguf_info;
-    bool gguf_info_read = false;
-    auto gguf = [&]() -> const GgufModelInfo & {
-        if (!gguf_info_read) {
-            gguf_info = read_gguf_model_info(cfg.model_path.c_str());
-            gguf_info_read = true;
+    // The gguf header answers several separate questions below — the arch-prefixed key for a
+    // top-k override, the route trace's effective top-k, the run info's top-k/expert count, and
+    // the streamer's per-tensor file offsets — and each used to reopen and reparse the file for
+    // its own answer. Parse it at most once, lazily: the callers are conditional (a run with no
+    // override, no trace and no streaming asks nothing), so an eager read would be work the
+    // common path never needs. One parse serves both the model info and the offsets.
+    GgufMeta gguf_meta;
+    bool gguf_meta_read = false;
+    auto meta = [&]() -> const GgufMeta & {
+        if (!gguf_meta_read) {
+            gguf_meta = read_gguf_meta(cfg.model_path.c_str());
+            gguf_meta_read = true;
         }
-        return gguf_info;
+        return gguf_meta;
     };
+    auto gguf = [&]() -> const GgufModelInfo & { return meta().info; };
 
     // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
     // q4_K buffer would break the rebind), experts on CPU.
@@ -434,7 +436,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         if (llama_decode(ctx, warm) != 0) return fail("capture warm-up decode failed");
         im.hook->end_capture();
 
-        GgufOffsets offs = read_gguf_offsets(cfg.model_path.c_str());
+        const GgufOffsets & offs = meta().offsets;
         if (!offs.ok) return fail("cannot read gguf offsets: " + cfg.model_path);
 
         std::vector<LayerExperts> layers = im.hook->captured();

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -12,6 +12,10 @@
 #include <thread>
 #include <utility>
 
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+#include <intrin.h> // _mm_pause for the readiness spin-wait
+#endif
+
 namespace bmoe {
 
 using clock_t_ = std::chrono::steady_clock;
@@ -178,8 +182,10 @@ bool ExpertStreamSource::init(const std::string & gguf_path,
             const LayerExperts & L = layers_[il];
             if (!L.bound) continue;
             for (int p = 0; p < MoeRecipe::max_exps; ++p)
-                if (L.proj[p].tensor) texp_[(const void *) L.proj[p].tensor] = ((uint32_t) il << 8) | (uint32_t) p;
+                if (L.proj[p].tensor)
+                    texp_.emplace_back((const void *) L.proj[p].tensor, ((uint32_t) il << 8) | (uint32_t) p);
         }
+        std::sort(texp_.begin(), texp_.end());
     }
 
     // Hand the dense (non-expert) weights to their policy module: it warms them into the page cache,
@@ -628,7 +634,7 @@ uint64_t ExpertStreamSource::expert_bytes(int il) const {
 
 // The cache accounting both load paths share. See the header for why this is the part that is shared
 // and the job emission is not. Eval-thread only, like every other LRU mutation.
-bool ExpertStreamSource::touch_entry(int il, int e, bool & hit) {
+bool ExpertStreamSource::touch_entry(int il, int e, bool & hit, bool promote) {
     const int32_t id = il * n_expert_ + e;
     clookups_++;
     cstamp_[id] = cgen_;
@@ -638,8 +644,10 @@ bool ExpertStreamSource::touch_entry(int il, int e, bool & hit) {
             spec_useful_.fetch_add(1);
             cspec_[id] = 0;
         }
-        lru_unlink(id);
-        lru_push_front(id);
+        if (promote) {
+            lru_unlink(id);
+            lru_push_front(id);
+        }
         hit = true;
         return true;
     }
@@ -859,7 +867,9 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
         seen_.assign(seen_.size(), 0); // reuse as a per-staged miss marker keyed by expert
         for (int e : staged_) {
             bool hit = false;
-            if (!touch_entry(il, e, hit)) {
+            // promote=false: the token-major loop below re-orders every touched id anyway, so a
+            // hit-path LRU move here was k wasted pointer operations per layer per token.
+            if (!touch_entry(il, e, hit, /*promote=*/false)) {
                 // Nothing waits on a flag we will never publish: abort the graph instead.
                 fatal_.store(true, std::memory_order_release);
                 return false;
@@ -885,10 +895,9 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
 
         // Promote every touched expert in raw id order (token-major) so the LRU order reflects
         // the LAST token that used it, not the sorted/first-touch order staged_ imposes — this
-        // keeps the prompt tail's experts hot across prefill. Bookkeeping only; every id staged
-        // above is now valid and linked. In decode (n=1) this is a no-op reshuffle when the ids are
-        // distinct, and an idempotent re-promote of the same entry when cache-aware dropping has
-        // repointed a slot at the routing's top expert.
+        // keeps the prompt tail's experts hot across prefill. This loop is the ONLY promotion on
+        // this path (touch_entry above runs with promote=false); every id staged above is valid
+        // and linked, a miss by its initial push, so unlink here is always legal.
         // Skipped in load_all (everything is resident, so LRU order is meaningless).
         if (!load_all_) {
             for (int i = 0; i < n_ids; ++i) {
@@ -930,11 +939,29 @@ void ExpertStreamSource::c_expert_ready(const ggml_tensor * src0, int expert, vo
     static_cast<ExpertStreamSource *>(user_data)->on_expert_ready(src0, expert);
 }
 
+// One idle beat of the spin-wait below: keep the core out of the sibling threads' way without
+// entering the scheduler. yield() is a syscall; these are single instructions.
+static inline void cpu_relax() {
+#if defined(__aarch64__)
+    __asm__ __volatile__("isb" ::: "memory");
+#elif defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#if defined(_MSC_VER)
+    _mm_pause();
+#else
+    __builtin_ia32_pause();
+#endif
+#else
+    std::this_thread::yield();
+#endif
+}
+
 // Called from EVERY compute thread, for each routed expert, before it reads that expert's rows.
 // Blocks until the expert's slice for the layer in flight is resident (or the run goes fatal).
 void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
-    auto it = texp_.find((const void *) src0);
-    if (it == texp_.end()) return; // not one of our streamed expert tensors
+    const void * key = (const void *) src0;
+    auto it = std::lower_bound(texp_.begin(), texp_.end(), key,
+                               [](const std::pair<const void *, uint32_t> & a, const void * k) { return a.first < k; });
+    if (it == texp_.end() || it->first != key) return; // not one of our streamed expert tensors
     const uint32_t packed = it->second;
     const int il = (int) (packed >> 8);
     const int p = (int) (packed & 0xff);
@@ -953,14 +980,17 @@ void ExpertStreamSource::on_expert_ready(const ggml_tensor * src0, int expert) {
     if (ready_[idx].gen.load(std::memory_order_acquire) == want) return; // already resident
 
     const auto t0 = clock_t_::now();
-    // Short spin first: a slice usually lands within microseconds, cheaper than a syscall.
-    for (int s = 0; s < 2048; ++s) {
+    // Short spin first: a slice usually lands within microseconds, cheaper than a syscall. The
+    // beat is a pause instruction, not yield() — 2048 yields burnt up to a millisecond of
+    // sched_yield churn per genuinely slow slice, stealing CPU from the I/O lanes and the
+    // sibling compute threads that would have finished the slice sooner.
+    for (int s = 0; s < 256; ++s) {
         if (ready_[idx].gen.load(std::memory_order_acquire) == want || fatal_.load(std::memory_order_acquire)) {
             stall_ns_.fetch_add(
                 (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - t0).count());
             return;
         }
-        std::this_thread::yield();
+        cpu_relax();
     }
     // Register as a waiter BEFORE the last look at the flag. The publisher sets the flag before it
     // reads this count, and both sides are seq_cst, so one of the two must observe the other: either

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -156,7 +156,9 @@ private:
     // that stays with each caller. `hit` tells the caller whether this expert still needs reads.
     // Returns false only if committing the pages failed; the caller decides how fatal that is.
     // LRU mode only (cache_max_ > 0) — the shared-slot path has no entries to account for.
-    bool touch_entry(int il, int e, bool & hit);
+    // `promote` = false skips the hit-path LRU move for callers that re-order every touched id
+    // afterwards anyway (the overlap path's token-major promote loop); a miss is always linked.
+    bool touch_entry(int il, int e, bool & hit, bool promote = true);
 
     // LRU helpers (active only when cache_max_ > 0)
     void lru_unlink(int32_t id);
@@ -292,8 +294,10 @@ private:
     // re-check a predicate that was almost never its own. Registration and publication are both
     // seq_cst so the two cannot miss each other — see on_expert_ready.
     std::atomic<int> ready_waiters_{0};
-    std::atomic<long long> stall_ns_{0};              // summed across all stalling compute threads
-    std::unordered_map<const void *, uint32_t> texp_; // expert tensor* -> (il<<8)|p, built in init
+    std::atomic<long long> stall_ns_{0}; // summed across all stalling compute threads
+    // expert tensor* -> (il<<8)|p. Sorted by pointer and static after init, and probed by every
+    // compute thread for every routed expert — a flat binary search beats hashing the pointer.
+    std::vector<std::pair<const void *, uint32_t>> texp_;
     std::vector<int> staged_;                         // per-load sorted unique expert scratch
     bool hook_registered_ = false;
 };

--- a/core/src/moe/gguf_offsets.cpp
+++ b/core/src/moe/gguf_offsets.cpp
@@ -36,20 +36,15 @@ int meta_int(const gguf_context * ctx, const std::string & key, int dflt) {
     }
 }
 
-} // namespace
-
-GgufOffsets read_gguf_offsets(const char * path) {
-    GgufOffsets out;
-
+// Single parse; each extraction below reads from the already-parsed context.
+gguf_context * open_meta(const char * path) {
     gguf_init_params gp{};
     gp.no_alloc = true; // metadata + offsets only; no tensor bytes touched
     gp.ctx = nullptr;
+    return gguf_init_from_file(path, gp);
+}
 
-    gguf_context * gctx = gguf_init_from_file(path, gp);
-    if (!gctx) {
-        return out;
-    }
-
+void fill_offsets(const gguf_context * gctx, GgufOffsets & out) {
     const uint64_t data_off = (uint64_t) gguf_get_data_offset(gctx);
     const int64_t n = gguf_get_n_tensors(gctx);
     out.off_by_name.reserve((size_t) n);
@@ -59,24 +54,10 @@ GgufOffsets read_gguf_offsets(const char * path) {
         out.off_by_name[name] = data_off + (uint64_t) gguf_get_tensor_offset(gctx, i);
         out.size_by_name[name] = (uint64_t) gguf_get_tensor_size(gctx, i);
     }
-
-    gguf_free(gctx);
     out.ok = true;
-    return out;
 }
 
-GgufModelInfo read_gguf_model_info(const char * path) {
-    GgufModelInfo out;
-
-    gguf_init_params gp{};
-    gp.no_alloc = true; // metadata only; no tensor bytes touched
-    gp.ctx = nullptr;
-
-    gguf_context * gctx = gguf_init_from_file(path, gp);
-    if (!gctx) {
-        return out;
-    }
-
+void fill_model_info(const gguf_context * gctx, GgufModelInfo & out) {
     const int64_t arch_id = gguf_find_key(gctx, "general.architecture");
     if (arch_id >= 0 && gguf_get_kv_type(gctx, arch_id) == GGUF_TYPE_STRING) {
         out.arch = gguf_get_val_str(gctx, arch_id);
@@ -87,9 +68,37 @@ GgufModelInfo read_gguf_model_info(const char * path) {
         out.n_expert = meta_int(gctx, out.arch + ".expert_count", 0);
         out.n_expert_used = meta_int(gctx, out.arch + ".expert_used_count", 0);
     }
-
-    gguf_free(gctx);
     out.ok = true;
+}
+
+} // namespace
+
+GgufOffsets read_gguf_offsets(const char * path) {
+    GgufOffsets out;
+    if (gguf_context * gctx = open_meta(path)) {
+        fill_offsets(gctx, out);
+        gguf_free(gctx);
+    }
+    return out;
+}
+
+GgufModelInfo read_gguf_model_info(const char * path) {
+    GgufModelInfo out;
+    if (gguf_context * gctx = open_meta(path)) {
+        fill_model_info(gctx, out);
+        gguf_free(gctx);
+    }
+    return out;
+}
+
+GgufMeta read_gguf_meta(const char * path) {
+    GgufMeta out;
+    if (gguf_context * gctx = open_meta(path)) {
+        fill_offsets(gctx, out.offsets);
+        fill_model_info(gctx, out.info);
+        gguf_free(gctx);
+        out.ok = true;
+    }
     return out;
 }
 

--- a/core/src/moe/gguf_offsets.h
+++ b/core/src/moe/gguf_offsets.h
@@ -39,4 +39,13 @@ struct GgufModelInfo {
 // if the file cannot be opened as gguf; a present file with a missing key leaves that field 0.
 GgufModelInfo read_gguf_model_info(const char * path);
 
+// Both of the above from ONE parse. gguf_init_from_file walks the whole KV section even with
+// no_alloc, so a caller that needs offsets and model info should not pay that walk twice.
+struct GgufMeta {
+    GgufOffsets   offsets;
+    GgufModelInfo info;
+    bool          ok = false; // both parses' ok, from the single underlying open
+};
+GgufMeta read_gguf_meta(const char * path);
+
 } // namespace bmoe


### PR DESCRIPTION
Closes #123 — implements its top three findings, parks the rest with reasons.

## What ships

1. **`on_expert_ready` lookup + spin** (finding 1). The per-routed-expert readiness lookup is a binary search over a flat sorted array instead of a hash-map probe (the table is static after init). The pre-block spin drops from 2048 `sched_yield` syscalls to 256 single-instruction pauses (`isb` on arm64, `pause` on x86) before the thread registers as a waiter. `stall_ns_` still brackets the whole wait, so the change is visible to the A/B owed in #120.
2. **Redundant second LRU promotion** (finding 2). On the overlap path, a cache hit's `touch_entry` promotion was overwritten unconditionally by the token-major promote loop two steps later; `touch_entry` now takes `promote=false` there. The serial path keeps promoting (it has no trailing loop for first touches). Final LRU order is byte-for-byte the same in every case.
3. **gguf header parsed once** (finding 3). `read_gguf_meta` does one `gguf_init_from_file` and serves both the tensor offsets and the model info; the session's lazy accessor hands the same parse to the top-k override, the route trace, the run info and the streamer.

## Parked, with reasons (recorded here so the issue can close)

- **Finding 4** (metrics work with no consumer): only reachable by a library embedder; the CLI always attaches a consumer. Wants the `GenTally` cursor rework, not a guard.
- **Finding 5** (`direct()` misreport where `O_DIRECT` is stubbed): macOS-only; no shipping platform affected. The fix is wiring `F_NOCACHE`, worth doing only if a macOS measurement ever matters.
- **Finding 6** (llama.cpp context defaults never A/B'd): a bench campaign, not a code change; belongs with the device session that closes #120.

## Verification

Byte-identity gates pass (7/7). No routing decision, LRU order or readiness semantics change; on-device throughput effect (if any) is part of the #120 A/B.
