### PR TITLE
perf(cli): BMOE_PROGRESS carries the answer as a delta, not cumulatively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Semantic Versioning.
 ## [Unreleased]
 
 ### Changed
+- **`BMOE_PROGRESS` carries the answer as a delta, not cumulatively.** Every per-token line
+  repeated the whole answer and reasoning so far, so a generation of n tokens wrote, JSON-escaped
+  and made the app parse O(n²) bytes — megabytes of pipe traffic for a thousand-token reasoning
+  answer (#119). The line now carries `delta_reasoning`/`delta_text` (the tail since the previous
+  line) and the reader appends; when the chat parser retroactively reclassifies answer text as
+  reasoning (a closing think tag arrives) the line carries full snapshots with `"reset":1` and the
+  reader replaces. The full final text still travels in `BMOE_DONE`, and the app parser
+  accumulates in a builder instead of re-copying strings. Protocol readers: both emitters (one-shot
+  `--progress` and `--session`) changed together, and [docs/telemetry.md](docs/telemetry.md)
+  documents the new fields.
 - **The overlap hook's per-expert bookkeeping got out of the kernel's way.** Three findings from
   the audit's leftovers (#123): the readiness lookup every compute thread ran for every routed
   expert was a hash-map probe — now a binary search over a flat sorted array, static after init;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -68,20 +68,44 @@ static std::string json_escape(const std::string & s) {
     return o;
 }
 
+// What BMOE_PROGRESS already delivered this generation, so each line carries only the new tail.
+// One state per generation: reset it (fresh object) when a new one begins.
+struct ProgressDelta {
+    std::string reasoning;
+    std::string text;
+};
+
+static bool is_extension(const std::string & full, const std::string & prev) {
+    return full.size() >= prev.size() && full.compare(0, prev.size(), prev) == 0;
+}
+
 // One token's line-protocol output: the optional BMOE_LOAD, then BMOE_PROGRESS (docs/telemetry.md).
 // Both emitters — the one-shot --progress run and the interactive session, which is a superset of it
 // — must produce a byte-identical line, since the Android app parses one parser's worth of protocol.
 // Keeping the format string in one place is what makes that true rather than merely intended.
-static void emit_progress_line(const TokenMetrics & m) {
+//
+// The answer travels as a DELTA: sending the cumulative text every token made a generation of n
+// tokens write, escape and parse O(n^2) bytes (#119). The common case appends the suffix since the
+// last line; when a closing tag makes common_chat_parse retroactively reclassify answer text as
+// reasoning, an append cannot express it, so the line carries the full snapshot with "reset":1 and
+// the reader replaces instead of appending. The first line of a generation is a plain extension of
+// the empty state. The full final text still travels in BMOE_DONE.
+static void emit_progress_line(const TokenMetrics & m, ProgressDelta & st) {
     if (m.read_bytes || m.io_ms > 0.0)
         std::printf("BMOE_LOAD {\"mb\":%.2f,\"ms\":%.1f}\n", m.read_bytes / (1024.0 * 1024.0), m.io_ms);
+    const bool ext = is_extension(m.reasoning, st.reasoning) && is_extension(m.text, st.text);
+    const std::string d_reason = ext ? m.reasoning.substr(st.reasoning.size()) : m.reasoning;
+    const std::string d_text = ext ? m.text.substr(st.text.size()) : m.text;
     std::printf("BMOE_PROGRESS {\"step\":%d,\"steps\":%d,\"wall_ms\":%.1f,\"io_ms\":%.1f,"
                 "\"compute_ms\":%.1f,\"mgmt_ms\":%.1f,\"stall_ms\":%.1f,\"read_mb\":%.2f,"
                 "\"cache_hit_pct\":%.1f,\"majflt\":%llu,\"cpu_ms\":%.1f,\"dense_resident_frac\":%.3f,"
-                "\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
+                "%s\"delta_reasoning\":\"%s\",\"delta_text\":\"%s\"}\n",
                 m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, m.mgmt_ms, m.stall_ms,
                 m.read_bytes / (1024.0 * 1024.0), m.cache_hit_pct, (unsigned long long) m.majflt, m.cpu_ms,
-                m.dense_resident_frac, json_escape(m.reasoning).c_str(), json_escape(m.text).c_str());
+                m.dense_resident_frac, ext ? "" : "\"reset\":1,", json_escape(d_reason).c_str(),
+                json_escape(d_text).c_str());
+    st.reasoning = m.reasoning;
+    st.text = m.text;
     std::fflush(stdout);
 }
 
@@ -285,7 +309,8 @@ static int run_session_loop(const RunConfig & cfg,
         req.clear_kv = cmd.clear_kv;
         req.render_text = true; // the line protocol carries the parsed answer on every token
 
-        RunResult r = session->generate(req, emit_progress_line, sink);
+        ProgressDelta pd; // fresh per generation: the first line extends the empty state
+        RunResult r = session->generate(req, [&](const TokenMetrics & m) { emit_progress_line(m, pd); }, sink);
         if (!r) {
             // A bad request (empty prompt, context overflow) leaves the session usable; a decode
             // failure means the context is compromised, so end the loop.
@@ -673,9 +698,10 @@ int main(int argc, char ** argv) {
         std::fflush(stdout);
     }
 
+    ProgressDelta pd; // one generation per one-shot run
     auto on_token = [&](const TokenMetrics & m) {
         if (cfg.progress) {
-            emit_progress_line(m);
+            emit_progress_line(m, pd);
         } else {
             std::fwrite(m.piece.data(), 1, m.piece.size(), stdout);
             std::fflush(stdout);

--- a/docs/session.md
+++ b/docs/session.md
@@ -49,8 +49,8 @@ with thinking **off** (the app default) the re-fed suffix is just the new user t
 wrapper tokens.
 
 **Reasoning is returned, not discarded.** On a thinking model the Session parses the reasoning span
-out of the raw stream and carries it in its own field (`TokenMetrics`/`RunResult::reasoning`, and
-`reasoning` on `BMOE_PROGRESS`/`BMOE_DONE`) rather than dropping it. The answer text stays free of
+out of the raw stream and carries it in its own field (`TokenMetrics`/`RunResult::reasoning`,
+`delta_reasoning` on `BMOE_PROGRESS`, `reasoning` on `BMOE_DONE`) rather than dropping it. The answer text stays free of
 it either way, so the byte-identity gates are unaffected; a caller that wants to show the thinking
 reads the separate field. The parser wiring lives in `core/src/engine/chat_parse.cpp`
 (see [seam.md](seam.md)).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -12,7 +12,7 @@ BMOE_LOAD {"mb":<float>,"ms":<float>}
 BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
                "compute_ms":<float>,"mgmt_ms":<float>,"stall_ms":<float>,"read_mb":<float>,
                "cache_hit_pct":<float>,"majflt":<int>,"cpu_ms":<float>,"dense_resident_frac":<float>,
-               "reasoning":"<string>","text":"<string>"}
+               ["reset":1,]"delta_reasoning":"<string>","delta_text":"<string>"}
 ```
 
 - `BMOE_LOAD` appears only when experts were read this token; `mb` is the flash bytes read,
@@ -73,12 +73,18 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
   `mincore`, throttled). Under `--dense-weights anon` it samples our own buffers (is zram holding
   them?); under mmap/warm the model's mmap (is the kernel dropping it?). A diagnostic read alongside
   `majflt` — nothing acts on it. `-1` when unmeasured.
-- `text` is the full generated **answer** so far, JSON-escaped (for streaming into a UI), with any
-  reasoning span stripped out.
-- `reasoning` is the thinking span so far, JSON-escaped, when a reasoning model's chat template
-  separated it from the answer. Empty with chat off, on a non-reasoning model, or when thinking was
-  disabled (`think=false`). It is display-only and kept apart from `text` so a UI can render it as a
-  distinct thinking block rather than inline in the answer.
+- `delta_text` is the newly generated **answer** text since the previous `BMOE_PROGRESS` line,
+  JSON-escaped, with any reasoning span stripped out. The reader appends it to what this
+  generation already delivered. (Carrying the cumulative answer on every line made a generation of
+  n tokens O(n²) on the wire; the full final text still travels in `BMOE_DONE`.)
+- `delta_reasoning` is the same delta for the thinking span, when a reasoning model's chat
+  template separated it from the answer. Empty with chat off, on a non-reasoning model, or when
+  thinking was disabled (`think=false`). Display-only, kept apart from the answer so a UI can
+  render it as a distinct thinking block.
+- `reset` (present only as `"reset":1`) means the deltas on THIS line are full snapshots that
+  **replace** the accumulated state instead of extending it. It appears when the chat parser
+  retroactively reclassifies — a closing think tag arrives and text reported as answer becomes
+  reasoning — which an append-only delta cannot express.
 
 ## End-of-run lines
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -124,7 +124,13 @@ fun breakdown(t: Telemetry, overlap: Boolean, busyThreads: Int): Breakdown {
  * Incrementally parses the CLI's per-token telemetry contract (see docs/telemetry.md):
  *   BMOE_LOAD     {"mb":..,"ms":..}
  *   BMOE_PROGRESS {"step":..,"steps":..,"wall_ms":..,"io_ms":..,"compute_ms":..,
- *                  "cache_hit_pct":..,"text":".."}
+ *                  "cache_hit_pct":..,"delta_text":".."}
+ *
+ * The answer arrives as a delta: `delta_reasoning`/`delta_text` append to what this generation
+ * already received, unless the line carries `"reset":1` — the engine's chat parser retroactively
+ * reclassified answer text as reasoning (a closing tag arrived), and the deltas are full
+ * snapshots that REPLACE the accumulated state. Sending the cumulative text every token made a
+ * generation O(n²) on the wire (engine #119).
  *
  * The session control lines (BMOE_READY/BEGIN/DONE/ERROR) and the one-shot text summary lines
  * are handled by the RunService state machine, not here.
@@ -133,9 +139,17 @@ class TelemetryParser {
     var current = Telemetry()
         private set
 
+    // Accumulated answer/reasoning of the generation in flight. StringBuilder, not the data
+    // class's String fields: appending a token to a String re-copies the whole answer per token,
+    // which is the O(n²) this protocol change removes.
+    private val text = StringBuilder()
+    private val reasoning = StringBuilder()
+
     /** Clear the per-token state at the start of a new generation. */
     fun reset() {
         current = Telemetry()
+        text.setLength(0)
+        reasoning.setLength(0)
     }
 
     /** Returns true if [line] updated the token telemetry (UI should refresh). */
@@ -154,8 +168,14 @@ class TelemetryParser {
             current.cacheHitPct = o.optDouble("cache_hit_pct", -1.0)
             current.majflt = o.optDouble("majflt", 0.0)
             current.cpuMs = o.optDouble("cpu_ms", 0.0)
-            current.reasoning = o.optString("reasoning")
-            current.text = o.optString("text")
+            if (o.optInt("reset") == 1) {
+                reasoning.setLength(0)
+                text.setLength(0)
+            }
+            reasoning.append(o.optString("delta_reasoning"))
+            text.append(o.optString("delta_text"))
+            current.reasoning = reasoning.toString()
+            current.text = text.toString()
         }.isSuccess
     }
 }


### PR DESCRIPTION
Closes #119.

## What

`BMOE_PROGRESS` carried `"text"`/`"reasoning"` — the **cumulative** answer — on every token: O(n²) bytes written, JSON-escaped and app-parsed per generation. The line now carries `delta_reasoning`/`delta_text` (the tail since the previous line); the reader appends.

The one thing an append-only protocol cannot express is `common_chat_parse`'s retroactive reclassification (a closing think tag turns reported answer text into reasoning). That case falls back to a full snapshot with `"reset":1`, and the reader replaces.

## Both sides of the contract, one PR

- CLI: the single shared format string changed (one-shot `--progress` and `--session` stay byte-identical); per-generation `ProgressDelta` state, fresh per request.
- App: `TelemetryParser` accumulates in `StringBuilder`s (appending to a `String` re-copied the whole answer per token) and resets them with the generation. UI sees the same full strings as before.
- Docs: `docs/telemetry.md` field list, `docs/session.md` reference.

`BMOE_DONE` still carries the full final text/reasoning, so end-of-run consumers (including the committed `grade.py`, which reads archived transcripts of the old shape and is untouched) are unaffected going forward via the summary line.

## What it does not do

The engine still re-parses the accumulated string per token (`common_chat_parse` cannot resume) — this PR removes the pipe/escape/app-parse cost only, which is exactly the region `loop_overhead_ms` (v0.17.0) measures. Throttling the parse itself is a separate question.

## Verification

Byte-identity gates pass (7/7) — the protocol is presentation-only. In-app validation on device (reasoning model, reset path included) is part of the #120 session before the next release.
