### PR TITLE
chore: clang-format the 0.18.0 sources

### DIFF
--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -189,7 +189,7 @@ struct RunInfo {
     int io_threads = 0;
     bool o_direct = false;
     bool overlap = false;
-    bool io_two_wave = false;           // two-wave batch publish (#118): first projection published early
+    bool io_two_wave = false; // two-wave batch publish (#118): first projection published early
     int prefetch_layers = 0;
     bool predict_prefetch = false;      // stale-gate predictive prefetch (see MoeStreamConfig)
     bool predict_log = false;           // the accuracy probe: costs a barrier and two GEMVs per layer

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -925,7 +925,8 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
             }
         };
         if (!two_wave) {
-            for (int p = 0; p < MoeRecipe::max_exps; ++p) emit_proj(p);
+            for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                emit_proj(p);
         } else {
             // Wave one: the first projection's jobs, published before anything else is committed.
             emit_proj(p0);

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -181,7 +181,7 @@ private:
     bool active_ = false;
     bool load_all_ = false;
     bool overlap_ = false;
-    bool two_wave_ = false; // publish the first projection's jobs before committing the rest (#118)
+    bool two_wave_ = false;      // publish the first projection's jobs before committing the rest (#118)
     bool prefetch_sync_ = false; // test only: drain prefetch reads synchronously (serial mode)
     int n_layer_ = 0;
     int n_expert_ = 0;
@@ -304,7 +304,7 @@ private:
     // expert tensor* -> (il<<8)|p. Sorted by pointer and static after init, and probed by every
     // compute thread for every routed expert — a flat binary search beats hashing the pointer.
     std::vector<std::pair<const void *, uint32_t>> texp_;
-    std::vector<int> staged_;                         // per-load sorted unique expert scratch
+    std::vector<int> staged_; // per-load sorted unique expert scratch
     bool hook_registered_ = false;
 };
 

--- a/core/src/moe/gguf_offsets.h
+++ b/core/src/moe/gguf_offsets.h
@@ -42,9 +42,9 @@ GgufModelInfo read_gguf_model_info(const char * path);
 // Both of the above from ONE parse. gguf_init_from_file walks the whole KV section even with
 // no_alloc, so a caller that needs offsets and model info should not pay that walk twice.
 struct GgufMeta {
-    GgufOffsets   offsets;
+    GgufOffsets offsets;
     GgufModelInfo info;
-    bool          ok = false; // both parses' ok, from the single underlying open
+    bool ok = false; // both parses' ok, from the single underlying open
 };
 GgufMeta read_gguf_meta(const char * path);
 


### PR DESCRIPTION
The 0.18.0 PRs (#126, #128) landed with clang-format violations in four files, so the format gate has been failing every push since. Formatted with clang-format 18 (the CI version); whitespace and comment reflow only.