### PR TITLE
feat(engine): self-speculative decoding — the model's own MTP head, or n-gram lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ Android CLI: `pwsh scripts/build-android.ps1` (needs the NDK), then build the AP
 - **Group commits.** One commit = one coherent change. Never a commit for a trivial
   tweak on its own — fold small fixes, doc touches and follow-ups into the change they
   belong to. If several small things accumulate, batch them into one commit.
+- **Delete the branch when its PR closes** — merged or rejected, local and remote
+  (`git branch -d`, `git push origin --delete`). A branch list should only show work in
+  flight. Nothing is lost on a rejected PR: GitHub keeps its commits reachable from the
+  closed PR itself.
 - **Language:** all code, comments, docs, and commit messages in English.
 - **Style:** `.clang-format` (LLVM base, 4-space, 120 col). CI checks with
   **clang-format 18**; match that version locally (`pip install clang-format==18.*`) or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,32 @@ Semantic Versioning.
   block — which Qwen3.6's ordinary quantisations do, verified from their headers, so no `-MTP-`
   conversion is required — and greedy decoding; both are rejected at load with a message rather than
   silently ignored. See `docs/mtp.md`.
+- **`--mtp-p-min F` — stop drafting when the head is unsure.** The draft loop already knows the
+  head's confidence in each token it proposes; this makes it stop below a floor instead of always
+  filling the width. On a streamed device a draft not made is a pass through the MTP block — with
+  its own MoE FFN — that never happens, *and* one fewer independently routed position in the verify
+  batch. Default `0` (never stop), which is what the host numbers were measured at.
+
+### Changed
+- **The MTP draft context's graph width drops from 256 to 32.** Compute buffers are reserved for the
+  widest ubatch and the dominant term scales with `ubatch × vocabulary`; on device that reservation
+  measured **493 MiB** for a context that evaluates one token per draft step and is handed at most
+  `1 + draft_max` positions by the catch-up. On this engine memory is the expert cache's, and the
+  device A/B showed exactly what it cost: major faults per token rose from ~69 without speculation
+  to 633 at draft 3 as the kernel swapped and dropped file pages to find the room.
+
+### Fixed
+- **The cost of speculation is now measured rather than inferred.** Drafting happens between decodes,
+  so it never entered `wall_ms` and `tok/s` never included it — a speculated run could report a rate
+  the user was not experiencing. New `mtp_draft_ms` per-token column, `mtp_draft_s/tok` in the CSV
+  trailer, `mtp_draft_s_tok` and `loop_overhead_s_tok` in `BMOE_DONE`, and a second `mtp:` summary
+  line giving the effective rate next to the reported one. The Android app now reads the `mtp_*`
+  keys it was already being sent and shows acceptance, tokens per pass and the real rate — before,
+  the UI could not tell whether speculation had run at all.
+- The first device A/B is recorded in `docs/mtp.md`: on the test phone MTP **loses** at every draft
+  width (5.59 at draft 2 and 4.38 at draft 3 against 5.82–6.14 baseline) because the shipping
+  configuration is compute-bound — `stall_s/tok` is 0.025–0.027 whether speculation is on or off —
+  while the read set widens 35–54% and CPU per token rises 28–67%. The flag stays off.
 
 ## [0.18.1] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,54 @@ Semantic Versioning.
   (compressed sparse attention, the lightning indexer and its dedicated KV cache) is dense-side
   llama.cpp code, invisible to the streaming seam. Requires a llama.cpp with DeepSeek V4 support
   (the pinned submodule has it).
+- **`--ngram` — a second draft source for the same verify loop, drafting from repeated text instead
+  of from a trained head (off by default).** It takes the last few tokens, finds where that exact run
+  occurred before in the prompt or in what has been generated, and proposes whatever followed. No
+  head, no draft context, no decode, no expert read — and it works on any model, including the ones
+  `--mtp` refuses for want of a `nextn` block (verified on Qwen3-30B-A3B). Verification is unchanged,
+  so it is exact in the same sense `--mtp` is and carries the same non-bit-reproducibility caveat;
+  neither belongs in a byte-identity gate.
+  It was built because of what the flash-split counter said about MTP, not on a hunch: at draft 3 on
+  the host, **the head's own routing was 2.9% of the extra bytes a speculated run streams — the other
+  97.1% was the widened verify batch**, which every source pays. So a cheaper draft producer is worth
+  almost nothing, and the one property that could matter is that this source can *decline to draft at
+  zero cost*, which the head cannot: below `--ngram-min-match` it proposes nothing, the batch is never
+  widened, and the step is exactly a plain single-token decode.
+  **Measured, that floor holds per step but not per run, and the feature does not win.** Host,
+  Qwen3.6-35B-A3B-MXFP4 streamed, 256 greedy tokens, back-to-back with `off` run twice: on free prose
+  6.51 tok/s against a 5.80/6.59 noise band — inside it, because 92.6% of steps drafted nothing. On a
+  copy-heavy prompt 5.24 against a 5.45/5.65 floor — *below* it, because the 15% of steps that did
+  draft widened the read set to 67.2 MiB/token (48–58 at baseline) and at 44.2% acceptance bought only
+  1.20 tokens per decode. On the same prompt the MTP head accepted 82.4% and gained 15% effective.
+  Acceptance is what pays for the widening, and a trained head has it. Drafting cost measures
+  `0.0000 s/token` in every n-gram cell, exactly as claimed — it was simply never the constraint.
+  A `--ngram-min-match` sweep settles it rather than leaving it open: raising the gate 3 → 5 → 8 lifts
+  acceptance 44% → 75% while coverage collapses 15% → 3.4%, and narrowing to `--draft 1` reaches
+  82.6% acceptance — the head's own figure on this prompt. Every cell climbs toward baseline **from
+  below** and none crosses it; the best configuration found (`--draft 1 --ngram-min-match 5`, 5.56)
+  lands on the floor. A drafting step is net-negative or neutral here, so tightening the knob only
+  shrinks the exposure and its limit is the flag being off. Even at 82.6% a drafted step bought 1.08
+  tokens per decode: a match rare enough to trust carries one or two tokens of evidence, while the
+  batch it widens pays every position's independent routing.
+  The device A/B agrees and adds one cost the host could not show. Test phone, same model streamed on
+  the shipping recipe, cells thermally gated (a 120 s settle, then a battery-temperature gate, so all
+  six start between 35.3 and 36.4 °C): prose 4.90 inside a 4.59–5.17 band, copy-heavy **3.14 against
+  4.43** — a 29% loss, worse than MTP's 18%. The counter that explains it is new: **major faults per
+  token go 126 → 1427** for a source that allocates no draft context at all. Those are the rollback
+  snapshots. `n_rs_seq = draft_max` is asked for by *any* speculation, since rejecting a draft means
+  rewinding the KV, and on a hybrid attention/SSM model that snapshot is a real allocation scaling
+  with the context — so the n-gram source escapes MTP's draft context but not the loop's own memory,
+  and on device that memory is the expert cache's. The prose cell, with a 16-token prompt, barely
+  notices; the copy cell, with 224 tokens to snapshot, storms. The same run also re-measured MTP with
+  the thermal confound removed — 3.64 effective against 4.43, so the earlier device verdict was not an
+  artefact of benching without a cooldown gate — and reproduced the flash split at **3.7%** head
+  against 96.3% widened verify batch, matching the host's 2.9–3.0%.
+  Kept and shipped off: it is the only speculation available on a headless model, the per-step floor
+  is a real property, and `--ngram-min-match` is an untested lever on precisely the failure above.
+  The matcher (`core/include/bmoe/ngram_draft.h`) is pure policy over token ids with **no llama.cpp
+  at all** — not even `llama.h` — so it sits on the clean side of the seam, adds no `common`
+  dependency, and is unit-tested with no model (`tests/ngram_test.cpp`: tie-breaks, clipping,
+  self-match exclusion, gate boundary). See `docs/ngram.md`.
 - **`--mtp` — decode through the model's own MTP head, verifying a whole group per pass (off by
   default).** Qwen3.5/3.6 ship a trained multi-token-prediction block inside the gguf. With the flag
   on, that head drafts `--mtp-draft` continuation tokens and the target verifies all of them in one
@@ -68,6 +116,23 @@ Semantic Versioning.
   batch. Default `0` (never stop), which is what the host numbers were measured at.
 
 ### Changed
+- **The speculation config generalised to a draft *source*, and the flags with it.** `MtpConfig`
+  became `SpecConfig` with `DraftSource { none, mtp, ngram }`, and `--mtp-draft N` became `--draft N`
+  because the width belongs to the verify batch, not to whoever filled it; `--mtp` and `--ngram`
+  select the source and are rejected together rather than silently resolved by flag order. In the
+  session the gate split in two — `spec_on` (wide batch, acceptance, rollback: both sources) versus
+  `mtp_on` (draft context, `common/speculative.h`, the catch-up: the head only) — which is what lets
+  the n-gram source reuse the whole verify half while allocating nothing. CSV preamble: `mtp=0|1
+  mtp_draft_max=` became `spec=off|mtp|ngram spec_draft_max=` plus `ngram_min_match=`. The per-token
+  and trailer counters keep their `mtp_*` names on purpose: they always described the loop rather than
+  a source, `spec_*` already means the temporal prefetch in that trailer, and renaming would break
+  every CSV already holding a measurement. The Android setting became a three-way "Guess ahead"
+  picker, migrating the old boolean preference.
+- **A speculative step that drafts nothing now takes the plain decode path.** It used to build the
+  wide batch anyway — one token, all-logits, a logits row index of 0 — which was harmless but meant
+  the abstain case was not free. It now falls through to `llama_batch_get_one` with row `-1`, byte
+  for byte the unspeculated path. Required for `--ngram`, whose whole economics rest on it, and it
+  also tightens `--mtp-p-min`'s zero-draft steps for free.
 - **The MTP draft context's graph width drops from 256 to 32.** Compute buffers are reserved for the
   widest ubatch and the dominant term scales with `ubatch × vocabulary`; on device that reservation
   measured **493 MiB** for a context that evaluates one token per draft step and is handed at most
@@ -89,7 +154,14 @@ Semantic Versioning.
   see neither apart, since its framing brackets the target decode while the head only ever runs in
   the draft context. A third `mtp:` summary line now splits the run's streamed MiB between the two.
   They are attacked in opposite ways (a narrower draft shrinks the first, only better agreement
-  shrinks the second), so a single total was not actionable.
+  shrinks the second), so a single total was not actionable. This is the counter that produced the
+  2.9%/97.1% split `--ngram` was designed against, and it is why that design targets the abstain case
+  rather than the drafting cost.
+- **Coverage is now reported, so a speculative result can be read.** New `drafted_steps` in the CSV
+  trailer and in `BMOE_DONE`, and an `ngram:` summary line giving it as a percentage of the verify
+  decodes. The head drafts on every step, so for `--mtp` this is a constant; for `--ngram` it is the
+  shape of the whole result, since the steps that abstained ran at exactly the unspeculated cost and
+  the same delta means something quite different at 7% coverage than at 100%.
 - The first device A/B is recorded in `docs/mtp.md`: on the test phone MTP **loses** at every draft
   width (5.59 at draft 2 and 4.38 at draft 3 against 5.82–6.14 baseline) because the shipping
   configuration is compute-bound — `stall_s/tok` is 0.025–0.027 whether speculation is on or off —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ Semantic Versioning.
   line giving the effective rate next to the reported one. The Android app now reads the `mtp_*`
   keys it was already being sent and shows acceptance, tokens per pass and the real rate — before,
   the UI could not tell whether speculation had run at all.
+- **The flash cost of drafting is now attributable.** A speculated run reads more bytes per token
+  for two unrelated reasons — the head's own MoE FFN routes on every draft pass, and the verify
+  batch widens the trunk's read set wherever adjacent positions disagree — and the route trace can
+  see neither apart, since its framing brackets the target decode while the head only ever runs in
+  the draft context. A third `mtp:` summary line now splits the run's streamed MiB between the two.
+  They are attacked in opposite ways (a narrower draft shrinks the first, only better agreement
+  shrinks the second), so a single total was not actionable.
 - The first device A/B is recorded in `docs/mtp.md`: on the test phone MTP **loses** at every draft
   width (5.59 at draft 2 and 4.38 at draft 3 against 5.82–6.14 baseline) because the shipping
   configuration is compute-bound — `stall_s/tok` is 0.025–0.027 whether speculation is on or off —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,40 @@ Semantic Versioning.
   (compressed sparse attention, the lightning indexer and its dedicated KV cache) is dense-side
   llama.cpp code, invisible to the streaming seam. Requires a llama.cpp with DeepSeek V4 support
   (the pinned submodule has it).
+- **`--mtp` — decode through the model's own MTP head, verifying a whole group per pass (off by
+  default).** Qwen3.5/3.6 ship a trained multi-token-prediction block inside the gguf. With the flag
+  on, that head drafts `--mtp-draft` continuation tokens and the target verifies all of them in one
+  wider decode, confirming the longest prefix whose argmax equals what the target itself would have
+  produced. Nothing is approximated and no weight is skipped, so the quality is the full model's —
+  but it is **not** byte-identical the way `--overlap` and `--prefetch` are, and it must not be used
+  in a byte-identity gate: the verify pass evaluates `1 + N` positions in one batch, and a batched
+  matmul is not bit-identical to N single-token ones, so a near-tie can flip. Measured on
+  Qwen3.6-35B-A3B-MXFP4 over 128 greedy tokens: exactly one token differs from an unspeculated run,
+  draft widths 1 and 3 agree with each other exactly, and a plain-vs-plain control is exact.
+  The prize is that a decode's dominant cost, moving the dense weights and the routed expert slices,
+  is paid once per group instead of once per token; the counterweight is that the verify positions
+  route independently, so a layer's read set widens toward `N × k` wherever adjacent tokens disagree,
+  and the draft pass routes through the MTP block's own expert layer on top. Measured on the desktop
+  host (DRAM-bandwidth-bound, model streamed at ~1.4× RAM): **+15.1%** at draft 3 with the host's
+  best recipe (7.12 → 8.19 tok/s) and **+29%** without the lossy drop knob, with acceptance falling
+  from 71% at draft 2 to 52% at draft 4 and flash bytes per token rising 19.7 → 33.7 MiB as the
+  widening predicts. Draft 3 is the optimum here; 4 is worse than 2. On a flash-I/O-bound phone that
+  balance can invert, so the flag ships off pending the device A/B. The orchestration is llama.cpp's own
+  (`common/speculative.h`, public headers only): no fork, no patch, no submodule bump. The MTP block
+  is streamed like any other layer — the hook and the expert source are sized `n_layer +
+  n_layer_nextn`, the capture warm-up runs on the draft context too (the MTP graph exists nowhere
+  else), and prefill is fed through the driver so the draft context's KV reaches the last prompt
+  position. The loop also accepts **before** catching the draft context up, so the catch-up runs on
+  the accepted prefix instead of the whole verify batch: acceptance depends only on the target's
+  logits, which are already in hand, and the rejected tail was being computed only to be deleted a
+  few statements later. Identical state, `n_draft − n_accepted` fewer positions through the MTP
+  block per group — and since that block carries its own MoE FFN, on a streamed device those are
+  expert reads that no longer happen. New telemetry: `mtp:` summary line, `mtp_batch` per-token column (a verify decode's
+  whole cost is charged to its group's first row), `mtp_drafted` / `mtp_accepted` / `mtp_decodes` in
+  the CSV trailer, and `mtp` / `mtp_draft_max` in the preamble. Needs a gguf carrying the `nextn`
+  block — which Qwen3.6's ordinary quantisations do, verified from their headers, so no `-MTP-`
+  conversion is required — and greedy decoding; both are rejected at load with a message rather than
+  silently ignored. See `docs/mtp.md`.
 
 ## [0.18.1] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ is flash-bound) may not win; and unlike `--overlap` it is not *byte*-identical, 
 single-token matmuls differ in the last bits and a near-tie can flip one token.
 [docs/mtp.md](docs/mtp.md).
 
+`--ngram` drafts for the same verify loop without the head: it looks the last few tokens up in the
+prompt and in what has been generated, and proposes whatever followed last time. That costs no
+compute, no memory and no expert read, and it works on any model — including the ones `--mtp`
+refuses. It exists because of what the counters said about MTP: the head's own routing was only
+**3%** of the bytes speculation adds, so making the draft cheaper is not where the prize is. What is
+left is that this source can decline to draft at zero cost. Measured, that floor holds per *step*
+but not per *run*: the steps it does draft widen the expert read set at a lower acceptance than a
+trained head, and on the host that put it slightly **below** baseline while `--mtp` gained 15%.
+Off by default, and honest about it — [docs/ngram.md](docs/ngram.md).
+
 ### Sessions and telemetry
 
 The model stays loaded across chat turns, and every run can account for its own time: `--progress`

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ layer's experts before the layer runs. Prediction accuracy is proven; reading ah
 on-device A/B and ships off. [docs/expert-prediction.md](docs/expert-prediction.md) explains why a
 better guess still costs more than it saves.
 
+`--mtp` buys speed without trading quality: on a gguf carrying a trained multi-token-prediction
+head (Qwen3.5/3.6), the model drafts its own next few tokens and the engine verifies them in one
+wider decode, keeping only the prefix the model itself would have produced. Nothing is approximated
+and no weight is skipped, so the weights move once per group instead of once per token — measured
+**+15%** on desktop, where decode is DRAM-bound. Two caveats keep it off by default: the verify
+positions route independently, which widens each layer's expert read set, so a phone (where decode
+is flash-bound) may not win; and unlike `--overlap` it is not *byte*-identical, because batched and
+single-token matmuls differ in the last bits and a near-tie can flip one token.
+[docs/mtp.md](docs/mtp.md).
+
 ### Sessions and telemetry
 
 The model stays loaded across chat turns, and every run can account for its own time: `--progress`

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -773,6 +773,15 @@ int main(int argc, char ** argv) {
         std::printf("mtp: drafting costs %.4f s/token on top of decode → %.2f tok/s effective "
                     "(vs %.2f reported)\n",
                     s.mtp_draft_s_per_token, eff, s.tokens_per_second);
+        // Splits the run's flash bytes into the head's own routing and everything else, which is
+        // the widened verify union. The two are attacked in completely different ways, and the
+        // route trace cannot tell them apart — it brackets the target decode only.
+        if (s.moe_read_mib > 0) {
+            std::printf("mtp: of %.1f MiB streamed, %.1f MiB (%.1f%%) was the head's own routing, "
+                        "%.1f MiB the widened verify batch\n",
+                        s.moe_read_mib, s.mtp_draft_read_mib, 100.0 * s.mtp_draft_read_mib / s.moe_read_mib,
+                        s.moe_read_mib - s.mtp_draft_read_mib);
+        }
     }
     if (s.n_prompt > 0) {
         double prefill_tps = s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -331,13 +331,15 @@ static int run_session_loop(const RunConfig & cfg,
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
                     "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"majflt_tok\":%.2f,\"cpu_s_tok\":%.4f,"
                     "\"token_demand_mib\":%.1f,\"mtp_drafted\":%lld,\"mtp_accepted\":%lld,\"mtp_decodes\":%lld,"
+                    "\"mtp_draft_s_tok\":%.4f,\"loop_overhead_s_tok\":%.4f,"
                     "\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
                     s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, s.mtp_drafted, s.mtp_accepted,
-                    s.mtp_decodes, json_escape(r.reasoning_text).c_str(), json_escape(r.generated_text).c_str());
+                    s.mtp_decodes, s.mtp_draft_s_per_token, s.loop_overhead_s_per_token,
+                    json_escape(r.reasoning_text).c_str(), json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
 
@@ -394,6 +396,11 @@ static void print_usage(const char * argv0) {
         "                          the risk is that N positions route independently and widen\n"
         "                          the per-layer expert read set. Off by default\n"
         "      --mtp-draft N      tokens drafted per verify batch (default 3, max %d)\n"
+        "      --mtp-p-min F       stop drafting when the head's best candidate falls below this\n"
+        "                          probability (0..1, default 0 = draft the full width however\n"
+        "                          unsure it is). Makes the draft width adaptive per step: a draft\n"
+        "                          not made is one fewer MTP-block pass AND one fewer independently\n"
+        "                          routed position in the verify batch\n"
         "\n"
         "  MoE expert streaming:\n"
         "      --moe-stream        stream only the routed experts per token (MoE models)\n"
@@ -547,6 +554,8 @@ int main(int argc, char ** argv) {
             cfg.mtp.enabled = true;
         else if (a == "--mtp-draft")
             cfg.mtp.draft_max = std::atoi(next("--mtp-draft"));
+        else if (a == "--mtp-p-min")
+            cfg.mtp.draft_p_min = (float) std::atof(next("--mtp-p-min"));
         else if (a == "--chatml")
             cfg.chatml = true;
         else if (a == "--no-think")
@@ -757,6 +766,13 @@ int main(int argc, char ** argv) {
                     "(%lld decodes for %d tokens)\n",
                     s.mtp_accepted, s.mtp_drafted, s.mtp_drafted > 0 ? 100.0 * s.mtp_accepted / s.mtp_drafted : 0.0,
                     (double) s.n_generated / (double) s.mtp_decodes, s.mtp_decodes, s.n_generated);
+        // tok/s above counts decode time only, so drafting is time the caller waits that the
+        // headline rate does not show. Print what it actually costs, and the rate that includes it.
+        const double eff =
+            s.s_per_token + s.mtp_draft_s_per_token > 0 ? 1.0 / (s.s_per_token + s.mtp_draft_s_per_token) : 0.0;
+        std::printf("mtp: drafting costs %.4f s/token on top of decode → %.2f tok/s effective "
+                    "(vs %.2f reported)\n",
+                    s.mtp_draft_s_per_token, eff, s.tokens_per_second);
     }
     if (s.n_prompt > 0) {
         double prefill_tps = s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -330,13 +330,14 @@ static int run_session_loop(const RunConfig & cfg,
                     "\"prefill_tps\":%.2f,\"load_s\":%.3f,\"cache_hit_pct\":%.1f,\"n_prompt\":%d,\"n_past\":%d,"
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
                     "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"majflt_tok\":%.2f,\"cpu_s_tok\":%.4f,"
-                    "\"token_demand_mib\":%.1f,\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
+                    "\"token_demand_mib\":%.1f,\"mtp_drafted\":%lld,\"mtp_accepted\":%lld,\"mtp_decodes\":%lld,"
+                    "\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
-                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, json_escape(r.reasoning_text).c_str(),
-                    json_escape(r.generated_text).c_str());
+                    s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, s.mtp_drafted, s.mtp_accepted,
+                    s.mtp_decodes, json_escape(r.reasoning_text).c_str(), json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
 
@@ -385,6 +386,15 @@ static void print_usage(const char * argv0) {
         "      --top-p F           nucleus cutoff in (0,1] when sampling (default 0.95)\n"
         "      --seed N            RNG seed for sampling (default: random per run)\n"
         "\n"
+        "  Self-speculative decoding (lossless; needs a gguf with the MTP/nextn block):\n"
+        "      --mtp          draft with the model's own multi-token-prediction head and\n"
+        "                          verify every draft in one wider decode. Greedy verification\n"
+        "                          makes the output token-identical to plain decode; the win is\n"
+        "                          reading the weights once per N tokens instead of N times,\n"
+        "                          the risk is that N positions route independently and widen\n"
+        "                          the per-layer expert read set. Off by default\n"
+        "      --mtp-draft N      tokens drafted per verify batch (default 3, max %d)\n"
+        "\n"
         "  MoE expert streaming:\n"
         "      --moe-stream        stream only the routed experts per token (MoE models)\n"
         "      --cache-mb N|auto   LRU expert cache budget in MiB (0=off, or >=%d); auto=size to device\n"
@@ -427,7 +437,7 @@ static void print_usage(const char * argv0) {
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
         "BMOE_N_EXPERT_USED, BMOE_PREDICT_LOG, BMOE_PREDICT_PREFETCH\n",
-        argv0, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
+        argv0, MtpConfig::draft_max_limit, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
 }
 
 // The prediction probe's report (see MoeStreamConfig::predict_log).
@@ -533,6 +543,10 @@ int main(int argc, char ** argv) {
             cfg.sampling.top_p = (float) std::atof(next("--top-p"));
         else if (a == "--seed")
             cfg.sampling.seed = (uint32_t) std::strtoul(next("--seed"), nullptr, 10);
+        else if (a == "--mtp")
+            cfg.mtp.enabled = true;
+        else if (a == "--mtp-draft")
+            cfg.mtp.draft_max = std::atoi(next("--mtp-draft"));
         else if (a == "--chatml")
             cfg.chatml = true;
         else if (a == "--no-think")
@@ -735,6 +749,14 @@ int main(int argc, char ** argv) {
             s.s_per_token > 0 && cfg.n_threads > 0 ? s.cpu_s_per_token / (s.s_per_token * cfg.n_threads) : 0.0;
         std::printf("compute: %.1f%% CPU occupancy (%.4f cpu-s/token over %d threads), %.2f major faults/token\n",
                     occ * 100.0, s.cpu_s_per_token, cfg.n_threads, s.majflt_per_token);
+    }
+    // Acceptance is the number that decides whether speculation can pay at all; tokens-per-decode is
+    // what it actually bought, and it is what tok/s above is a function of.
+    if (s.mtp_decodes > 0 && cfg.mtp.enabled) {
+        std::printf("mtp: %lld/%lld drafts accepted (%.1f%%), %.2f tokens per verify decode "
+                    "(%lld decodes for %d tokens)\n",
+                    s.mtp_accepted, s.mtp_drafted, s.mtp_drafted > 0 ? 100.0 * s.mtp_accepted / s.mtp_drafted : 0.0,
+                    (double) s.n_generated / (double) s.mtp_decodes, s.mtp_decodes, s.n_generated);
     }
     if (s.n_prompt > 0) {
         double prefill_tps = s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -331,14 +331,14 @@ static int run_session_loop(const RunConfig & cfg,
                     "\"compute_s_tok\":%.4f,\"io_s_tok\":%.4f,\"cache_resident_mib\":%.0f,\"cache_budget_mib\":%.0f,"
                     "\"read_mib\":%.1f,\"stall_s_tok\":%.4f,\"mgmt_s_tok\":%.4f,\"majflt_tok\":%.2f,\"cpu_s_tok\":%.4f,"
                     "\"token_demand_mib\":%.1f,\"mtp_drafted\":%lld,\"mtp_accepted\":%lld,\"mtp_decodes\":%lld,"
-                    "\"mtp_draft_s_tok\":%.4f,\"loop_overhead_s_tok\":%.4f,"
+                    "\"mtp_draft_s_tok\":%.4f,\"drafted_steps\":%lld,\"loop_overhead_s_tok\":%.4f,"
                     "\"reasoning\":\"%s\",\"text\":\"%s\"}\n",
                     cmd.id, r.cancelled ? "true" : "false", s.n_generated, s.tokens_per_second, s.prefill_seconds,
                     (s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0), s.load_seconds, s.cache_hit_pct,
                     s.n_prompt, s.n_past, s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_resident_mib,
                     s.cache_budget_mib, s.moe_read_mib, s.moe_stall_s_per_token, s.moe_mgmt_s_per_token,
                     s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib, s.mtp_drafted, s.mtp_accepted,
-                    s.mtp_decodes, s.mtp_draft_s_per_token, s.loop_overhead_s_per_token,
+                    s.mtp_decodes, s.mtp_draft_s_per_token, s.drafted_steps, s.loop_overhead_s_per_token,
                     json_escape(r.reasoning_text).c_str(), json_escape(r.generated_text).c_str());
         std::fflush(stdout);
     }
@@ -388,19 +388,26 @@ static void print_usage(const char * argv0) {
         "      --top-p F           nucleus cutoff in (0,1] when sampling (default 0.95)\n"
         "      --seed N            RNG seed for sampling (default: random per run)\n"
         "\n"
-        "  Self-speculative decoding (lossless; needs a gguf with the MTP/nextn block):\n"
-        "      --mtp          draft with the model's own multi-token-prediction head and\n"
-        "                          verify every draft in one wider decode. Greedy verification\n"
-        "                          makes the output token-identical to plain decode; the win is\n"
-        "                          reading the weights once per N tokens instead of N times,\n"
-        "                          the risk is that N positions route independently and widen\n"
-        "                          the per-layer expert read set. Off by default\n"
-        "      --mtp-draft N      tokens drafted per verify batch (default 3, max %d)\n"
-        "      --mtp-p-min F       stop drafting when the head's best candidate falls below this\n"
-        "                          probability (0..1, default 0 = draft the full width however\n"
-        "                          unsure it is). Makes the draft width adaptive per step: a draft\n"
-        "                          not made is one fewer MTP-block pass AND one fewer independently\n"
-        "                          routed position in the verify batch\n"
+        "  Self-speculative decoding (draft a continuation, verify it in one wider decode).\n"
+        "  Greedy verification makes the output token-identical to plain decode; the win is reading\n"
+        "  the weights once per N tokens instead of N times, the risk is that N positions route\n"
+        "  independently and widen the per-layer expert read set. Pick one source; off by default:\n"
+        "      --mtp               draft with the model's own multi-token-prediction head.\n"
+        "                          Needs a gguf with the nextn block (Qwen3.5/3.6)\n"
+        "      --ngram             draft by looking the recent tokens up in the prompt and in what\n"
+        "                          has been generated, proposing whatever followed last time. Costs\n"
+        "                          no compute, no memory and no expert read, works on any model,\n"
+        "                          and drafts NOTHING when it has no confident match — so a step\n"
+        "                          without one costs exactly a plain decode\n"
+        "      --draft N           tokens drafted per verify batch (default 3, max %d)\n"
+        "      --mtp-p-min F       --mtp only: stop drafting when the head's best candidate falls\n"
+        "                          below this probability (0..1, default 0 = draft the full width\n"
+        "                          however unsure it is). Makes the draft width adaptive per step:\n"
+        "                          a draft not made is one fewer MTP-block pass AND one fewer\n"
+        "                          independently routed position in the verify batch\n"
+        "      --ngram-min-match N --ngram only: shortest run of matching tokens allowed to draft\n"
+        "                          (default 3). The confidence gate: raise it for fewer, better\n"
+        "                          drafts, lower it for coverage\n"
         "\n"
         "  MoE expert streaming:\n"
         "      --moe-stream        stream only the routed experts per token (MoE models)\n"
@@ -444,7 +451,7 @@ static void print_usage(const char * argv0) {
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
         "BMOE_N_EXPERT_USED, BMOE_PREDICT_LOG, BMOE_PREDICT_PREFETCH\n",
-        argv0, MtpConfig::draft_max_limit, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
+        argv0, SpecConfig::draft_max_limit, MoeStreamConfig::cache_min_mb, MoeStreamConfig::io_threads_max);
 }
 
 // The prediction probe's report (see MoeStreamConfig::predict_log).
@@ -550,12 +557,22 @@ int main(int argc, char ** argv) {
             cfg.sampling.top_p = (float) std::atof(next("--top-p"));
         else if (a == "--seed")
             cfg.sampling.seed = (uint32_t) std::strtoul(next("--seed"), nullptr, 10);
-        else if (a == "--mtp")
-            cfg.mtp.enabled = true;
-        else if (a == "--mtp-draft")
-            cfg.mtp.draft_max = std::atoi(next("--mtp-draft"));
+        else if (a == "--mtp" || a == "--ngram") {
+            // Two sources for one loop, so asking for both is a contradiction rather than a
+            // precedence question — say so instead of silently honouring the last flag.
+            const DraftSource want = a == "--mtp" ? DraftSource::mtp : DraftSource::ngram;
+            if (cfg.spec.enabled() && cfg.spec.source != want) {
+                std::fprintf(stderr, "bmoe: --mtp and --ngram are two draft sources for the same verify loop; "
+                                     "choose one.\n");
+                return 2;
+            }
+            cfg.spec.source = want;
+        } else if (a == "--draft")
+            cfg.spec.draft_max = std::atoi(next("--draft"));
         else if (a == "--mtp-p-min")
-            cfg.mtp.draft_p_min = (float) std::atof(next("--mtp-p-min"));
+            cfg.spec.draft_p_min = (float) std::atof(next("--mtp-p-min"));
+        else if (a == "--ngram-min-match")
+            cfg.spec.ngram_min_match = std::atoi(next("--ngram-min-match"));
         else if (a == "--chatml")
             cfg.chatml = true;
         else if (a == "--no-think")
@@ -761,22 +778,32 @@ int main(int argc, char ** argv) {
     }
     // Acceptance is the number that decides whether speculation can pay at all; tokens-per-decode is
     // what it actually bought, and it is what tok/s above is a function of.
-    if (s.mtp_decodes > 0 && cfg.mtp.enabled) {
-        std::printf("mtp: %lld/%lld drafts accepted (%.1f%%), %.2f tokens per verify decode "
+    if (s.mtp_decodes > 0 && cfg.spec.enabled()) {
+        const char * src = cfg.spec.is_mtp() ? "mtp" : "ngram";
+        std::printf("%s: %lld/%lld drafts accepted (%.1f%%), %.2f tokens per verify decode "
                     "(%lld decodes for %d tokens)\n",
-                    s.mtp_accepted, s.mtp_drafted, s.mtp_drafted > 0 ? 100.0 * s.mtp_accepted / s.mtp_drafted : 0.0,
+                    src, s.mtp_accepted, s.mtp_drafted,
+                    s.mtp_drafted > 0 ? 100.0 * s.mtp_accepted / s.mtp_drafted : 0.0,
                     (double) s.n_generated / (double) s.mtp_decodes, s.mtp_decodes, s.n_generated);
         // tok/s above counts decode time only, so drafting is time the caller waits that the
         // headline rate does not show. Print what it actually costs, and the rate that includes it.
         const double eff =
             s.s_per_token + s.mtp_draft_s_per_token > 0 ? 1.0 / (s.s_per_token + s.mtp_draft_s_per_token) : 0.0;
-        std::printf("mtp: drafting costs %.4f s/token on top of decode → %.2f tok/s effective "
+        std::printf("%s: drafting costs %.4f s/token on top of decode → %.2f tok/s effective "
                     "(vs %.2f reported)\n",
-                    s.mtp_draft_s_per_token, eff, s.tokens_per_second);
+                    src, s.mtp_draft_s_per_token, eff, s.tokens_per_second);
+        // How often the source had anything to say. For the n-gram lookup this is the whole shape of
+        // the result: the steps that did not draft ran at exactly the unspeculated cost, so a small
+        // delta over baseline means something quite different at 10% coverage than at 90%.
+        if (cfg.spec.is_ngram()) {
+            std::printf("ngram: drafted on %lld of %lld steps (%.1f%%); the rest decoded plainly\n", s.drafted_steps,
+                        s.mtp_decodes, s.mtp_decodes > 0 ? 100.0 * (double) s.drafted_steps / s.mtp_decodes : 0.0);
+        }
         // Splits the run's flash bytes into the head's own routing and everything else, which is
         // the widened verify union. The two are attacked in completely different ways, and the
-        // route trace cannot tell them apart — it brackets the target decode only.
-        if (s.moe_read_mib > 0) {
+        // route trace cannot tell them apart — it brackets the target decode only. Only the head has
+        // a share: the n-gram source reads no weights at all, so its split is 0 by construction.
+        if (cfg.spec.is_mtp() && s.moe_read_mib > 0) {
             std::printf("mtp: of %.1f MiB streamed, %.1f MiB (%.1f%%) was the head's own routing, "
                         "%.1f MiB the widened verify batch\n",
                         s.moe_read_mib, s.mtp_draft_read_mib, 100.0 * s.mtp_draft_read_mib / s.moe_read_mib,

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,12 +1,13 @@
 # bmoe_core — the streaming engine.
 #
-# Pure-policy sources (config validation, the architecture registry) build with no
-# native dependency. The streaming adapters compile only when llama.cpp is present,
-# because they include its public headers (llama.h, ggml.h, gguf.h).
+# Pure-policy sources (config validation, the architecture registry, the n-gram draft
+# matcher) build with no native dependency. The streaming adapters compile only when
+# llama.cpp is present, because they include its public headers (llama.h, ggml.h, gguf.h).
 
 add_library(bmoe_core STATIC
     src/config.cpp
     src/moe/arch_registry.cpp
+    src/engine/ngram_draft.cpp
 )
 
 target_include_directories(bmoe_core PUBLIC

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -191,42 +191,45 @@ struct MoeStreamConfig {
     static constexpr int prefetch_layers_max = 8;
 };
 
-// Self-speculative decoding through the model's own trained multi-token-prediction head.
-//
-// The head drafts draft_max continuation tokens, the target then verifies all of them in ONE
-// decode; the longest prefix whose argmax agrees with the draft is accepted. Nothing is approximated
+// Where the draft tokens of a self-speculative step come from. The verify half of the loop is
+// identical for both sources; only the producer differs, and with it what a draft costs.
+enum class DraftSource {
+    none,  // no speculation: one token per decode
+    mtp,   // the model's own trained multi-token-prediction head (needs the nextn block)
+    ngram, // prompt-lookup over prompt + generated tokens (needs nothing from the model)
+};
+
+// Self-speculative decoding: draft draft_max continuation tokens, then verify all of them in ONE
+// decode and accept the longest prefix whose argmax agrees with the draft. Nothing is approximated
 // and no weight is skipped, so this is a latency optimisation, not a quality trade.
 //
 // It is NOT byte-identical the way overlap and prefetch are, and must not be used in a byte-identity
 // gate. Verification evaluates 1 + draft_max positions in one batch, and a batched matmul is not
 // bit-identical to that many single-token ones; on a near-tie the argmax can flip. Measured on
 // Qwen3.6-35B-A3B-MXFP4 over 128 greedy tokens: one token differs from an unspeculated run, and
-// every draft width agrees with every other. See docs/mtp.md.
-//
-// Only applies to models whose gguf carries the nextn block (Qwen3.5/3.6); init fails loudly on a
-// model without one rather than silently decoding one token at a time.
+// every draft width agrees with every other. The caveat is a property of the batched verify, so it
+// applies to every draft source. See docs/mtp.md.
 //
 // Why it can win, and why it can lose. Verifying N positions in one decode reads the dense weights
 // and each routed expert ONCE for N tokens instead of N times, which is the whole prize: on a
 // DRAM-bandwidth-bound host it amortises the measured bottleneck directly, and on a flash-streamed
 // device it amortises latency-to-ready. The counterweight is that the N verify positions route
-// INDEPENDENTLY, so a layer's read set widens toward N*k experts instead of k, and the draft pass
-// itself routes through the MTP block's own expert layer. Where routing across adjacent tokens
-// diverges, the widened read set can cost more than the amortisation saves. Default off until the
-// A/B says otherwise on the target device.
-struct MtpConfig {
-    bool enabled = false; // draft with the model's native MTP head and verify greedily
+// INDEPENDENTLY, so a layer's read set widens toward N*k experts instead of k. Measured at draft 3
+// on the host, that widening is 97.1% of the extra bytes a speculated run streams — it is what the
+// choice of source cannot change. Default off until the A/B says otherwise on the target device.
+struct SpecConfig {
+    DraftSource source = DraftSource::none;
 
     // Tokens drafted per verify batch. The verify decode is 1 + draft_max positions wide, so this
     // sets both the ceiling on tokens-per-decode and the width of the read-set widening above.
-    // Past the head's acceptance horizon the extra drafts are rejected and paid for anyway, which
+    // Past the source's acceptance horizon the extra drafts are rejected and paid for anyway, which
     // is why the useful range is small; 3 is upstream's default for a single trained head.
     int draft_max = 3;
 
-    // Confidence floor for continuing to draft, as the head's own probability for the token it is
-    // proposing. At 0 the head is asked for draft_max tokens unconditionally, however unsure it is;
-    // above 0 it stops as soon as its best candidate falls below this, making the draft width
-    // adaptive per step at no cost.
+    // MTP only. Confidence floor for continuing to draft, as the head's own probability for the
+    // token it is proposing. At 0 the head is asked for draft_max tokens unconditionally, however
+    // unsure it is; above 0 it stops as soon as its best candidate falls below this, making the
+    // draft width adaptive per step at no cost.
     //
     // This is the cheap half of expert-cost-aware drafting, and on a streamed device it pays twice:
     // a draft not made is a pass through the MTP block (with its own MoE FFN) that does not happen,
@@ -238,7 +241,24 @@ struct MtpConfig {
     // measure rather than a constant to guess.
     float draft_p_min = 0.0f;
 
+    // N-gram only. Shortest suffix match that is allowed to draft. This is the whole economics of
+    // the n-gram source: below it the step drafts NOTHING and costs exactly a plain decode, so the
+    // floor of the feature is the baseline rather than a loss. Raising it buys precision (fewer,
+    // better drafts) at the cost of coverage. 3 because free prose rarely repeats a trigram, which
+    // is what keeps prose runs on the floor while copy-heavy segments still match.
+    int ngram_min_match = 3;
+
+    // N-gram only. Longest suffix considered when looking for a match. A cap, not a target: it
+    // bounds the per-step scan (O(corpus * ngram_max_match)) and stops a long verbatim quote from
+    // making every step scan its full length for no additional selectivity.
+    int ngram_max_match = 12;
+
     static constexpr int draft_max_limit = 8;
+    static constexpr int ngram_match_limit = 64;
+
+    bool enabled() const { return source != DraftSource::none; }
+    bool is_mtp() const { return source == DraftSource::mtp; }
+    bool is_ngram() const { return source == DraftSource::ngram; }
 };
 
 // A full run: model, prompt, decoding, streaming, telemetry.
@@ -289,7 +309,7 @@ struct RunConfig {
 
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
-    MtpConfig mtp; // self-speculative decoding via the model's MTP head; off by default
+    SpecConfig spec; // self-speculative decoding (MTP head or n-gram lookup); off by default
 };
 
 // Validation result: ok plus a human-readable reason when not.

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -191,6 +191,41 @@ struct MoeStreamConfig {
     static constexpr int prefetch_layers_max = 8;
 };
 
+// Self-speculative decoding through the model's own trained multi-token-prediction head.
+//
+// The head drafts draft_max continuation tokens, the target then verifies all of them in ONE
+// decode; the longest prefix whose argmax agrees with the draft is accepted. Nothing is approximated
+// and no weight is skipped, so this is a latency optimisation, not a quality trade.
+//
+// It is NOT byte-identical the way overlap and prefetch are, and must not be used in a byte-identity
+// gate. Verification evaluates 1 + draft_max positions in one batch, and a batched matmul is not
+// bit-identical to that many single-token ones; on a near-tie the argmax can flip. Measured on
+// Qwen3.6-35B-A3B-MXFP4 over 128 greedy tokens: one token differs from an unspeculated run, and
+// every draft width agrees with every other. See docs/mtp.md.
+//
+// Only applies to models whose gguf carries the nextn block (Qwen3.5/3.6); init fails loudly on a
+// model without one rather than silently decoding one token at a time.
+//
+// Why it can win, and why it can lose. Verifying N positions in one decode reads the dense weights
+// and each routed expert ONCE for N tokens instead of N times, which is the whole prize: on a
+// DRAM-bandwidth-bound host it amortises the measured bottleneck directly, and on a flash-streamed
+// device it amortises latency-to-ready. The counterweight is that the N verify positions route
+// INDEPENDENTLY, so a layer's read set widens toward N*k experts instead of k, and the draft pass
+// itself routes through the MTP block's own expert layer. Where routing across adjacent tokens
+// diverges, the widened read set can cost more than the amortisation saves. Default off until the
+// A/B says otherwise on the target device.
+struct MtpConfig {
+    bool enabled = false; // draft with the model's native MTP head and verify greedily
+
+    // Tokens drafted per verify batch. The verify decode is 1 + draft_max positions wide, so this
+    // sets both the ceiling on tokens-per-decode and the width of the read-set widening above.
+    // Past the head's acceptance horizon the extra drafts are rejected and paid for anyway, which
+    // is why the useful range is small; 3 is upstream's default for a single trained head.
+    int draft_max = 3;
+
+    static constexpr int draft_max_limit = 8;
+};
+
 // A full run: model, prompt, decoding, streaming, telemetry.
 struct RunConfig {
     std::string model_path;
@@ -239,6 +274,7 @@ struct RunConfig {
 
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
+    MtpConfig mtp; // self-speculative decoding via the model's MTP head; off by default
 };
 
 // Validation result: ok plus a human-readable reason when not.

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -223,6 +223,21 @@ struct MtpConfig {
     // is why the useful range is small; 3 is upstream's default for a single trained head.
     int draft_max = 3;
 
+    // Confidence floor for continuing to draft, as the head's own probability for the token it is
+    // proposing. At 0 the head is asked for draft_max tokens unconditionally, however unsure it is;
+    // above 0 it stops as soon as its best candidate falls below this, making the draft width
+    // adaptive per step at no cost.
+    //
+    // This is the cheap half of expert-cost-aware drafting, and on a streamed device it pays twice:
+    // a draft not made is a pass through the MTP block (with its own MoE FFN) that does not happen,
+    // AND one fewer position in the verify batch, so one fewer independent routing widening the
+    // layer's read set. A rejected draft costs both of those and buys nothing.
+    //
+    // 0 by default — it is the width the host measurement was taken at, and the useful value is a
+    // property of the device's balance between drafting cost and acceptance, so it is a knob to
+    // measure rather than a constant to guess.
+    float draft_p_min = 0.0f;
+
     static constexpr int draft_max_limit = 8;
 };
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -73,6 +73,12 @@ struct TokenMetrics {
     // zeros read as free tokens. Divide the first row's wall_ms by mtp_batch for the per-token cost.
     int mtp_batch = 1;
 
+    // Time this group spent drafting and catching the draft context up — everything speculation
+    // adds OUTSIDE the target decode. A SLICE of loop_overhead_ms, not an addition: both measure
+    // the gap between decodes. Charged to the group's first row like every other group cost, and 0
+    // without --mtp. Without it the drafting cost can only be inferred by differencing two runs.
+    double mtp_draft_ms = 0.0;
+
     std::string piece; // text of just this token (delta, for inline streaming)
     std::string text;  // full generated answer so far, reasoning stripped (for UI streaming)
     // The reasoning span so far, when the model is thinking and the chat parser separated it from
@@ -153,6 +159,11 @@ struct RunSummary {
     long long mtp_drafted = 0;
     long long mtp_accepted = 0;
     long long mtp_decodes = 0; // verify decodes issued; equals n_generated when speculation is off
+    // Drafting + catch-up seconds per generated token: the price of speculation, measured rather
+    // than inferred. tok/s is computed from decode time alone, so this is time the caller waits
+    // that the headline rate does not show — compare it against s_per_token before believing a
+    // speculated run is faster.
+    double mtp_draft_s_per_token = 0.0;
 
     // Expert-prediction accuracy (all zero unless MoeStreamConfig::predict_log). `predict_stale` is
     // the next layer's routing ranked a layer early, `predict_prev` the previous token's routing —
@@ -228,6 +239,7 @@ struct RunInfo {
     // TokenMetrics::mtp_batch. Recorded so the two are never averaged together by accident.
     bool mtp = false;
     int mtp_draft_max = 0;
+    float mtp_p_min = 0.0f; // the head's confidence floor for continuing to draft (0 = no floor)
 
     // Diagnostics that perturb what they measure. A traced run is not a benchmark run — recorded so
     // a file cannot be mistaken for one.

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -164,6 +164,13 @@ struct RunSummary {
     // that the headline rate does not show — compare it against s_per_token before believing a
     // speculated run is faster.
     double mtp_draft_s_per_token = 0.0;
+    // Flash MiB the drafting passes streamed, as a subset of moe_read_mib. The MTP block is a MoE
+    // layer of its own, so the head has an I/O cost and not just a compute one. Subtracting this
+    // from the run's total is what splits the growth in bytes/token under speculation into its two
+    // causes — the widened verify union on the trunk, and the head's own routing — which need
+    // completely different fixes. The route trace cannot see it: its framing brackets the target
+    // decode, and the head only ever runs in the draft context.
+    double mtp_draft_read_mib = 0.0;
 
     // Expert-prediction accuracy (all zero unless MoeStreamConfig::predict_log). `predict_stale` is
     // the next layer's routing ranked a layer early, `predict_prev` the previous token's routing —

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -67,6 +67,12 @@ struct TokenMetrics {
     double cache_budget_mib = 0.0;
     int turn = 0; // session turn this token belongs to (0 for a one-shot run)
 
+    // How many tokens the decode that produced this one confirmed (1 without speculation). Under
+    // --mtp a verify decode confirms a whole group, and the group's entire cost — wall, faults,
+    // CPU, flash bytes — is charged to its FIRST row; the rest carry zeros. Without this field those
+    // zeros read as free tokens. Divide the first row's wall_ms by mtp_batch for the per-token cost.
+    int mtp_batch = 1;
+
     std::string piece; // text of just this token (delta, for inline streaming)
     std::string text;  // full generated answer so far, reasoning stripped (for UI streaming)
     // The reasoning span so far, when the model is thinking and the chat parser separated it from
@@ -139,6 +145,15 @@ struct RunSummary {
     long long moe_spec_experts = 0;
     long long moe_spec_useful = 0;
 
+    // MTP self-speculation (zero when MtpConfig::enabled is off). `mtp_drafted` counts tokens the head
+    // proposed, `mtp_accepted` how many the target's argmax confirmed; their ratio is the head's
+    // acceptance on this prompt, the one number that decides whether the feature can pay. Tokens
+    // per verify decode (n_generated / mtp_decodes) is the amortisation actually achieved — it is
+    // what tok/s is bought with, and it is always below 1 + draft_max.
+    long long mtp_drafted = 0;
+    long long mtp_accepted = 0;
+    long long mtp_decodes = 0; // verify decodes issued; equals n_generated when speculation is off
+
     // Expert-prediction accuracy (all zero unless MoeStreamConfig::predict_log). `predict_stale` is
     // the next layer's routing ranked a layer early, `predict_prev` the previous token's routing —
     // the bet --prefetch already makes — and `predict_self` a zero-staleness control that bounds
@@ -207,6 +222,12 @@ struct RunInfo {
     int top_k = 40;
     float top_p = 0.95f;
     uint32_t seed = 0xFFFFFFFFu;
+
+    // Self-speculation. It changes how many tokens a decode confirms, so every per-token row in the
+    // file was produced under a different accounting than an unspeculated run — see
+    // TokenMetrics::mtp_batch. Recorded so the two are never averaged together by accident.
+    bool mtp = false;
+    int mtp_draft_max = 0;
 
     // Diagnostics that perturb what they measure. A traced run is not a benchmark run — recorded so
     // a file cannot be mistaken for one.

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -151,14 +151,22 @@ struct RunSummary {
     long long moe_spec_experts = 0;
     long long moe_spec_useful = 0;
 
-    // MTP self-speculation (zero when MtpConfig::enabled is off). `mtp_drafted` counts tokens the head
-    // proposed, `mtp_accepted` how many the target's argmax confirmed; their ratio is the head's
-    // acceptance on this prompt, the one number that decides whether the feature can pay. Tokens
-    // per verify decode (n_generated / mtp_decodes) is the amortisation actually achieved — it is
-    // what tok/s is bought with, and it is always below 1 + draft_max.
+    // Self-speculation (zero when SpecConfig::source is none). These are the LOOP's counters, not a
+    // source's: whichever drafted, `mtp_drafted` counts tokens proposed and `mtp_accepted` how many
+    // the target's argmax confirmed. Their ratio is the acceptance on this prompt, the one number
+    // that decides whether the feature can pay. Tokens per verify decode (n_generated / mtp_decodes)
+    // is the amortisation actually achieved — it is what tok/s is bought with, and it is always
+    // below 1 + draft_max. The keys keep the mtp_ prefix they were published under; renaming them
+    // would break every CSV and dashboard already holding measurements.
     long long mtp_drafted = 0;
     long long mtp_accepted = 0;
     long long mtp_decodes = 0; // verify decodes issued; equals n_generated when speculation is off
+    // Steps that drafted anything. Against mtp_decodes this is the n-gram source's match rate: the
+    // fraction of the run where it had evidence, widened the verify batch and could win — the rest
+    // ran as plain decodes at exactly the unspeculated cost. It is the number that says whether a
+    // result is about the source's precision or about how rarely it fired. For the head it is every
+    // step, unless draft_p_min stopped it.
+    long long drafted_steps = 0;
     // Drafting + catch-up seconds per generated token: the price of speculation, measured rather
     // than inferred. tok/s is computed from decode time alone, so this is time the caller waits
     // that the headline rate does not show — compare it against s_per_token before believing a
@@ -241,12 +249,15 @@ struct RunInfo {
     float top_p = 0.95f;
     uint32_t seed = 0xFFFFFFFFu;
 
-    // Self-speculation. It changes how many tokens a decode confirms, so every per-token row in the
-    // file was produced under a different accounting than an unspeculated run — see
-    // TokenMetrics::mtp_batch. Recorded so the two are never averaged together by accident.
-    bool mtp = false;
-    int mtp_draft_max = 0;
-    float mtp_p_min = 0.0f; // the head's confidence floor for continuing to draft (0 = no floor)
+    // Self-speculation, and which source drafted ("off", "mtp", "ngram"). It changes how many tokens
+    // a decode confirms, so every per-token row in the file was produced under a different
+    // accounting than an unspeculated run — see TokenMetrics::mtp_batch. Recorded so the two are
+    // never averaged together by accident, and so two speculated files are not compared across
+    // sources without noticing.
+    std::string spec = "off";
+    int spec_draft_max = 0;
+    float mtp_p_min = 0.0f;  // mtp: the head's confidence floor for drafting (0 = no floor)
+    int ngram_min_match = 0; // ngram: shortest suffix match allowed to draft
 
     // Diagnostics that perturb what they measure. A traced run is not a benchmark run — recorded so
     // a file cannot be mistaken for one.

--- a/core/include/bmoe/ngram_draft.h
+++ b/core/include/bmoe/ngram_draft.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace bmoe {
+
+// Prompt-lookup drafting: propose the continuation that followed the last time this exact token
+// sequence was seen, in the prompt or in what has been generated so far.
+//
+// This is a draft SOURCE for the self-speculative loop, alternative to the model's MTP head. It
+// exists because of what the flash split measured: at draft 3 on the host, the MTP head's own
+// routing was 2.9% of the extra bytes a speculated run streams — the other 97.1% was the widened
+// verify batch, which every source pays. So the prize is not in making the draft cheaper, with one
+// exception: this source can decide to draft NOTHING, at zero cost, and the head cannot. Below
+// min_match the step falls back to a plain single-token decode, which is why the floor of the
+// feature is the baseline rather than a loss. The win, where it exists, lives in segments the model
+// is copying — code edits, quoting from the context, structured output.
+//
+// Deliberately free of llama.cpp: tokens are int32_t (which is what llama_token is), so this stays
+// pure policy on the `core/include/bmoe` side of the seam, is unit-testable with no model, and adds
+// no dependency on llama.cpp's `common` layer — unlike the MTP path, which needs
+// common/speculative.h. See docs/seam.md.
+//
+// The match: let the corpus be `ctx` followed by `last`, and the pattern be its suffix. Every
+// position strictly before the corpus end is a candidate match end; the longest common suffix wins,
+// and among equal lengths the most recent one does (recency is what a code edit or a repeated
+// quotation wants). A match may overlap the pattern, which is what makes a run of one repeated token
+// predict itself.
+//
+// Cost is O(corpus * max_match) with an early exit, on a corpus bounded by n_ctx — microseconds,
+// and no incremental structure to keep in step with the KV cache.
+//
+//   ctx        prompt + tokens generated so far, in order (the caller already maintains it)
+//   last       the token just confirmed, not yet appended to ctx; part of the pattern
+//   n_max      most tokens to draft (the verify batch is 1 + this)
+//   min_match  shortest suffix match allowed to draft at all; below it, draft nothing
+//   max_match  longest suffix considered (a scan bound, not a target)
+//   out        cleared, then filled with the drafted tokens
+//
+// Returns the number of tokens drafted, in [0, n_max]. 0 means "no confident match" and the caller
+// must take the ordinary non-speculative path for this step.
+int ngram_draft(const std::vector<int32_t> & ctx,
+                int32_t last,
+                int n_max,
+                int min_match,
+                int max_match,
+                std::vector<int32_t> & out);
+
+} // namespace bmoe

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -49,6 +49,9 @@ struct SessionConfig {
     bool compute_trace_layers = false;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
+    // Self-speculative decoding through the model's MTP head. Fixed for the session: it decides
+    // whether open() builds the draft context and the wider verify batch. See RunConfig::mtp.
+    MtpConfig mtp;
 };
 
 // The RunConfig → SessionConfig mapping, in one place. Both entry points that open a session from a

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -49,9 +49,10 @@ struct SessionConfig {
     bool compute_trace_layers = false;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
-    // Self-speculative decoding through the model's MTP head. Fixed for the session: it decides
-    // whether open() builds the draft context and the wider verify batch. See RunConfig::mtp.
-    MtpConfig mtp;
+    // Self-speculative decoding, and which source drafts. Fixed for the session: it decides whether
+    // open() builds the wider verify batch, and — for the MTP source only — the draft context.
+    // See RunConfig::spec.
+    SpecConfig spec;
 };
 
 // The RunConfig → SessionConfig mapping, in one place. Both entry points that open a session from a

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -52,6 +52,32 @@ ValidationResult validate(const RunConfig & cfg) {
         }
     }
 
+    // Verification is exact only because greedy acceptance compares argmax against argmax. Under a
+    // sampling chain the accepted prefix would depend on which draws happened to agree, which is a
+    // different distribution from the one the caller asked for. Rejected rather than silently
+    // ignored: a caller who asked for both was promised something the engine cannot give.
+    if (cfg.mtp.enabled && cfg.sampling.temp > 0.0f) {
+        return fail("mtp requires greedy decoding (sampling.temp <= 0): speculative verification is "
+                    "token-identical to single-token decode only under argmax.");
+    }
+    // The floor is 1 (draft one token, verify two positions); at 0 there is nothing to verify and
+    // the loop degenerates into plain decode with a draft context's memory attached. The ceiling is
+    // an evidence boundary, not a physical one — see MtpConfig::draft_max.
+    if (cfg.mtp.enabled && (cfg.mtp.draft_max < 1 || cfg.mtp.draft_max > MtpConfig::draft_max_limit)) {
+        return fail("mtp.draft_max must be in [1, " + std::to_string(MtpConfig::draft_max_limit) + "]");
+    }
+    // The verify pass is 1 + draft_max positions and its whole point is that they are computed
+    // TOGETHER. A narrower graph splits it back into single-token passes, which spends the draft
+    // and keeps none of the amortisation — the feature would cost time and buy nothing. Rejected
+    // rather than silently degraded: nothing in the output would show that it happened. 0 means
+    // "as wide as the context" and is always wide enough.
+    if (cfg.mtp.enabled && cfg.n_ubatch > 0 && cfg.n_ubatch < cfg.mtp.draft_max + 1) {
+        return fail("n_ubatch=" + std::to_string(cfg.n_ubatch) + " is narrower than the verify batch (" +
+                    std::to_string(cfg.mtp.draft_max + 1) +
+                    " positions): the graph would be split back into single-token passes and MTP would "
+                    "draft at a cost with nothing to show for it. Raise n_ubatch or lower mtp.draft_max.");
+    }
+
     // overlap is meaningless without streaming (it gates the streamer's own reads). The
     // hook-availability check is deferred to run(): validate() stays pure (no native).
     if (cfg.moe.overlap && !cfg.moe.enabled) {

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -66,6 +66,12 @@ ValidationResult validate(const RunConfig & cfg) {
     if (cfg.mtp.enabled && (cfg.mtp.draft_max < 1 || cfg.mtp.draft_max > MtpConfig::draft_max_limit)) {
         return fail("mtp.draft_max must be in [1, " + std::to_string(MtpConfig::draft_max_limit) + "]");
     }
+    // A probability, so [0,1]. 1 would mean "only draft what the head is certain of", which is a
+    // legitimate (if extreme) setting; above 1 nothing would ever be drafted and the flag would be
+    // an expensive way to decode one token at a time.
+    if (cfg.mtp.enabled && (cfg.mtp.draft_p_min < 0.0f || cfg.mtp.draft_p_min > 1.0f)) {
+        return fail("mtp.draft_p_min must be in [0, 1]");
+    }
     // The verify pass is 1 + draft_max positions and its whole point is that they are computed
     // TOGETHER. A narrower graph splits it back into single-token passes, which spends the draft
     // and keeps none of the amortisation — the feature would cost time and buy nothing. Rejected

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -56,32 +56,50 @@ ValidationResult validate(const RunConfig & cfg) {
     // sampling chain the accepted prefix would depend on which draws happened to agree, which is a
     // different distribution from the one the caller asked for. Rejected rather than silently
     // ignored: a caller who asked for both was promised something the engine cannot give.
-    if (cfg.mtp.enabled && cfg.sampling.temp > 0.0f) {
-        return fail("mtp requires greedy decoding (sampling.temp <= 0): speculative verification is "
+    if (cfg.spec.enabled() && cfg.sampling.temp > 0.0f) {
+        return fail("speculative decoding requires greedy decoding (sampling.temp <= 0): verification is "
                     "token-identical to single-token decode only under argmax.");
     }
     // The floor is 1 (draft one token, verify two positions); at 0 there is nothing to verify and
-    // the loop degenerates into plain decode with a draft context's memory attached. The ceiling is
-    // an evidence boundary, not a physical one — see MtpConfig::draft_max.
-    if (cfg.mtp.enabled && (cfg.mtp.draft_max < 1 || cfg.mtp.draft_max > MtpConfig::draft_max_limit)) {
-        return fail("mtp.draft_max must be in [1, " + std::to_string(MtpConfig::draft_max_limit) + "]");
+    // the loop degenerates into plain decode with the speculative scaffolding attached. The ceiling
+    // is an evidence boundary, not a physical one — see SpecConfig::draft_max.
+    if (cfg.spec.enabled() && (cfg.spec.draft_max < 1 || cfg.spec.draft_max > SpecConfig::draft_max_limit)) {
+        return fail("spec.draft_max must be in [1, " + std::to_string(SpecConfig::draft_max_limit) + "]");
     }
     // A probability, so [0,1]. 1 would mean "only draft what the head is certain of", which is a
     // legitimate (if extreme) setting; above 1 nothing would ever be drafted and the flag would be
     // an expensive way to decode one token at a time.
-    if (cfg.mtp.enabled && (cfg.mtp.draft_p_min < 0.0f || cfg.mtp.draft_p_min > 1.0f)) {
-        return fail("mtp.draft_p_min must be in [0, 1]");
+    if (cfg.spec.is_mtp() && (cfg.spec.draft_p_min < 0.0f || cfg.spec.draft_p_min > 1.0f)) {
+        return fail("spec.draft_p_min must be in [0, 1]");
+    }
+    // Both of these are source-specific knobs. Accepting one against the other source would silently
+    // do nothing, which is exactly the class of "the flag was ignored" bug this validation exists to
+    // prevent — the caller asked for a behaviour the chosen source does not have.
+    if (cfg.spec.is_ngram() && cfg.spec.draft_p_min != 0.0f) {
+        return fail("spec.draft_p_min is an MTP knob (the head's own confidence in its proposal) and has "
+                    "no meaning for the n-gram source, which has no probabilities — its confidence gate "
+                    "is spec.ngram_min_match.");
+    }
+    if (cfg.spec.is_ngram() &&
+        (cfg.spec.ngram_max_match < 1 || cfg.spec.ngram_max_match > SpecConfig::ngram_match_limit)) {
+        return fail("spec.ngram_max_match must be in [1, " + std::to_string(SpecConfig::ngram_match_limit) + "]");
+    }
+    if (cfg.spec.is_ngram() && (cfg.spec.ngram_min_match < 1 || cfg.spec.ngram_min_match > cfg.spec.ngram_max_match)) {
+        return fail(
+            "spec.ngram_min_match must be in [1, spec.ngram_max_match=" + std::to_string(cfg.spec.ngram_max_match) +
+            "]: a floor above the longest suffix considered would never draft anything.");
     }
     // The verify pass is 1 + draft_max positions and its whole point is that they are computed
     // TOGETHER. A narrower graph splits it back into single-token passes, which spends the draft
     // and keeps none of the amortisation — the feature would cost time and buy nothing. Rejected
     // rather than silently degraded: nothing in the output would show that it happened. 0 means
     // "as wide as the context" and is always wide enough.
-    if (cfg.mtp.enabled && cfg.n_ubatch > 0 && cfg.n_ubatch < cfg.mtp.draft_max + 1) {
+    if (cfg.spec.enabled() && cfg.n_ubatch > 0 && cfg.n_ubatch < cfg.spec.draft_max + 1) {
         return fail("n_ubatch=" + std::to_string(cfg.n_ubatch) + " is narrower than the verify batch (" +
-                    std::to_string(cfg.mtp.draft_max + 1) +
-                    " positions): the graph would be split back into single-token passes and MTP would "
-                    "draft at a cost with nothing to show for it. Raise n_ubatch or lower mtp.draft_max.");
+                    std::to_string(cfg.spec.draft_max + 1) +
+                    " positions): the graph would be split back into single-token passes and speculation "
+                    "would draft at a cost with nothing to show for it. Raise n_ubatch or lower "
+                    "spec.draft_max.");
     }
 
     // overlap is meaningless without streaming (it gates the streamer's own reads). The

--- a/core/src/engine/ngram_draft.cpp
+++ b/core/src/engine/ngram_draft.cpp
@@ -1,0 +1,68 @@
+#include "bmoe/ngram_draft.h"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace bmoe {
+
+int ngram_draft(const std::vector<int32_t> & ctx,
+                int32_t last,
+                int n_max,
+                int min_match,
+                int max_match,
+                std::vector<int32_t> & out) {
+    out.clear();
+
+    if (n_max <= 0) return 0;
+    if (min_match < 1) min_match = 1;
+    if (max_match < min_match) return 0;
+
+    // The corpus is ctx ++ [last], addressed without materialising it: `last` is the final position
+    // and belongs to the pattern, because the token just confirmed is the strongest evidence there
+    // is about what comes next.
+    const size_t L = ctx.size() + 1;
+    const auto at = [&](size_t i) -> int32_t { return i < ctx.size() ? ctx[i] : last; };
+
+    // A match needs min_match tokens ending strictly before the corpus end.
+    if (L < (size_t) min_match + 1) return 0;
+
+    const size_t end = L - 1;                    // the pattern's last position
+    const size_t j_min = (size_t) min_match - 1; // below this a candidate cannot reach min_match
+
+    int best_m = 0;
+    size_t best_j = 0;
+
+    // Scan backwards from the most recent candidate. Because a longer match only ever replaces a
+    // shorter one (strict >), the most recent position wins among equal lengths for free.
+    for (size_t j = end - 1;; --j) {
+        if (at(j) == at(end)) {
+            // Longest common suffix of C[..j] and C[..end], capped by max_match and by how much
+            // corpus lies at or before j. Overlap with the pattern is intentional.
+            const int lim = std::min(max_match, (int) (j + 1));
+            int m = 1;
+            while (m < lim && at(j - m) == at(end - m)) {
+                ++m;
+            }
+            if (m > best_m) {
+                best_m = m;
+                best_j = j;
+                if (best_m == max_match) break; // capped: nothing earlier can beat it
+            }
+        }
+        if (j <= j_min) break;
+    }
+
+    // The confidence gate, and the whole economics of this source: no confident match means no
+    // draft, no widened verify batch, and a step that costs exactly a plain decode.
+    if (best_m < min_match) return 0;
+
+    const size_t avail = end - best_j; // tokens that followed the match, up to the corpus end
+    const size_t n = std::min((size_t) n_max, avail);
+    out.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        out.push_back(at(best_j + 1 + i));
+    }
+    return (int) n;
+}
+
+} // namespace bmoe

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -18,7 +18,7 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.compute_trace_layers = cfg.compute_trace_layers;
     sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
-    sc.mtp = cfg.mtp; // MTP self-speculation; off by default
+    sc.spec = cfg.spec; // self-speculation (MTP head or n-gram lookup); off by default
     return sc;
 }
 

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -18,6 +18,7 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.compute_trace_layers = cfg.compute_trace_layers;
     sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
+    sc.mtp = cfg.mtp; // MTP self-speculation; off by default
     return sc;
 }
 

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -243,6 +243,12 @@ struct Session::Impl {
     // OUTSIDE the target decode. It used to land in loop_overhead_ms together with sampling and
     // rendering, where it could only be inferred by differencing against an unspeculated run.
     double mtp_draft_seconds = 0.0;
+    // Flash bytes those passes streamed. The MTP block is a MoE layer of its own, so drafting has
+    // an I/O cost as well as a compute one — and it is invisible to the route trace, whose framing
+    // brackets the target decode only. Without this the growth in bytes/token under speculation
+    // cannot be split between the widened verify union on the trunk and the head's own routing,
+    // which are attacked in completely different ways.
+    uint64_t mtp_draft_read_bytes = 0;
 
     const llama_vocab * vocab = nullptr;
     int n_vocab = 0;
@@ -1113,6 +1119,7 @@ RunResult Session::generate(const GenerateRequest & req,
     const long long mtp0_accepted = im.mtp_accepted;
     const long long mtp0_decodes = im.mtp_decodes;
     const double mtp0_draft_s = im.mtp_draft_seconds;
+    const uint64_t mtp0_draft_bytes = im.mtp_draft_read_bytes;
 
     // The token the last decode settled on, not yet in the KV. Greedy stays argmax (byte-identical
     // to the resident reference the gates check); with a sampling chain, draw from the context's
@@ -1132,6 +1139,7 @@ RunResult Session::generate(const GenerateRequest & req,
         const int room = req.n_predict - n_gen - 1; // tokens still wanted after `tok` itself
         if (mtp_on && room > 0) {
             const auto d0 = clock_t_::now();
+            const uint64_t db0 = moe.enabled ? im.source.stats().read_bytes : 0;
             im.draft_buf.clear();
             common_speculative_draft_params & dp = common_speculative_get_draft_params(im.mtp.get(), /*seq*/ 0);
             dp.drafting = true;
@@ -1153,6 +1161,7 @@ RunResult Session::generate(const GenerateRequest & req,
             if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), /*seq*/ 0, n_past, -1))
                 return fail("the MTP draft context does not support rewinding its KV cache");
             draft_s += secs(d0, clock_t_::now());
+            if (moe.enabled) im.mtp_draft_read_bytes += im.source.stats().read_bytes - db0;
         }
 
         // ── verify batch: the confirmed token, then every draft, all asking for logits ──
@@ -1231,10 +1240,12 @@ RunResult Session::generate(const GenerateRequest & req,
             // through the MTP block — and that block routes experts of its own, so on a streamed
             // device the saving is flash reads, not just arithmetic.
             const auto p0 = clock_t_::now();
+            const uint64_t pb0 = moe.enabled ? im.source.stats().read_bytes : 0;
             batch_fill(im.mtp_batch, verify_toks.data(), 1 + n_acc, n_past, /*all_logits*/ false);
             if (!common_speculative_process(im.mtp.get(), im.mtp_batch))
                 return fail("MTP draft context failed to process the verify batch");
             draft_s += secs(p0, clock_t_::now());
+            if (moe.enabled) im.mtp_draft_read_bytes += im.source.stats().read_bytes - pb0;
             im.mtp_draft_seconds += draft_s;
 
             // Drop the rejected tail from the target; the bounded-rollback snapshots asked for at
@@ -1363,6 +1374,7 @@ RunResult Session::generate(const GenerateRequest & req,
     s.mtp_accepted = im.mtp_accepted - mtp0_accepted;
     s.mtp_decodes = im.mtp_decodes - mtp0_decodes;
     s.mtp_draft_s_per_token = n_gen > 0 ? (im.mtp_draft_seconds - mtp0_draft_s) / n_gen : 0.0;
+    s.mtp_draft_read_mib = (double) (im.mtp_draft_read_bytes - mtp0_draft_bytes) / (1024.0 * 1024.0);
     if (moe.predict_log) {
         // Session totals, not a per-generation delta: these are an accuracy estimate, and every
         // turn's routings are equally valid samples of it. See RunSummary.

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -3,6 +3,7 @@
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
 #include "bmoe/version.h"
+#include "bmoe/ngram_draft.h"
 #include "chat_parse.h"
 #include "thinking_control.h"
 #include "../moe/router_hook.h"
@@ -225,10 +226,14 @@ struct Session::Impl {
     std::unique_ptr<RouterHook> hook; // heap: its address is baked into cparams.cb_eval_user_data
     ExpertStreamSource source;
 
-    // MTP self-speculation (MtpConfig::enabled). A SECOND context over the SAME model, created with
-    // ctx_type = MTP so llama.cpp builds the nextn graph instead of the trunk one. It carries the
-    // same eval callback as the target — the hook is per-context, not per-model — so the MTP
-    // block's expert layer is captured and streamed by the one source both contexts share.
+    // The MTP draft source (SpecConfig::source == mtp). A SECOND context over the SAME model,
+    // created with ctx_type = MTP so llama.cpp builds the nextn graph instead of the trunk one. It
+    // carries the same eval callback as the target — the hook is per-context, not per-model — so the
+    // MTP block's expert layer is captured and streamed by the one source both contexts share.
+    //
+    // The n-gram source has no equivalent state: it drafts from the token history alone, which is
+    // why it costs no context, no memory and no expert read. Everything below this pair is shared by
+    // both sources, because the verify half of the loop does not care who drafted.
     std::unique_ptr<llama_context, void (*)(llama_context *)> ctx_dft{nullptr, llama_free};
     common_speculative_ptr mtp;
     // Serves both roles on the speculative path, never both at once: a prefill chunk (up to
@@ -239,6 +244,10 @@ struct Session::Impl {
     long long mtp_drafted = 0;
     long long mtp_accepted = 0;
     long long mtp_decodes = 0;
+    // Steps that drafted anything at all. Against mtp_decodes this is the n-gram source's match
+    // rate — the fraction of the run where it had evidence and widened the verify batch. For the
+    // head it is all of them, since it drafts unconditionally unless p_min stops it.
+    long long drafted_steps = 0;
     // Time spent drafting and catching the draft context up, i.e. everything speculation adds
     // OUTSIDE the target decode. It used to land in loop_overhead_ms together with sampling and
     // rendering, where it could only be inferred by differencing against an unspeculated run.
@@ -424,10 +433,12 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // trained MTP head — which is most ggufs, including quants of MTP-capable models that were
     // converted without the nextn tensors.
     im.n_layer_nextn = llama_model_n_layer_nextn(model);
-    if (cfg.mtp.enabled && im.n_layer_nextn <= 0)
+    if (cfg.spec.is_mtp() && im.n_layer_nextn <= 0)
         return fail("--mtp needs a model with a trained MTP head, and this gguf has no nextn block "
                     "(nextn_predict_layers is absent or zero). Qwen3.5/3.6 carry one in their "
-                    "ordinary quantisations; other architectures have none. See docs/mtp.md.");
+                    "ordinary quantisations; other architectures have none. --ngram speculates on any "
+                    "model, since it drafts from the text rather than from the weights. See "
+                    "docs/mtp.md and docs/ngram.md.");
 
     char arch[128] = {0};
     llama_model_meta_val_str(model, "general.architecture", arch, sizeof(arch));
@@ -459,7 +470,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // on the hook and the streamer must span the trunk PLUS the head. The index space is contiguous
     // and the tensor naming identical, so this bound is the only thing standing between the streamer
     // and the MTP experts — left at n_layer they are silently skipped and stay mmap-resident.
-    const int n_layer_streamed = im.n_layer + (cfg.mtp.enabled ? im.n_layer_nextn : 0);
+    const int n_layer_streamed = im.n_layer + (cfg.spec.is_mtp() ? im.n_layer_nextn : 0);
     im.hook = std::make_unique<RouterHook>(recipe ? *recipe : MoeRecipe{}, n_layer_streamed);
     im.hook->set_prefetch_layers(cfg.moe.prefetch_layers);
     im.hook->set_drop_policy(cfg.moe.drop_cold_frac, cfg.moe.drop_renorm, cfg.moe.drop_prefill);
@@ -483,7 +494,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // Rejecting a draft means rewinding the KV to the last accepted position. With recurrent-state
     // snapshots the rewind is a cheap restore; without them llama.cpp has to fall back to replaying
     // the sequence, which would hand back exactly the decode the speculation just saved.
-    if (cfg.mtp.enabled) cparams.n_rs_seq = (uint32_t) cfg.mtp.draft_max;
+    if (cfg.spec.enabled()) cparams.n_rs_seq = (uint32_t) cfg.spec.draft_max;
 
     llama_context * ctx = llama_init_from_model(model, cparams);
     if (!ctx) return fail("failed to create context");
@@ -493,7 +504,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // The MTP draft context: same model, same eval callback, but ctx_type = MTP so llama.cpp builds
     // the nextn graph. It keeps its own (single-position) KV, hence n_rs_seq = 0 — nothing is ever
     // rolled back on the draft side, the target is the one that speculates.
-    if (cfg.mtp.enabled) {
+    if (cfg.spec.is_mtp()) {
         llama_context_params dparams = cparams;
         dparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
         dparams.n_rs_seq = 0;
@@ -507,7 +518,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // points of hit rate. n_batch stays as it is — the speculative driver sizes its internal
         // batch from it and must still accept a whole prefill chunk, which llama.cpp then splits
         // into ubatches of the width below.
-        dparams.n_ubatch = (uint32_t) std::max(cfg.mtp.draft_max + 1, mtp_draft_ubatch);
+        dparams.n_ubatch = (uint32_t) std::max(cfg.spec.draft_max + 1, mtp_draft_ubatch);
         if (dparams.n_ubatch > cparams.n_ubatch) dparams.n_ubatch = cparams.n_ubatch;
         llama_context * ctx_dft = llama_init_from_model(model, dparams);
         if (!ctx_dft) return fail("failed to create the MTP draft context");
@@ -542,25 +553,30 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // Built before the capture warm-up on purpose: the driver's constructor turns on nextn
     // extraction for both contexts, which is what the target graph looks like for the rest of the
     // session. Capturing the graph it actually runs beats capturing the one it briefly had.
-    if (cfg.mtp.enabled) {
+    if (cfg.spec.is_mtp()) {
         common_params_speculative sp;
         sp.types = {COMMON_SPECULATIVE_TYPE_DRAFT_MTP};
-        sp.draft.n_max = cfg.mtp.draft_max;
+        sp.draft.n_max = cfg.spec.draft_max;
         sp.draft.n_min = 0; // never skip a whole draft; width is bounded by n_max and p_min below
         // The head's own confidence floor for continuing to draft. At 0 (the default) it drafts
         // n_max tokens however unsure it is, which is what the host was measured at; above 0 the
-        // width becomes adaptive per step. See MtpConfig::draft_p_min for why that pays twice on a
+        // width becomes adaptive per step. See SpecConfig::draft_p_min for why that pays twice on a
         // streamed device.
-        sp.draft.p_min = cfg.mtp.draft_p_min;
+        sp.draft.p_min = cfg.spec.draft_p_min;
         sp.draft.ctx_tgt = ctx; // self-speculation: one model, two contexts over it
         sp.draft.ctx_dft = im.ctx_dft.get();
         im.mtp.reset(common_speculative_init(sp, /*n_seq*/ 1));
         if (!im.mtp) return fail("failed to initialise MTP speculative decoding");
+    }
 
+    // The wide verify batch belongs to the loop, not to a source: whoever drafted, the target is
+    // handed 1 + draft_max positions in one decode. Allocated for any speculation, which is what
+    // lets the n-gram source reuse the whole verify half without a draft context.
+    if (cfg.spec.enabled()) {
         // One batch for the session, wide enough for the larger of its two roles.
-        im.mtp_batch = llama_batch_init(std::max(cfg.n_batch, cfg.mtp.draft_max + 1), /*embd*/ 0, /*n_seq_max*/ 1);
+        im.mtp_batch = llama_batch_init(std::max(cfg.n_batch, cfg.spec.draft_max + 1), /*embd*/ 0, /*n_seq_max*/ 1);
         im.mtp_batch_owned = true;
-        im.draft_buf.reserve((size_t) cfg.mtp.draft_max);
+        im.draft_buf.reserve((size_t) cfg.spec.draft_max);
     }
 
     if (cfg.moe.enabled) {
@@ -570,7 +586,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         im.hook->begin_capture();
         llama_token warm_tok = llama_vocab_bos(im.vocab);
         if (warm_tok < 0) warm_tok = 0;
-        if (cfg.mtp.enabled) {
+        if (cfg.spec.is_mtp()) {
             batch_fill(im.mtp_batch, &warm_tok, 1, /*pos0*/ 0, /*all_logits*/ true);
             if (llama_decode(ctx, im.mtp_batch) != 0) return fail("capture warm-up decode failed");
             // The MTP graph is built only by a decode on the draft context, and process() is what
@@ -724,9 +740,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.n_ubatch = cfg.n_ubatch;
         ri.chatml = cfg.chatml;
         ri.compute_trace_layers = cfg.compute_trace_layers;
-        ri.mtp = cfg.mtp.enabled;
-        ri.mtp_draft_max = cfg.mtp.enabled ? cfg.mtp.draft_max : 0;
-        ri.mtp_p_min = cfg.mtp.enabled ? cfg.mtp.draft_p_min : 0.0f;
+        ri.spec = cfg.spec.is_mtp() ? "mtp" : cfg.spec.is_ngram() ? "ngram" : "off";
+        ri.spec_draft_max = cfg.spec.enabled() ? cfg.spec.draft_max : 0;
+        ri.mtp_p_min = cfg.spec.is_mtp() ? cfg.spec.draft_p_min : 0.0f;
+        ri.ngram_min_match = cfg.spec.is_ngram() ? cfg.spec.ngram_min_match : 0;
         ri.temp = cfg.sampling.temp;
         ri.top_k = cfg.sampling.top_k;
         ri.top_p = cfg.sampling.top_p;
@@ -1030,6 +1047,12 @@ RunResult Session::generate(const GenerateRequest & req,
 
     // ── prefill (chunked by n_batch; positions auto-continue from the reused prefix) ──
     const auto t_prefill0 = clock_t_::now();
+    // Two predicates, deliberately distinct. spec_on is "the verify loop runs" — a wide batch, an
+    // accept pass, a rollback — and both sources need all of it. mtp_on is "the draft comes from the
+    // head", which is the only thing that needs the second context and llama.cpp's `common`
+    // speculative driver. Conflating them is what would make the n-gram source pay for a draft
+    // context it never uses.
+    const bool spec_on = im.cfg.spec.enabled();
     const bool mtp_on = im.mtp != nullptr;
     for (int i = (int) n_common; i < n_prompt; i += im.cfg.n_batch) {
         const int chunk = std::min(im.cfg.n_batch, n_prompt - i);
@@ -1109,15 +1132,17 @@ RunResult Session::generate(const GenerateRequest & req,
     // n_prompt-1; without speculation this simply tracks n_prompt + n_gen, but a verify decode
     // advances it by a whole accepted group, so it is carried explicitly.
     llama_pos n_past = n_prompt;
-    // The token sequence the draft head conditions on: the prompt plus everything confirmed since.
-    // Only built when speculating — the plain path has no use for it.
+    // The token sequence the draft source conditions on: the prompt plus everything confirmed since.
+    // Only built when speculating — the plain path has no use for it. The head reads it as the
+    // sequence to seed from; the n-gram source searches it, and it IS the whole corpus.
     std::vector<llama_token> mtp_ctx;
-    if (mtp_on) mtp_ctx = tokens;
+    if (spec_on) mtp_ctx = tokens;
     std::vector<llama_token> verify_toks; // [confirmed token, drafts...] for the verify batch
     std::vector<llama_token> confirmed;   // what one decode confirmed, in order
     const long long mtp0_drafted = im.mtp_drafted;
     const long long mtp0_accepted = im.mtp_accepted;
     const long long mtp0_decodes = im.mtp_decodes;
+    const long long mtp0_drafted_steps = im.drafted_steps;
     const double mtp0_draft_s = im.mtp_draft_seconds;
     const uint64_t mtp0_draft_bytes = im.mtp_draft_read_bytes;
 
@@ -1131,47 +1156,67 @@ RunResult Session::generate(const GenerateRequest & req,
         if (llama_vocab_is_eog(im.vocab, tok)) break;
 
         // ── draft ──
-        // The head proposes a continuation of `tok`, capped at the caller's remaining budget: a
+        // The source proposes a continuation of `tok`, capped at the caller's remaining budget: a
         // draft accepted past n_predict would be verified, charged for, and then discarded. The cap
-        // goes in BEFORE drafting, so the head is never asked for tokens with nowhere to go.
+        // goes in BEFORE drafting, so no source is ever asked for tokens with nowhere to go.
         int n_draft = 0;
         double draft_s = 0.0;                       // this group's drafting + catch-up (see below)
         const int room = req.n_predict - n_gen - 1; // tokens still wanted after `tok` itself
-        if (mtp_on && room > 0) {
+        if (spec_on && room > 0) {
             const auto d0 = clock_t_::now();
             const uint64_t db0 = moe.enabled ? im.source.stats().read_bytes : 0;
             im.draft_buf.clear();
-            common_speculative_draft_params & dp = common_speculative_get_draft_params(im.mtp.get(), /*seq*/ 0);
-            dp.drafting = true;
-            dp.n_max = std::min(im.cfg.mtp.draft_max, room);
-            dp.n_past = n_past;
-            dp.id_last = tok;
-            dp.prompt = &mtp_ctx;
-            dp.result = &im.draft_buf;
-            common_speculative_draft(im.mtp.get());
-            if ((int) im.draft_buf.size() > room) im.draft_buf.resize((size_t) room);
-            n_draft = (int) im.draft_buf.size();
-            im.mtp_drafted += n_draft;
+            if (mtp_on) {
+                common_speculative_draft_params & dp = common_speculative_get_draft_params(im.mtp.get(), /*seq*/ 0);
+                dp.drafting = true;
+                dp.n_max = std::min(im.cfg.spec.draft_max, room);
+                dp.n_past = n_past;
+                dp.id_last = tok;
+                dp.prompt = &mtp_ctx;
+                dp.result = &im.draft_buf;
+                common_speculative_draft(im.mtp.get());
+                if ((int) im.draft_buf.size() > room) im.draft_buf.resize((size_t) room);
+                n_draft = (int) im.draft_buf.size();
 
-            // Drafting WROTE into the draft context's KV at the very positions the catch-up below is
-            // about to occupy. Rewind to where the draft started, or the second decode collides with
-            // the first (llama.cpp requires a batch to begin strictly after the last stored
-            // position). The catch-up is what replaces those rows with ones conditioned on the
-            // target's own hidden states instead of the head's guesses.
-            if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), /*seq*/ 0, n_past, -1))
-                return fail("the MTP draft context does not support rewinding its KV cache");
+                // Drafting WROTE into the draft context's KV at the very positions the catch-up
+                // below is about to occupy. Rewind to where the draft started, or the second decode
+                // collides with the first (llama.cpp requires a batch to begin strictly after the
+                // last stored position). The catch-up is what replaces those rows with ones
+                // conditioned on the target's own hidden states instead of the head's guesses.
+                if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), /*seq*/ 0, n_past, -1))
+                    return fail("the MTP draft context does not support rewinding its KV cache");
+            } else {
+                // The n-gram source reads the text and nothing else: no draft context, no decode, no
+                // expert read, so the bytes bracketed around this arm are zero by construction. When
+                // it finds no confident match it returns 0 and the step below is an ordinary
+                // single-token decode — the property the head does not have, and the reason the
+                // floor of this source is the baseline rather than a loss.
+                n_draft = ngram_draft(mtp_ctx, tok, std::min(im.cfg.spec.draft_max, room), im.cfg.spec.ngram_min_match,
+                                      im.cfg.spec.ngram_max_match, im.draft_buf);
+            }
+            im.mtp_drafted += n_draft;
+            if (n_draft > 0) ++im.drafted_steps;
             draft_s += secs(d0, clock_t_::now());
             if (moe.enabled) im.mtp_draft_read_bytes += im.source.stats().read_bytes - db0;
         }
 
         // ── verify batch: the confirmed token, then every draft, all asking for logits ──
+        //
+        // With nothing drafted there is nothing to verify, so the step takes the plain path — one
+        // token, one logits row, no rollback. That is not an optimisation of the speculative loop,
+        // it IS the loop's floor: a step that drafts nothing must cost exactly what it would have
+        // cost with speculation off, or a source that abstains would still be paying for the
+        // scaffolding. It applies to the head too, whenever p_min stops it drafting.
+        const bool wide = spec_on && n_draft > 0;
         llama_batch step;
-        if (mtp_on) {
+        if (spec_on) {
             verify_toks.clear();
             verify_toks.push_back(tok);
             // n_draft, not draft_buf.size(): on the last token of a run there is no room to draft
             // and the buffer still holds the previous step's proposal.
             verify_toks.insert(verify_toks.end(), im.draft_buf.begin(), im.draft_buf.begin() + n_draft);
+        }
+        if (wide) {
             batch_fill(im.mtp_batch, verify_toks.data(), (int) verify_toks.size(), n_past, /*all_logits*/ true);
             step = im.mtp_batch;
         } else {
@@ -1221,7 +1266,7 @@ RunResult Session::generate(const GenerateRequest & req,
             }
             confirmed.push_back(want);
         }
-        if (mtp_on) {
+        if (spec_on) {
             im.mtp_accepted += n_acc;
 
             // Catch the draft context up on the ACCEPTED PREFIX ONLY.
@@ -1239,13 +1284,18 @@ RunResult Session::generate(const GenerateRequest & req,
             // range the rollback used to carve out. What it saves is (n_draft - n_acc) positions
             // through the MTP block — and that block routes experts of its own, so on a streamed
             // device the saving is flash reads, not just arithmetic.
-            const auto p0 = clock_t_::now();
-            const uint64_t pb0 = moe.enabled ? im.source.stats().read_bytes : 0;
-            batch_fill(im.mtp_batch, verify_toks.data(), 1 + n_acc, n_past, /*all_logits*/ false);
-            if (!common_speculative_process(im.mtp.get(), im.mtp_batch))
-                return fail("MTP draft context failed to process the verify batch");
-            draft_s += secs(p0, clock_t_::now());
-            if (moe.enabled) im.mtp_draft_read_bytes += im.source.stats().read_bytes - pb0;
+            //
+            // The n-gram source has no state to catch up: its next draft is read off the token
+            // history the emit block appends to, which is already correct by the time it is read.
+            if (mtp_on) {
+                const auto p0 = clock_t_::now();
+                const uint64_t pb0 = moe.enabled ? im.source.stats().read_bytes : 0;
+                batch_fill(im.mtp_batch, verify_toks.data(), 1 + n_acc, n_past, /*all_logits*/ false);
+                if (!common_speculative_process(im.mtp.get(), im.mtp_batch))
+                    return fail("MTP draft context failed to process the verify batch");
+                draft_s += secs(p0, clock_t_::now());
+                if (moe.enabled) im.mtp_draft_read_bytes += im.source.stats().read_bytes - pb0;
+            }
             im.mtp_draft_seconds += draft_s;
 
             // Drop the rejected tail from the target; the bounded-rollback snapshots asked for at
@@ -1256,7 +1306,7 @@ RunResult Session::generate(const GenerateRequest & req,
                 if (!llama_memory_seq_rm(llama_get_memory(ctx), /*seq*/ 0, keep, -1))
                     return fail("failed to roll back the rejected draft tokens from the KV cache");
             }
-            common_speculative_accept(im.mtp.get(), /*seq*/ 0, (uint16_t) n_acc);
+            if (mtp_on) common_speculative_accept(im.mtp.get(), /*seq*/ 0, (uint16_t) n_acc);
         }
 
         // ── emit ──
@@ -1273,7 +1323,7 @@ RunResult Session::generate(const GenerateRequest & req,
             std::string delta = np > 0 ? std::string(piece, np) : std::string();
             gen += delta;
             if (chat_on) im.kv_tokens.push_back(out); // this token is now in the KV
-            if (mtp_on) mtp_ctx.push_back(out);
+            if (spec_on) mtp_ctx.push_back(out);
             ++n_gen;
 
             TokenMetrics m;
@@ -1305,7 +1355,7 @@ RunResult Session::generate(const GenerateRequest & req,
         // hold the target's own continuation — the next token, arrived at for free. Off the
         // speculative path the row index stays -1, exactly as before: one token, one row.
         n_past += 1 + n_acc;
-        const int32_t row = mtp_on ? n_acc : -1;
+        const int32_t row = wide ? n_acc : -1;
         logits = llama_get_logits_ith(ctx, row);
         tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, row) : argmax(logits, im.n_vocab);
     }
@@ -1314,7 +1364,7 @@ RunResult Session::generate(const GenerateRequest & req,
     // token is decoded but never emitted, and a group can be cut short by n_predict. The KV and
     // kv_tokens must agree exactly or the next turn's prefix reuse decodes from a state that never
     // produced this answer, so trim back to what was actually emitted.
-    if (mtp_on) {
+    if (spec_on) {
         const llama_pos emitted_end = (llama_pos) n_prompt + n_gen;
         if (!llama_memory_seq_rm(llama_get_memory(ctx), 0, emitted_end, -1)) {
             // Nothing survives that we can still describe, so say so rather than leave kv_tokens
@@ -1325,7 +1375,7 @@ RunResult Session::generate(const GenerateRequest & req,
         // The draft context mirrors the target's positions (process() decodes the same batches into
         // it), so it is trimmed to the same point — not cleared, or a continued chat turn would
         // feed it only the new suffix and draft from a state that never saw the conversation.
-        if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), 0, emitted_end, -1))
+        if (mtp_on && !llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), 0, emitted_end, -1))
             llama_memory_clear(llama_get_memory(im.ctx_dft.get()), true);
     }
 
@@ -1373,6 +1423,7 @@ RunResult Session::generate(const GenerateRequest & req,
     s.mtp_drafted = im.mtp_drafted - mtp0_drafted;
     s.mtp_accepted = im.mtp_accepted - mtp0_accepted;
     s.mtp_decodes = im.mtp_decodes - mtp0_decodes;
+    s.drafted_steps = im.drafted_steps - mtp0_drafted_steps;
     s.mtp_draft_s_per_token = n_gen > 0 ? (im.mtp_draft_seconds - mtp0_draft_s) / n_gen : 0.0;
     s.mtp_draft_read_mib = (double) (im.mtp_draft_read_bytes - mtp0_draft_bytes) / (1024.0 * 1024.0);
     if (moe.predict_log) {

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -17,6 +17,7 @@
 // reasoning parsing. See the note in the root CMakeLists / docs/seam.md.
 #include "chat.h"
 #include "common.h"
+#include "speculative.h"
 
 #include <algorithm>
 #include <atomic>
@@ -39,6 +40,30 @@ using clock_t_ = std::chrono::steady_clock;
 double secs(clock_t_::time_point a, clock_t_::time_point b) {
     return std::chrono::duration<double>(b - a).count();
 }
+
+// Fill an explicitly-allocated batch with `n` tokens at consecutive positions on sequence 0.
+//
+// The engine otherwise decodes through llama_batch_get_one, which leaves pos/seq_id/logits null and
+// lets llama.cpp infer them. Speculation cannot: the driver reads the batch's sequence ids, and a
+// verify pass needs logits at EVERY position, not just the last. So every batch on the speculative
+// path is spelled out — including prefill, which the driver must see to keep the draft context's
+// KV in step with the target's.
+void batch_fill(llama_batch & b, const llama_token * toks, int n, llama_pos pos0, bool all_logits) {
+    b.n_tokens = n;
+    for (int i = 0; i < n; ++i) {
+        b.token[i] = toks[i];
+        b.pos[i] = pos0 + i;
+        b.n_seq_id[i] = 1;
+        b.seq_id[i][0] = 0;
+        b.logits[i] = (int8_t) (all_logits || i == n - 1);
+    }
+}
+
+// Graph width for the MTP draft context. Wide enough that prefilling the head (ONE layer) is not
+// chopped into pointless slivers, narrow enough that its compute-buffer reservation is a rounding
+// error next to the target's. Raised to 1 + draft_max when a very wide draft asks for more, and
+// clamped down to the target's own ubatch so it is never the wider of the two.
+constexpr int mtp_draft_ubatch = 256;
 
 llama_token argmax(const float * logits, int n_vocab) {
     llama_token best = 0;
@@ -187,10 +212,29 @@ struct Session::Impl {
     std::unique_ptr<RouterHook> hook; // heap: its address is baked into cparams.cb_eval_user_data
     ExpertStreamSource source;
 
+    // MTP self-speculation (MtpConfig::enabled). A SECOND context over the SAME model, created with
+    // ctx_type = MTP so llama.cpp builds the nextn graph instead of the trunk one. It carries the
+    // same eval callback as the target — the hook is per-context, not per-model — so the MTP
+    // block's expert layer is captured and streamed by the one source both contexts share.
+    std::unique_ptr<llama_context, void (*)(llama_context *)> ctx_dft{nullptr, llama_free};
+    common_speculative_ptr mtp;
+    // Serves both roles on the speculative path, never both at once: a prefill chunk (up to
+    // n_batch tokens, logits on the last) and a verify pass (1 + draft_max tokens, logits on all).
+    llama_batch mtp_batch{};
+    bool mtp_batch_owned = false; // whether mtp_batch holds a llama_batch_init allocation to free
+    std::vector<llama_token> draft_buf;
+    long long mtp_drafted = 0;
+    long long mtp_accepted = 0;
+    long long mtp_decodes = 0;
+
     const llama_vocab * vocab = nullptr;
     int n_vocab = 0;
     int n_expert_used = 0; // effective routing width, after any override (0 = not MoE)
     int n_layer = 0;
+    // Trained MTP heads in this gguf (0 = no nextn block). The MTP block occupies layer indices
+    // [n_layer, n_layer + n_layer_nextn), contiguous with the trunk and using the same tensor
+    // naming, so widening the streamer's layer bound by it is all the streamer needs to reach it.
+    int n_layer_nextn = 0;
     bool chat_on = false;
     common_chat_templates_ptr chat_tmpls;
     // How a think=false request can be honoured on this model; probed once at open(). Template
@@ -239,6 +283,11 @@ struct Session::Impl {
         // at the hook), then the hook, then unmap the model, then release the backend.
         source.shutdown();
         if (smpl) llama_sampler_free(smpl); // independent of ctx/model; free before them
+        // The speculative driver holds both contexts and detaches the backend samplers it
+        // installed on the draft one, so it goes before either context is freed.
+        mtp.reset();
+        if (mtp_batch_owned) llama_batch_free(mtp_batch);
+        ctx_dft.reset();
         ctx.reset();
         hook.reset();
         model.reset();
@@ -348,6 +397,14 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.vocab = llama_model_get_vocab(model);
     im.n_vocab = llama_vocab_n_tokens(im.vocab);
     im.n_layer = llama_model_n_layer(model);
+    // Excluded from n_layer by llama.cpp, so ask for it separately. Zero on every model without a
+    // trained MTP head — which is most ggufs, including quants of MTP-capable models that were
+    // converted without the nextn tensors.
+    im.n_layer_nextn = llama_model_n_layer_nextn(model);
+    if (cfg.mtp.enabled && im.n_layer_nextn <= 0)
+        return fail("--mtp needs a model with a trained MTP head, and this gguf has no nextn block "
+                    "(nextn_predict_layers is absent or zero). Qwen3.5/3.6 carry one in their "
+                    "ordinary quantisations; other architectures have none. See docs/mtp.md.");
 
     char arch[128] = {0};
     llama_model_meta_val_str(model, "general.architecture", arch, sizeof(arch));
@@ -375,7 +432,12 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         }
     }
 
-    im.hook = std::make_unique<RouterHook>(recipe ? *recipe : MoeRecipe{}, im.n_layer);
+    // The MTP block lives at layer index n_layer and routes experts of its own, so with speculation
+    // on the hook and the streamer must span the trunk PLUS the head. The index space is contiguous
+    // and the tensor naming identical, so this bound is the only thing standing between the streamer
+    // and the MTP experts — left at n_layer they are silently skipped and stay mmap-resident.
+    const int n_layer_streamed = im.n_layer + (cfg.mtp.enabled ? im.n_layer_nextn : 0);
+    im.hook = std::make_unique<RouterHook>(recipe ? *recipe : MoeRecipe{}, n_layer_streamed);
     im.hook->set_prefetch_layers(cfg.moe.prefetch_layers);
     im.hook->set_drop_policy(cfg.moe.drop_cold_frac, cfg.moe.drop_renorm, cfg.moe.drop_prefill);
     im.hook->set_predict_log(cfg.moe.predict_log);
@@ -395,11 +457,40 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         cparams.cb_eval = &RouterHook::c_eval;
         cparams.cb_eval_user_data = im.hook.get();
     }
+    // Rejecting a draft means rewinding the KV to the last accepted position. With recurrent-state
+    // snapshots the rewind is a cheap restore; without them llama.cpp has to fall back to replaying
+    // the sequence, which would hand back exactly the decode the speculation just saved.
+    if (cfg.mtp.enabled) cparams.n_rs_seq = (uint32_t) cfg.mtp.draft_max;
 
     llama_context * ctx = llama_init_from_model(model, cparams);
     if (!ctx) return fail("failed to create context");
     im.ctx.reset(ctx);
     llama_set_n_threads(ctx, cfg.n_threads, cfg.n_threads);
+
+    // The MTP draft context: same model, same eval callback, but ctx_type = MTP so llama.cpp builds
+    // the nextn graph. It keeps its own (single-position) KV, hence n_rs_seq = 0 — nothing is ever
+    // rolled back on the draft side, the target is the one that speculates.
+    if (cfg.mtp.enabled) {
+        llama_context_params dparams = cparams;
+        dparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+        dparams.n_rs_seq = 0;
+        // Compute buffers are reserved for the WIDEST ubatch, and left at the target's width the
+        // draft context reserves gigabytes for a graph it never runs: the widest thing it ever
+        // computes is a prefill chunk, and at decode time it is 1 + draft_max positions. On this
+        // engine every MiB reserved is a MiB the expert cache does not get, and the cache is what
+        // decides whether the widened verify read set is a hit or a flash read — so an oversized
+        // draft context does not merely waste memory, it eats the feature's own prize. Measured on
+        // the desktop host: leaving it at the target's width cost ~1 GiB of expert cache and 3
+        // points of hit rate. n_batch stays as it is — the speculative driver sizes its internal
+        // batch from it and must still accept a whole prefill chunk, which llama.cpp then splits
+        // into ubatches of the width below.
+        dparams.n_ubatch = (uint32_t) std::max(cfg.mtp.draft_max + 1, mtp_draft_ubatch);
+        if (dparams.n_ubatch > cparams.n_ubatch) dparams.n_ubatch = cparams.n_ubatch;
+        llama_context * ctx_dft = llama_init_from_model(model, dparams);
+        if (!ctx_dft) return fail("failed to create the MTP draft context");
+        im.ctx_dft.reset(ctx_dft);
+        llama_set_n_threads(ctx_dft, cfg.n_threads, cfg.n_threads);
+    }
 
     // Opt-in sampling. temp <= 0 leaves smpl null and the decode loop on argmax — the deterministic
     // default the byte-identity gates rely on. temp > 0 builds the standard chain, using only the
@@ -425,6 +516,26 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         },
         &im);
 
+    // Built before the capture warm-up on purpose: the driver's constructor turns on nextn
+    // extraction for both contexts, which is what the target graph looks like for the rest of the
+    // session. Capturing the graph it actually runs beats capturing the one it briefly had.
+    if (cfg.mtp.enabled) {
+        common_params_speculative sp;
+        sp.types = {COMMON_SPECULATIVE_TYPE_DRAFT_MTP};
+        sp.draft.n_max = cfg.mtp.draft_max;
+        sp.draft.n_min = 0;     // never skip a draft: the engine decides the width, not a heuristic
+        sp.draft.p_min = 0.0f;  // greedy — the draft is a proposal, acceptance is decided by argmax
+        sp.draft.ctx_tgt = ctx; // self-speculation: one model, two contexts over it
+        sp.draft.ctx_dft = im.ctx_dft.get();
+        im.mtp.reset(common_speculative_init(sp, /*n_seq*/ 1));
+        if (!im.mtp) return fail("failed to initialise MTP speculative decoding");
+
+        // One batch for the session, wide enough for the larger of its two roles.
+        im.mtp_batch = llama_batch_init(std::max(cfg.n_batch, cfg.mtp.draft_max + 1), /*embd*/ 0, /*n_seq_max*/ 1);
+        im.mtp_batch_owned = true;
+        im.draft_buf.reserve((size_t) cfg.mtp.draft_max);
+    }
+
     if (cfg.moe.enabled) {
         // Capture warm-up: one mmap-resident decode so the eval-callback can harvest the expert
         // tensor pointers from the graph. Any valid token builds the same graph (the expert
@@ -432,8 +543,19 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         im.hook->begin_capture();
         llama_token warm_tok = llama_vocab_bos(im.vocab);
         if (warm_tok < 0) warm_tok = 0;
-        llama_batch warm = llama_batch_get_one(&warm_tok, 1);
-        if (llama_decode(ctx, warm) != 0) return fail("capture warm-up decode failed");
+        if (cfg.mtp.enabled) {
+            batch_fill(im.mtp_batch, &warm_tok, 1, /*pos0*/ 0, /*all_logits*/ true);
+            if (llama_decode(ctx, im.mtp_batch) != 0) return fail("capture warm-up decode failed");
+            // The MTP graph is built only by a decode on the draft context, and process() is what
+            // issues it. Without this pass the head's expert layer never reaches the eval callback,
+            // so it would stay unbound and silently mmap-resident — the one thing streaming exists
+            // to avoid on a model that does not fit.
+            if (!common_speculative_process(im.mtp.get(), im.mtp_batch))
+                return fail("MTP capture warm-up failed: the draft context could not process the batch");
+        } else {
+            llama_batch warm = llama_batch_get_one(&warm_tok, 1);
+            if (llama_decode(ctx, warm) != 0) return fail("capture warm-up decode failed");
+        }
         im.hook->end_capture();
 
         const GgufOffsets & offs = meta().offsets;
@@ -468,7 +590,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // Computed before init consumes `layers`: the dense split needs the captured expert
         // tensor names and the gguf sizes together.
         std::vector<uint64_t> dense_bytes;
-        if (route_trace) dense_bytes = dense_bytes_per_layer(offs, layers, im.n_layer);
+        if (route_trace) dense_bytes = dense_bytes_per_layer(offs, layers, n_layer_streamed);
 
         // Anonymous dense-weights mode: hand the streamer the dense (non-expert) model weights to
         // read into anon buffers. The list is every captured weight leaf that IS a gguf tensor
@@ -505,7 +627,9 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             RouteTraceStatic st;
             st.model = cfg.model_path;
             st.arch = im.arch;
-            st.n_layer = im.n_layer;
+            // The streamed span, not the trunk: with speculation on, the MTP block is a layer the
+            // streamer manages like any other, and a trace that stopped at the trunk would drop it.
+            st.n_layer = n_layer_streamed;
             st.n_expert = n_expert;
             // The effective top-k: an override IS the applied width, otherwise the model's own.
             st.n_expert_used = cfg.n_expert_used;
@@ -514,8 +638,8 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                 st.n_expert_used = info.ok ? info.n_expert_used : 0;
             }
             st.dense_bytes_per_layer = std::move(dense_bytes);
-            st.expert_bytes_per_layer.resize((size_t) im.n_layer);
-            for (int il = 0; il < im.n_layer; ++il)
+            st.expert_bytes_per_layer.resize((size_t) n_layer_streamed);
+            for (int il = 0; il < n_layer_streamed; ++il)
                 st.expert_bytes_per_layer[(size_t) il] = im.source.expert_bytes(il);
             route_trace->on_static(st);
         }
@@ -534,6 +658,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         }
 
         llama_memory_clear(llama_get_memory(ctx), true); // discard warm-up KV
+        if (im.ctx_dft) llama_memory_clear(llama_get_memory(im.ctx_dft.get()), true);
     }
 
     // Decode traces. Outside the streaming block on purpose: the compute trace measures the graph,
@@ -572,6 +697,8 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.n_ubatch = cfg.n_ubatch;
         ri.chatml = cfg.chatml;
         ri.compute_trace_layers = cfg.compute_trace_layers;
+        ri.mtp = cfg.mtp.enabled;
+        ri.mtp_draft_max = cfg.mtp.enabled ? cfg.mtp.draft_max : 0;
         ri.temp = cfg.sampling.temp;
         ri.top_k = cfg.sampling.top_k;
         ri.top_p = cfg.sampling.top_p;
@@ -674,6 +801,9 @@ RunResult Session::generate(const GenerateRequest & req,
     // continues the conversation, reusing the KV prefix already decoded from earlier turns.
     if (req.clear_kv) {
         llama_memory_clear(llama_get_memory(ctx), true);
+        // The draft context tracks the target's positions and must be dropped with it, or the first
+        // draft of the new conversation is conditioned on the previous one.
+        if (im.ctx_dft) llama_memory_clear(llama_get_memory(im.ctx_dft.get()), true);
         im.chat_history.clear();
         im.kv_tokens.clear();
         // A new chat resets the sampler RNG, so a fixed seed reproduces the same transcript from a
@@ -792,6 +922,13 @@ RunResult Session::generate(const GenerateRequest & req,
             }
             im.kv_tokens.resize(n_common);
         }
+        // The draft context mirrors the target's positions, so it has to be rewound to the SAME
+        // point — including when n_common did not move, since the previous turn left it holding
+        // everything it generated. Miss this and the first prefill batch of the turn starts at a
+        // position the draft context already has, which llama.cpp rejects outright: the second
+        // message of a conversation fails while the first always works.
+        if (im.ctx_dft && !llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), 0, (llama_pos) n_common, -1))
+            llama_memory_clear(llama_get_memory(im.ctx_dft.get()), true);
     }
 
     // Roll this turn back to the state before it started: drop the KV added this turn, forget the
@@ -807,6 +944,13 @@ RunResult Session::generate(const GenerateRequest & req,
             }
         } else {
             llama_memory_clear(llama_get_memory(ctx), true);
+        }
+        // Whatever the target rolled back to, the draft context follows: a cancelled turn that left
+        // the two at different positions would fail the NEXT turn, not this one.
+        if (im.ctx_dft) {
+            const llama_pos keep = chat_on ? (llama_pos) n_common : 0;
+            if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), 0, keep, -1))
+                llama_memory_clear(llama_get_memory(im.ctx_dft.get()), true);
         }
     };
 
@@ -858,9 +1002,18 @@ RunResult Session::generate(const GenerateRequest & req,
 
     // ── prefill (chunked by n_batch; positions auto-continue from the reused prefix) ──
     const auto t_prefill0 = clock_t_::now();
+    const bool mtp_on = im.mtp != nullptr;
     for (int i = (int) n_common; i < n_prompt; i += im.cfg.n_batch) {
         const int chunk = std::min(im.cfg.n_batch, n_prompt - i);
-        llama_batch pf = llama_batch_get_one(tokens.data() + i, chunk);
+        llama_batch pf;
+        if (mtp_on) {
+            // Positions are absolute here — the prompt token at index i sits at position i, reused
+            // prefix included — which is exactly what llama_batch_get_one would have inferred.
+            batch_fill(im.mtp_batch, tokens.data() + i, chunk, /*pos0*/ i, /*all_logits*/ false);
+            pf = im.mtp_batch;
+        } else {
+            pf = llama_batch_get_one(tokens.data() + i, chunk);
+        }
         trace_begin(i, chunk, /*phase*/ 0);
         if (llama_decode(ctx, pf) != 0) {
             if (im.cancel_requested.load(std::memory_order_relaxed)) {
@@ -873,11 +1026,18 @@ RunResult Session::generate(const GenerateRequest & req,
             return fail("prefill decode failed");
         }
         trace_flush();
+        // The draft context has to walk the prompt too: its KV must reach the last prompt position
+        // or the first draft is made from a hidden state that never saw the prompt.
+        if (mtp_on && !common_speculative_process(im.mtp.get(), pf))
+            return fail("MTP draft context failed to process the prefill batch");
     }
     // The suffix is now in the KV; record it so the next turn can diff against it.
     if (chat_on)
         for (int i = (int) n_common; i < n_prompt; ++i)
             im.kv_tokens.push_back(tokens[i]);
+    // Announced only once the prompt is in both contexts: begin() checks how far the draft context
+    // has actually got, so calling it before prefill would warn about a gap that is about to close.
+    if (mtp_on) common_speculative_begin(im.mtp.get(), /*seq_id*/ 0, tokens);
     const double prefill_seconds = secs(t_prefill0, clock_t_::now());
     const float * logits = llama_get_logits_ith(ctx, -1);
 
@@ -917,17 +1077,71 @@ RunResult Session::generate(const GenerateRequest & req,
     auto loop_mark = clock_t_::now();
     double loop_overhead_s = 0.0;
 
-    for (int t = 0; t < req.n_predict; ++t) {
-        // Greedy stays argmax (byte-identical to the resident reference the gates check); with a
-        // sampling chain, draw from the context's last-position logits, which llama_sampler_sample
-        // reads at index -1 — the same logits argmax would have read.
-        llama_token tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, -1) : argmax(logits, im.n_vocab);
+    // Absolute position the next decoded token occupies. Prefill left the context filled up to
+    // n_prompt-1; without speculation this simply tracks n_prompt + n_gen, but a verify decode
+    // advances it by a whole accepted group, so it is carried explicitly.
+    llama_pos n_past = n_prompt;
+    // The token sequence the draft head conditions on: the prompt plus everything confirmed since.
+    // Only built when speculating — the plain path has no use for it.
+    std::vector<llama_token> mtp_ctx;
+    if (mtp_on) mtp_ctx = tokens;
+    std::vector<llama_token> verify_toks; // [confirmed token, drafts...] for the verify batch
+    std::vector<llama_token> confirmed;   // what one decode confirmed, in order
+    const long long mtp0_drafted = im.mtp_drafted;
+    const long long mtp0_accepted = im.mtp_accepted;
+    const long long mtp0_decodes = im.mtp_decodes;
+
+    // The token the last decode settled on, not yet in the KV. Greedy stays argmax (byte-identical
+    // to the resident reference the gates check); with a sampling chain, draw from the context's
+    // last-position logits, which llama_sampler_sample reads at index -1 — the same logits argmax
+    // would have read.
+    llama_token tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, -1) : argmax(logits, im.n_vocab);
+
+    while (n_gen < req.n_predict) {
         if (llama_vocab_is_eog(im.vocab, tok)) break;
 
-        char piece[256];
-        int np = llama_token_to_piece(im.vocab, tok, piece, sizeof(piece), 0, true);
-        std::string delta = np > 0 ? std::string(piece, np) : std::string();
-        gen += delta;
+        // ── draft ──
+        // The head proposes a continuation of `tok`, capped at the caller's remaining budget: a
+        // draft accepted past n_predict would be verified, charged for, and then discarded. The cap
+        // goes in BEFORE drafting, so the head is never asked for tokens with nowhere to go.
+        int n_draft = 0;
+        const int room = req.n_predict - n_gen - 1; // tokens still wanted after `tok` itself
+        if (mtp_on && room > 0) {
+            im.draft_buf.clear();
+            common_speculative_draft_params & dp = common_speculative_get_draft_params(im.mtp.get(), /*seq*/ 0);
+            dp.drafting = true;
+            dp.n_max = std::min(im.cfg.mtp.draft_max, room);
+            dp.n_past = n_past;
+            dp.id_last = tok;
+            dp.prompt = &mtp_ctx;
+            dp.result = &im.draft_buf;
+            common_speculative_draft(im.mtp.get());
+            if ((int) im.draft_buf.size() > room) im.draft_buf.resize((size_t) room);
+            n_draft = (int) im.draft_buf.size();
+            im.mtp_drafted += n_draft;
+
+            // Drafting WROTE into the draft context's KV at the very positions the catch-up below is
+            // about to occupy. Rewind to where the draft started, or the second decode collides with
+            // the first (llama.cpp requires a batch to begin strictly after the last stored
+            // position). The catch-up is what replaces those rows with ones conditioned on the
+            // target's own hidden states instead of the head's guesses.
+            if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), /*seq*/ 0, n_past, -1))
+                return fail("the MTP draft context does not support rewinding its KV cache");
+        }
+
+        // ── verify batch: the confirmed token, then every draft, all asking for logits ──
+        llama_batch step;
+        if (mtp_on) {
+            verify_toks.clear();
+            verify_toks.push_back(tok);
+            // n_draft, not draft_buf.size(): on the last token of a run there is no room to draft
+            // and the buffer still holds the previous step's proposal.
+            verify_toks.insert(verify_toks.end(), im.draft_buf.begin(), im.draft_buf.begin() + n_draft);
+            batch_fill(im.mtp_batch, verify_toks.data(), (int) verify_toks.size(), n_past, /*all_logits*/ true);
+            step = im.mtp_batch;
+        } else {
+            step = llama_batch_get_one(&tok, 1);
+        }
 
         // Bracket ONLY the decode: major faults and CPU-time deltas here decompose this token's
         // compute residual into flash-fault stalls vs. genuine (or throttled) computation.
@@ -936,8 +1150,7 @@ RunResult Session::generate(const GenerateRequest & req,
         auto s0 = clock_t_::now();
         const double overhead = secs(loop_mark, s0); // everything since the previous decode returned
         loop_overhead_s += overhead;
-        llama_batch step = llama_batch_get_one(&tok, 1);
-        trace_begin(n_prompt + t, /*n_tokens*/ 1, /*phase*/ 1); // decodes at the position after the prompt
+        trace_begin(n_past, /*n_tokens*/ 1 + n_draft, /*phase*/ 1);
         int dec = llama_decode(ctx, step);
         auto s1 = clock_t_::now();
         loop_mark = s1; // the next token's overhead is measured from here
@@ -952,29 +1165,125 @@ RunResult Session::generate(const GenerateRequest & req,
             return fail("decode failed during generation");
         }
         trace_flush(); // outside the s0..s1 bracket: the trace's own writes must not bill wall_ms
-        logits = llama_get_logits_ith(ctx, -1);
-        if (chat_on) im.kv_tokens.push_back(tok); // this token is now in the KV
+        ++im.mtp_decodes;
 
-        ++n_gen;
-        double wall = secs(s0, s1);
-        gen_seconds += wall;
-
-        TokenMetrics m;
-        m.step = n_gen;
-        m.steps = req.n_predict;
-        m.loop_overhead_ms = overhead * 1000.0;
-        m.piece = delta;
-        // Only when someone will read it: the parser cannot resume, so this re-parses everything
-        // generated so far on every token, and off the chat path it is a full copy of the same.
-        if (req.render_text) {
-            ShownView sv = shown_view(gen, /*partial*/ true);
-            m.text = std::move(sv.content);
-            m.reasoning = std::move(sv.reasoning);
+        // ── accept ──
+        // `tok` was settled before the decode, so it is confirmed unconditionally. Each draft is
+        // confirmed only while it matches what the target itself would have produced at that
+        // position — no approximation enters here. The batch's arithmetic is still not bit-identical
+        // to a single-token pass, so a near-tie can land differently; see docs/mtp.md.
+        confirmed.clear();
+        confirmed.push_back(tok);
+        int n_acc = 0;
+        bool eog_hit = false;
+        for (int i = 0; i < n_draft; ++i) {
+            const llama_token want = argmax(llama_get_logits_ith(ctx, i), im.n_vocab);
+            if (want != im.draft_buf[i]) break;
+            ++n_acc; // accepted: it is in the KV whether or not the caller gets to see it
+            if (llama_vocab_is_eog(im.vocab, want)) {
+                eog_hit = true; // end-of-generation is never emitted, here as on the plain path
+                break;
+            }
+            confirmed.push_back(want);
         }
+        if (mtp_on) {
+            im.mtp_accepted += n_acc;
+
+            // Catch the draft context up on the ACCEPTED PREFIX ONLY.
+            //
+            // The catch-up re-runs the MTP block over the batch so the draft context holds rows
+            // conditioned on the target's own hidden states, and accept() below seeds the next draft
+            // from the row at index n_acc. Handing it the whole verify batch — the obvious ordering,
+            // and the one upstream's own loop uses — computes the rejected tail as well, and that
+            // tail is deleted a few statements later: those drafts were wrong and nothing ever reads
+            // their rows. Acceptance depends only on the target's logits, which are already in hand
+            // by this point, so the tail simply never has to be submitted.
+            //
+            // Identical state, strictly less work. accept() seeds from row min(n_acc, n_rows-1),
+            // which is row n_acc under either batch, and the KV this leaves behind is exactly the
+            // range the rollback used to carve out. What it saves is (n_draft - n_acc) positions
+            // through the MTP block — and that block routes experts of its own, so on a streamed
+            // device the saving is flash reads, not just arithmetic.
+            batch_fill(im.mtp_batch, verify_toks.data(), 1 + n_acc, n_past, /*all_logits*/ false);
+            if (!common_speculative_process(im.mtp.get(), im.mtp_batch))
+                return fail("MTP draft context failed to process the verify batch");
+
+            // Drop the rejected tail from the target; the bounded-rollback snapshots asked for at
+            // context creation are what make this a restore rather than a replay. The draft context
+            // needs no rollback of its own — it was never given the tail.
+            if (n_acc < n_draft) {
+                const llama_pos keep = n_past + 1 + n_acc;
+                if (!llama_memory_seq_rm(llama_get_memory(ctx), /*seq*/ 0, keep, -1))
+                    return fail("failed to roll back the rejected draft tokens from the KV cache");
+            }
+            common_speculative_accept(im.mtp.get(), /*seq*/ 0, (uint16_t) n_acc);
+        }
+
+        // ── emit ──
+        // One metrics row per confirmed token, but ONE decode produced them all: its cost goes to
+        // the first row and the rest carry zeros (see TokenMetrics::mtp_batch). Splitting the wall
+        // evenly would read as several equally-cheap tokens, which is not what happened.
+        const double wall = secs(s0, s1);
+        gen_seconds += wall;
         const IExpertSource::Stats st = moe.enabled ? im.source.stats() : IExpertSource::Stats{};
-        tally.record(m, wall, f1 - f0, c1 - c0, im.turn, moe.enabled ? &st : nullptr);
-        if (on_token) on_token(m);
-        if (sink) sink->on_token(m);
+        for (size_t e = 0; e < confirmed.size() && n_gen < req.n_predict; ++e) {
+            const llama_token out = confirmed[e];
+            char piece[256];
+            int np = llama_token_to_piece(im.vocab, out, piece, sizeof(piece), 0, true);
+            std::string delta = np > 0 ? std::string(piece, np) : std::string();
+            gen += delta;
+            if (chat_on) im.kv_tokens.push_back(out); // this token is now in the KV
+            if (mtp_on) mtp_ctx.push_back(out);
+            ++n_gen;
+
+            TokenMetrics m;
+            m.step = n_gen;
+            m.steps = req.n_predict;
+            m.mtp_batch = (int) confirmed.size();
+            m.loop_overhead_ms = e == 0 ? overhead * 1000.0 : 0.0;
+            m.piece = delta;
+            // Only when someone will read it: the parser cannot resume, so this re-parses everything
+            // generated so far on every token, and off the chat path it is a full copy of the same.
+            if (req.render_text) {
+                ShownView sv = shown_view(gen, /*partial*/ true);
+                m.text = std::move(sv.content);
+                m.reasoning = std::move(sv.reasoning);
+            }
+            if (e == 0)
+                tally.record(m, wall, f1 - f0, c1 - c0, im.turn, moe.enabled ? &st : nullptr);
+            else
+                tally.record(m, 0.0, 0, 0.0, im.turn, moe.enabled ? &st : nullptr);
+            if (on_token) on_token(m);
+            if (sink) sink->on_token(m);
+        }
+
+        if (eog_hit) break;
+        // The accepted group is now KV-resident, and the logits at the first unverified position
+        // hold the target's own continuation — the next token, arrived at for free. Off the
+        // speculative path the row index stays -1, exactly as before: one token, one row.
+        n_past += 1 + n_acc;
+        const int32_t row = mtp_on ? n_acc : -1;
+        logits = llama_get_logits_ith(ctx, row);
+        tok = im.smpl ? llama_sampler_sample(im.smpl, ctx, row) : argmax(logits, im.n_vocab);
+    }
+
+    // Speculation can leave the KV ahead of what the caller received: an accepted end-of-generation
+    // token is decoded but never emitted, and a group can be cut short by n_predict. The KV and
+    // kv_tokens must agree exactly or the next turn's prefix reuse decodes from a state that never
+    // produced this answer, so trim back to what was actually emitted.
+    if (mtp_on) {
+        const llama_pos emitted_end = (llama_pos) n_prompt + n_gen;
+        if (!llama_memory_seq_rm(llama_get_memory(ctx), 0, emitted_end, -1)) {
+            // Nothing survives that we can still describe, so say so rather than leave kv_tokens
+            // asserting a prefix the context no longer holds. The next turn re-prefills in full.
+            llama_memory_clear(llama_get_memory(ctx), true);
+            im.kv_tokens.clear();
+        }
+        // The draft context mirrors the target's positions (process() decodes the same batches into
+        // it), so it is trimmed to the same point — not cleared, or a continued chat turn would
+        // feed it only the new suffix and draft from a state that never saw the conversation.
+        if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), 0, emitted_end, -1))
+            llama_memory_clear(llama_get_memory(im.ctx_dft.get()), true);
     }
 
     ++im.turn; // this turn is written; label the next one apart
@@ -1016,6 +1325,11 @@ RunResult Session::generate(const GenerateRequest & req,
     }
     s.experts_routed = im.hook->experts_routed() - prev_routed;
     s.experts_dropped = im.hook->experts_dropped() - prev_dropped;
+    // Per-turn deltas, like every other generation figure here: a warm session's counters are
+    // cumulative, and an acceptance rate averaged over earlier prompts would describe none of them.
+    s.mtp_drafted = im.mtp_drafted - mtp0_drafted;
+    s.mtp_accepted = im.mtp_accepted - mtp0_accepted;
+    s.mtp_decodes = im.mtp_decodes - mtp0_decodes;
     if (moe.predict_log) {
         // Session totals, not a per-generation delta: these are an accuracy estimate, and every
         // turn's routings are equally valid samples of it. See RunSummary.

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -59,11 +59,24 @@ void batch_fill(llama_batch & b, const llama_token * toks, int n, llama_pos pos0
     }
 }
 
-// Graph width for the MTP draft context. Wide enough that prefilling the head (ONE layer) is not
-// chopped into pointless slivers, narrow enough that its compute-buffer reservation is a rounding
-// error next to the target's. Raised to 1 + draft_max when a very wide draft asks for more, and
-// clamped down to the target's own ubatch so it is never the wider of the two.
-constexpr int mtp_draft_ubatch = 256;
+// Graph width for the MTP draft context, and it wants to be SMALL.
+//
+// llama.cpp reserves a context's compute buffers for its widest ubatch, and the dominant term is the
+// output buffer, which scales with ubatch x vocabulary — at 256 on a 152k-vocab model that alone is
+// ~156 MB, inside a reservation measured at 493 MiB on device. The draft context never needs it:
+// at decode time it evaluates ONE token per draft step, the catch-up hands it at most 1 + draft_max
+// positions, and that catch-up asks for no logits at all. Only prefill ever feeds it a wide batch,
+// and that is one layer, so splitting it into more ubatches costs very little.
+//
+// The width was 256 until the device A/B showed what it cost. Half a gigabyte of reservation is what
+// tipped the phone past its memory budget: major faults per token went from ~69 without speculation
+// to 632 at draft 3, as the kernel swapped and dropped file pages to find the room. On this engine
+// memory is never free — it is the expert cache's, and the cache is what decides whether the wider
+// verify read set is a hit or a flash read.
+//
+// Raised to 1 + draft_max when a very wide draft asks for more, and clamped down to the target's own
+// ubatch so it is never the wider of the two.
+constexpr int mtp_draft_ubatch = 32;
 
 llama_token argmax(const float * logits, int n_vocab) {
     llama_token best = 0;
@@ -226,6 +239,10 @@ struct Session::Impl {
     long long mtp_drafted = 0;
     long long mtp_accepted = 0;
     long long mtp_decodes = 0;
+    // Time spent drafting and catching the draft context up, i.e. everything speculation adds
+    // OUTSIDE the target decode. It used to land in loop_overhead_ms together with sampling and
+    // rendering, where it could only be inferred by differencing against an unspeculated run.
+    double mtp_draft_seconds = 0.0;
 
     const llama_vocab * vocab = nullptr;
     int n_vocab = 0;
@@ -523,8 +540,12 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         common_params_speculative sp;
         sp.types = {COMMON_SPECULATIVE_TYPE_DRAFT_MTP};
         sp.draft.n_max = cfg.mtp.draft_max;
-        sp.draft.n_min = 0;     // never skip a draft: the engine decides the width, not a heuristic
-        sp.draft.p_min = 0.0f;  // greedy — the draft is a proposal, acceptance is decided by argmax
+        sp.draft.n_min = 0; // never skip a whole draft; width is bounded by n_max and p_min below
+        // The head's own confidence floor for continuing to draft. At 0 (the default) it drafts
+        // n_max tokens however unsure it is, which is what the host was measured at; above 0 the
+        // width becomes adaptive per step. See MtpConfig::draft_p_min for why that pays twice on a
+        // streamed device.
+        sp.draft.p_min = cfg.mtp.draft_p_min;
         sp.draft.ctx_tgt = ctx; // self-speculation: one model, two contexts over it
         sp.draft.ctx_dft = im.ctx_dft.get();
         im.mtp.reset(common_speculative_init(sp, /*n_seq*/ 1));
@@ -699,6 +720,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.compute_trace_layers = cfg.compute_trace_layers;
         ri.mtp = cfg.mtp.enabled;
         ri.mtp_draft_max = cfg.mtp.enabled ? cfg.mtp.draft_max : 0;
+        ri.mtp_p_min = cfg.mtp.enabled ? cfg.mtp.draft_p_min : 0.0f;
         ri.temp = cfg.sampling.temp;
         ri.top_k = cfg.sampling.top_k;
         ri.top_p = cfg.sampling.top_p;
@@ -1090,6 +1112,7 @@ RunResult Session::generate(const GenerateRequest & req,
     const long long mtp0_drafted = im.mtp_drafted;
     const long long mtp0_accepted = im.mtp_accepted;
     const long long mtp0_decodes = im.mtp_decodes;
+    const double mtp0_draft_s = im.mtp_draft_seconds;
 
     // The token the last decode settled on, not yet in the KV. Greedy stays argmax (byte-identical
     // to the resident reference the gates check); with a sampling chain, draw from the context's
@@ -1105,8 +1128,10 @@ RunResult Session::generate(const GenerateRequest & req,
         // draft accepted past n_predict would be verified, charged for, and then discarded. The cap
         // goes in BEFORE drafting, so the head is never asked for tokens with nowhere to go.
         int n_draft = 0;
+        double draft_s = 0.0;                       // this group's drafting + catch-up (see below)
         const int room = req.n_predict - n_gen - 1; // tokens still wanted after `tok` itself
         if (mtp_on && room > 0) {
+            const auto d0 = clock_t_::now();
             im.draft_buf.clear();
             common_speculative_draft_params & dp = common_speculative_get_draft_params(im.mtp.get(), /*seq*/ 0);
             dp.drafting = true;
@@ -1127,6 +1152,7 @@ RunResult Session::generate(const GenerateRequest & req,
             // target's own hidden states instead of the head's guesses.
             if (!llama_memory_seq_rm(llama_get_memory(im.ctx_dft.get()), /*seq*/ 0, n_past, -1))
                 return fail("the MTP draft context does not support rewinding its KV cache");
+            draft_s += secs(d0, clock_t_::now());
         }
 
         // ── verify batch: the confirmed token, then every draft, all asking for logits ──
@@ -1204,9 +1230,12 @@ RunResult Session::generate(const GenerateRequest & req,
             // range the rollback used to carve out. What it saves is (n_draft - n_acc) positions
             // through the MTP block — and that block routes experts of its own, so on a streamed
             // device the saving is flash reads, not just arithmetic.
+            const auto p0 = clock_t_::now();
             batch_fill(im.mtp_batch, verify_toks.data(), 1 + n_acc, n_past, /*all_logits*/ false);
             if (!common_speculative_process(im.mtp.get(), im.mtp_batch))
                 return fail("MTP draft context failed to process the verify batch");
+            draft_s += secs(p0, clock_t_::now());
+            im.mtp_draft_seconds += draft_s;
 
             // Drop the rejected tail from the target; the bounded-rollback snapshots asked for at
             // context creation are what make this a restore rather than a replay. The draft context
@@ -1241,6 +1270,9 @@ RunResult Session::generate(const GenerateRequest & req,
             m.steps = req.n_predict;
             m.mtp_batch = (int) confirmed.size();
             m.loop_overhead_ms = e == 0 ? overhead * 1000.0 : 0.0;
+            // Charged to the group's first row like every other group cost. This is a SLICE of
+            // loop_overhead_ms, not an addition to it: both measure time outside the decode.
+            m.mtp_draft_ms = e == 0 ? draft_s * 1000.0 : 0.0;
             m.piece = delta;
             // Only when someone will read it: the parser cannot resume, so this re-parses everything
             // generated so far on every token, and off the chat path it is a full copy of the same.
@@ -1330,6 +1362,7 @@ RunResult Session::generate(const GenerateRequest & req,
     s.mtp_drafted = im.mtp_drafted - mtp0_drafted;
     s.mtp_accepted = im.mtp_accepted - mtp0_accepted;
     s.mtp_decodes = im.mtp_decodes - mtp0_decodes;
+    s.mtp_draft_s_per_token = n_gen > 0 ? (im.mtp_draft_seconds - mtp0_draft_s) / n_gen : 0.0;
     if (moe.predict_log) {
         // Session totals, not a per-generation delta: these are an accuracy estimate, and every
         // turn's routings are equally valid samples of it. See RunSummary.

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -44,10 +44,10 @@ public:
                      r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync, r.dense_weights.c_str(),
                      (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
         std::fprintf(f_,
-                     "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d mtp=%d "
-                     "mtp_draft_max=%d mtp_p_min=%.4g\n",
-                     (double) r.temp, r.top_k, (double) r.top_p, r.seed, r.compute_trace_layers, r.mtp, r.mtp_draft_max,
-                     (double) r.mtp_p_min);
+                     "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d spec=%s "
+                     "spec_draft_max=%d mtp_p_min=%.4g ngram_min_match=%d\n",
+                     (double) r.temp, r.top_k, (double) r.top_p, r.seed, r.compute_trace_layers, r.spec.c_str(),
+                     r.spec_draft_max, (double) r.mtp_p_min, r.ngram_min_match);
         write_header();
     }
 
@@ -74,15 +74,16 @@ public:
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
                      "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
                      "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f "
-                     "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld mtp_draft_s/tok=%.4f\n",
+                     "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld mtp_draft_s/tok=%.4f "
+                     "drafted_steps=%lld\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
                      s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
                      s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped,
-                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes,
-                     s.mtp_draft_s_per_token);
+                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes, s.mtp_draft_s_per_token,
+                     s.drafted_steps);
         std::fflush(f_);
     }
 

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -43,8 +43,11 @@ public:
                      r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave, r.prefetch_layers,
                      r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync, r.dense_weights.c_str(),
                      (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
-        std::fprintf(f_, "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d\n", (double) r.temp, r.top_k,
-                     (double) r.top_p, r.seed, r.compute_trace_layers);
+        std::fprintf(f_,
+                     "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d mtp=%d "
+                     "mtp_draft_max=%d\n",
+                     (double) r.temp, r.top_k, (double) r.top_p, r.seed, r.compute_trace_layers, r.mtp,
+                     r.mtp_draft_max);
         write_header();
     }
 
@@ -52,12 +55,12 @@ public:
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f\n",
+                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f,%d\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms,
                      m.dense_resident_frac, m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib,
                      m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib,
-                     m.loop_overhead_ms);
+                     m.loop_overhead_ms, m.mtp_batch);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -70,14 +73,15 @@ public:
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
                      "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
-                     "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f\n",
+                     "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f "
+                     "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
                      s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
                      s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped,
-                     s.loop_overhead_s_per_token);
+                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes);
         std::fflush(f_);
     }
 
@@ -93,7 +97,8 @@ private:
         // then the memory block. Consumers read columns by name, so order is not a contract.
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
                          "dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,"
-                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms\n");
+                         "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,"
+                         "mtp_batch\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -45,9 +45,9 @@ public:
                      (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
         std::fprintf(f_,
                      "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d mtp=%d "
-                     "mtp_draft_max=%d\n",
-                     (double) r.temp, r.top_k, (double) r.top_p, r.seed, r.compute_trace_layers, r.mtp,
-                     r.mtp_draft_max);
+                     "mtp_draft_max=%d mtp_p_min=%.4g\n",
+                     (double) r.temp, r.top_k, (double) r.top_p, r.seed, r.compute_trace_layers, r.mtp, r.mtp_draft_max,
+                     (double) r.mtp_p_min);
         write_header();
     }
 
@@ -55,12 +55,12 @@ public:
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f,%d\n",
+                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f,%d,%.3f\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms,
                      m.dense_resident_frac, m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib,
                      m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib,
-                     m.loop_overhead_ms, m.mtp_batch);
+                     m.loop_overhead_ms, m.mtp_batch, m.mtp_draft_ms);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -74,14 +74,15 @@ public:
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
                      "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
                      "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f "
-                     "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld\n",
+                     "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld mtp_draft_s/tok=%.4f\n",
                      s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
                      s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
                      s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
                      s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped,
-                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes);
+                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes,
+                     s.mtp_draft_s_per_token);
         std::fflush(f_);
     }
 
@@ -98,7 +99,7 @@ private:
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
                          "dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,"
                          "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,"
-                         "mtp_batch\n");
+                         "mtp_batch,mtp_draft_ms\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ for the idea the project is built on.
 | [cache-sizing.md](cache-sizing.md) | `--cache-mb auto`, the cache ceiling, and dense warm-up. |
 | [prefetch.md](prefetch.md) | `--prefetch K`: the design and why it cannot change output (with the lossy knobs off). |
 | [expert-dropping.md](expert-dropping.md) | `--drop-cold-experts F`: spending quality only where it buys a flash read, and why it is the one setting whose output is not reproducible. |
+| [mtp.md](mtp.md) | `--mtp`: drafting with the model's own MTP head and verifying a whole group per decode — lossless by construction, and why a wider decode can lose in the streamed regime. |
 | [expert-prediction.md](expert-prediction.md) | `--predict-log`: how much of a routing can be known a layer early, measured against the predictor `--prefetch` already bets on — and why a good score still would not mean a faster decode. |
 | [android-memory.md](android-memory.md) | What reclaims the engine's memory on a phone, which levers exist (almost none), and why the cache hit rate is what the kernel judges you by. |
 | [pressure.md](pressure.md) | Cache policy under memory pressure: why an unaffordable budget starts a reclaim war, why the adaptive governor was retired, and what the fixed `--cache-mb` / `--dense-weights` levers do. |

--- a/docs/mtp.md
+++ b/docs/mtp.md
@@ -1,0 +1,224 @@
+# MTP decoding (`--mtp`)
+
+`--mtp` lets the model draft its own continuation with the multi-token-prediction (MTP) head
+trained into the gguf, then verifies every drafted token in a single wider decode. Off by default.
+
+Unlike [turbo top-k](../README.md#trading-quality-for-speed) and
+[expert dropping](expert-dropping.md), this one is **not** a quality trade: a draft is accepted only
+when it equals the target model's own argmax at that position, so nothing is approximated and no
+weight is skipped. The quality is the full model's.
+
+## It is exact, but it is not bit-reproducible
+
+Read that claim precisely, because it is weaker than the one the rest of this engine makes.
+
+`--overlap`, `--prefetch` and the whole streaming path are **byte-identical**: they change how
+weights reach the CPU and nothing else, and the [gates](../tests/moe_gates.cpp) prove the streamed
+output equals the resident one exactly. `--mtp` is not in that class. Verification evaluates
+`1 + N` positions in a single batch, and a batched matmul is not bit-identical to `N` separate
+single-token matmuls — different blocking, different summation order, different last bits. On a
+near-tie between two candidate tokens, that is enough to flip the argmax. The accepted sequence is
+always exactly the argmax sequence **of the batched forward pass**; that pass is just not the same
+arithmetic as the unbatched one.
+
+Measured on Qwen3.6-35B-A3B-MXFP4, 128 greedy tokens, streamed with `--overlap --cache-mb auto`:
+
+| comparison | result |
+|---|---|
+| plain vs plain (control) | identical, 608/608 chars |
+| **plain vs plain at `--ubatch 1`, no MTP at all** | **differs, 608/612 chars** |
+| plain vs `--mtp --mtp-draft 1` | diverges at char 151 — one token |
+| plain vs `--mtp --mtp-draft 3` | diverges at char 151 — the same token |
+| `--mtp-draft 1` vs `--mtp-draft 3` | **identical** |
+
+The second row is the one that settles it, and it involves **no speculation**: `--ubatch 1` only
+forces the prompt to be prefilled one token at a time instead of in one wide pass. Same model, same
+weights, same flags otherwise — and the greedy output already changes. Batch width moves the last
+bits on this backend, full stop; speculation merely makes every decode a wide batch and inherits it.
+
+The last row rules out the other candidate. Rolling back a rejected tail has to restore recurrent
+state (Qwen3.5/3.6 is hybrid, which is why the target context is created with `n_rs_seq`), and a
+broken rollback is a real failure mode — it is what SGLang diagnosed on Ascend NPU
+([#25587](https://github.com/sgl-project/sglang/issues/25587)). But a rollback bug scales with how
+much gets rolled back: draft 1 rewinds at most one position, draft 3 up to three. Those two runs are
+byte-identical to each other, so the rollback is not what is moving the output.
+
+One token differed (`Request` → `Query`), the continuation stayed coherent, and every speculated run
+agreed with every other regardless of draft width. A logic error in the accept/rollback path would
+do neither of those things: it would vary with the draft width and compound over the generation.
+
+This is expected, not a defect of this engine, and it is documented upstream:
+
+- **llama.cpp**, in its own server README, on why prompt caching can change results: *"Because
+  (depending on the backend) the logits are **not** guaranteed to be bit-for-bit identical for
+  different batch sizes (prompt processing vs. token generation) enabling this option can cause
+  nondeterministic results."* Speculation makes every decode a wide batch, so it lands in exactly
+  that case.
+- **vLLM**, whose speculative decoding is validated by a "Greedy Sampling Equality" test, still
+  states that it is *"theoretically lossless up to the precision limits of hardware numerics"* and
+  that *"changes in batch size may cause variations in logprobs and output probabilities."*
+- The failure mode of a genuinely **broken** batched speculative implementation looks different:
+  ["Batch Speculative Decoding Done Right"](https://arxiv.org/abs/2510.22876) describes
+  desynchronised position ids, attention masks and KV state producing repetitive tokens or
+  gibberish and *near-zero* exact-match against standard decoding — not one flipped near-tie inside
+  an otherwise identical transcript. A duplicated token (`"renowned for for"`) is the classic
+  accept/rollback off-by-one; a substituted one is not.
+
+Whether it shows up at all is a property of the **backend**, not of the idea. SGLang reports MTP
+output identical to non-speculative decoding on NVIDIA, where the kernels happen to be
+batch-invariant, and divergent on Ascend NPU. On ggml's CPU path — GEMV for one token, blocked GEMM
+plus `mul_mat_id` expert grouping for several — batch invariance does not hold, as the `--ubatch 1`
+row above shows directly. Do not port the NVIDIA expectation here.
+
+So: same model, same weights, no approximation — but do not expect a `--mtp` transcript to match an
+unspeculated one character for character, and do not use it in a byte-identity gate.
+
+## Why a wider decode can be faster
+
+A decode's cost is dominated by moving weights, not by arithmetic. One token reads the dense weights
+plus its routed experts and does a handful of GEMVs against them; the hardware spends its time
+waiting for bytes. Verifying `N` positions in one decode reads those same weights **once** and turns
+the GEMVs into small GEMMs. If the draft is usually right, the engine confirms several tokens for
+roughly the cost of one.
+
+That is the same lever in both regimes this engine runs in, for different reasons:
+
+- **DRAM-bandwidth-bound** (the desktop host): the dense weights are re-read from DRAM every token,
+  and that traffic is the measured ceiling. Amortising it over a group attacks the bottleneck head-on.
+- **Flash-streamed** (a >RAM model on a phone): what binds decode is latency-to-ready of the expert
+  slices, not raw bandwidth ([the sidecar refutation](benchmarks.md)). A group pays that latency once.
+
+## Why it can lose
+
+The `N` verify positions route **independently**. Each one picks its own top-k experts, so a layer's
+read set widens from `k` toward `N × k` distinct experts wherever routing diverges across adjacent
+tokens. In the streamed regime those extra experts are extra flash reads, and they can cost more
+than the amortisation saves. The draft itself is not free either: the MTP block carries its own MoE
+FFN, so every draft pass routes through one additional expert layer.
+
+The engine therefore treats it as a measurement, not an improvement: default off, and the numbers
+below decide whether it ships enabled on a given device.
+
+## Requirements
+
+The gguf must carry the `nextn` block — and on Qwen3.6 the **ordinary quantisations already do**.
+Verified from the gguf headers: bartowski's `Q4_0` and `Q4_K_M` and unsloth's `MXFP4_MOE` are all
+`qwen35moe` with `nextn_predict_layers = 1` and the same twenty `blk.40.*` tensors (full attention,
+its own 256 routed experts, shared experts, plus `nextn.eh_proj` / `enorm` / `hnorm` /
+`shared_head_norm`). The KV blocks differ only in provenance keys. **A file named `-MTP-` buys a
+quantisation, not a head** — do not go looking for a special conversion.
+
+There is no silent-fallback case to worry about either. `llama_model_n_layer_nextn()` reads the KV
+key `nextn_predict_layers`, and llama.cpp loads the MTP tensors as *required* when it is greater than
+zero, so a gguf that kept the key but dropped the tensors would not open at all. If a model opens
+with `--mtp`, the head is genuinely there; if it has no head, the engine fails at load with a
+message rather than quietly decoding one token at a time.
+
+One consequence for measurement: **an MTP A/B must be the same file with the flag on and off.**
+Comparing an `-MTP-`-named file against a differently-quantised baseline confounds the feature with
+the quantisation change.
+
+Speculation requires greedy decoding: `validate()` rejects `--mtp` together with `--temp > 0`,
+because acceptance under a sampling chain would depend on which draws happened to agree and the run
+would no longer be the single-token run it claims to be.
+
+## How it is wired
+
+The whole draft/verify orchestration is llama.cpp's, reached through `common/speculative.h`, which
+depends only on public headers. **No llama.cpp patch, no fork, no submodule pin of our own** — the
+same rule the rest of the engine follows ([seam.md](seam.md)).
+
+Self-speculation means one model and two contexts over it:
+
+- the **target** context, created with `n_rs_seq = --mtp-draft` so a rejected tail is rewound from a
+  bounded snapshot instead of replayed;
+- the **draft** context, created with `ctx_type = LLAMA_CONTEXT_TYPE_MTP` so llama.cpp builds the
+  nextn graph, and carrying the **same eval callback** as the target — the router hook is per-context,
+  not per-model.
+
+That callback is what makes the MTP block visible to the streamer. The head lives at layer index
+`n_layer` — contiguous with the trunk, same `ffn_{gate,up,down}_exps` tensor naming, same expert
+count — so with `--mtp` on, the hook and the expert source are sized `n_layer + n_layer_nextn`
+and the head's experts are streamed, cached and dropped like any other layer's. Two things follow
+from that and are easy to get wrong:
+
+- The capture warm-up has to run on the **draft** context too. The MTP graph is only ever built by a
+  decode there, so a warm-up on the target alone never harvests the head's expert tensors, and they
+  would stay mmap-resident — the fault storm streaming exists to avoid.
+- Prefill goes through the driver as well. The draft context's KV must reach the last prompt
+  position or the first draft is conditioned on a state that never saw the prompt.
+
+Per step the loop is: draft `--mtp-draft` tokens from the head, decode
+`[confirmed token, drafts…]` asking for logits at every position, accept the longest prefix whose
+argmax matches, let the draft context catch up on **that prefix**, roll the target's KV back over the
+rejected tail, and read the next token for free out of the logits at the first unverified position.
+
+### The catch-up runs on the accepted prefix, not the whole batch
+
+That ordering is deliberate and it is not the obvious one. The catch-up re-runs the MTP block over
+the batch so the draft context ends up holding rows conditioned on the target's own hidden states
+rather than the head's guesses, and the next draft is seeded from the row at the accepted position.
+The natural place to put it is right after the decode, on the whole verify batch — which is what
+upstream's own loop does. But that computes the rejected tail too, and the rejected tail is deleted a
+few statements later: those drafts were wrong, and nothing downstream ever reads their rows.
+
+Acceptance depends only on the target's logits, which are already in hand once the decode returns, so
+the tail never has to be submitted at all. Accepting first and handing the catch-up only
+`[confirmed token, accepted drafts…]` leaves **identical state** — the driver seeds from row
+`min(n_accepted, n_rows-1)`, which is the same row under either batch, and the surviving KV is
+exactly the range the rollback used to carve out — while skipping `n_draft − n_accepted` positions
+through the MTP block. It also removes the draft context's rollback entirely: it is never given a
+tail to drop.
+
+The saving is small on a host, where that block is one layer of arithmetic. It is not small on a
+streamed device: **the MTP block carries its own MoE FFN**, so every skipped position is a routing
+that no longer happens and a set of expert slices that no longer has to be read. At draft 3 with
+acceptance around 60%, roughly one position per group stops being computed and streamed.
+
+## Reading the numbers
+
+```
+mtp: 41/63 drafts accepted (65.1%), 2.31 tokens per verify decode (57 decodes for 132 tokens)
+```
+
+- **Acceptance** is a property of the model's trained head, not of this engine. It bounds everything
+  else: at 0% the feature is pure overhead.
+- **Tokens per verify decode** is what was actually bought — the factor the decode count fell by. It
+  is always below `1 + --mtp-draft`, and it is what `tok/s` is a function of.
+
+`token_demand_MiB` keeps its mechanical meaning but changes scope: it is the distinct expert bytes
+one **decode** routes, and under speculation a decode is a group, so the figure is the group's union
+— which is exactly the working set the cache has to stage. It is the same widening the "why it can
+lose" section describes, measured. Read it against `cache_budget_MiB` as usual, but never compare it
+across a speculated and an unspeculated run.
+
+In a CSV, `mtp_batch` says how many tokens each decode confirmed. The group's **entire** cost is
+charged to its first row and the rest carry zeros, so a group's per-token cost is that row's
+`wall_ms / mtp_batch`. Never average rows from an `mtp=1` file together with an unspeculated one.
+See [telemetry.md](telemetry.md).
+
+## Measured
+
+Desktop host (8 cores, 14.8 GB RAM, NVMe), Qwen3.6-35B-A3B-MXFP4_MOE (20.7 GiB, ~1.4× RAM), streamed,
+greedy, 256 tokens, one prompt, single session. This host is
+[DRAM-bandwidth-bound](benchmarks.md), which is the regime the amortisation targets.
+
+With the host's measured best recipe (`--overlap --cache-mb auto --drop-cold-experts 0.75`):
+
+| draft width | tok/s | vs off | acceptance | tokens / verify decode | flash MiB/token |
+|---|---|---|---|---|---|
+| off | 7.12 | — | — | 1.00 | 19.7 |
+| `--mtp-draft 2` | 7.66 | +7.6% | 71.4% | 2.42 | 30.3 |
+| **`--mtp-draft 3`** | **8.19** | **+15.1%** | 60.1% | 2.78 | 33.7 |
+| `--mtp-draft 4` | 7.64 | +7.3% | 52.4% | 3.08 | 31.1 |
+
+Without the lossy drop knob (`--overlap --cache-mb auto`, 128 tokens), the gain is larger — 4.28 →
+5.52 tok/s, **+29%** at draft 3 — because dropping had already removed some of the compute the
+amortisation is buying back.
+
+Two things to read off the table. First, **acceptance falls as the draft widens** while tokens per
+decode still rises, and the two effects cross: 3 is the optimum here, 4 is worse than 2. Second, the
+widening is real and visible — flash bytes per token rise from 19.7 to 33.7 MiB because the verify
+positions route independently. It still wins because compute per token falls further (0.115 →
+0.088 s) than the extra I/O costs on this host. **On a flash-I/O-bound device that balance can
+invert**, which is why the flag ships off and the phone A/B is a separate measurement.

--- a/docs/mtp.md
+++ b/docs/mtp.md
@@ -233,6 +233,11 @@ mtp: 41/63 drafts accepted (65.1%), 2.31 tokens per verify decode (57 decodes fo
   time alone and drafting happens *between* decodes, so the headline rate leaves out everything
   speculation adds. `mtp_draft_s/tok` in the CSV trailer and `mtp_draft_ms` per row measure it
   directly, instead of leaving it to be inferred by differencing against an unspeculated run.
+- **The flash split**, on the third line, says how much of the run's streamed MiB the head's own
+  routing pulled and how much was the widened verify batch. Speculation grows bytes per token for
+  two unrelated reasons and they need opposite fixes: a narrower draft attacks the head's share,
+  while the verify union only shrinks if adjacent positions agree more. The route trace cannot
+  separate them — it brackets the target decode, and the head only ever runs in the draft context.
 
 `token_demand_MiB` keeps its mechanical meaning but changes scope: it is the distinct expert bytes
 one **decode** routes, and under speculation a decode is a group, so the figure is the group's union

--- a/docs/mtp.md
+++ b/docs/mtp.md
@@ -118,6 +118,50 @@ One consequence for measurement: **an MTP A/B must be the same file with the fla
 Comparing an `-MTP-`-named file against a differently-quantised baseline confounds the feature with
 the quantisation change.
 
+## On device it loses, and the counters say why
+
+Measured on the test phone (12 GB), Qwen3.6-35B-A3B-Q4_K_M streamed with the shipping recipe
+(`--overlap`, 3000 MiB cache, pinned dense, `--drop-cold-experts 0.75`), same file with the flag on
+and off:
+
+| | tok/s | MiB/token | majflt/token | cpu-s/token | cache hit | acceptance |
+|---|---|---|---|---|---|---|
+| off | 5.82 / 6.14 | 69.3 | 69–109 | 0.43–0.45 | 73.5% | — |
+| `--mtp-draft 2` | 5.59 | 93.8 | 230 | 0.57 | 65.4% | 69% |
+| `--mtp-draft 3` | 4.38 | 106.6 | 633 | 0.74 | 66.7% | 52% |
+
+Speculation is working — 2.35–2.52 tokens per verify decode — and still losing, because **the prize
+does not exist in this regime**. `stall_s/tok` is 0.025–0.027 in every one of those runs, MTP on or
+off: 11–16% of the token. This configuration is compute-bound, and what MTP amortises is weight
+*movement*. Meanwhile all three costs are real and monotonic in the draft width: the read set widens
+(+35%, +54% flash bytes per token), the draft context's memory tips the device into a fault storm
+(major faults per token 3–9×), and the drafting itself adds CPU (+28%, +67%).
+
+Two mitigations came out of that measurement and are in the engine now. The draft context's graph
+width was cut from 256 to 32, because compute buffers are reserved for the widest ubatch and the
+output buffer scales with `ubatch × vocabulary` — 493 MiB reserved on device for a context that
+evaluates one token at a time. And `--mtp-p-min` makes the draft width adaptive. Neither changes the
+regime: the honest expectation is nearer break-even, not a win.
+
+The two `off` runs did byte-identical work and still differ by 5.6% in tok/s, so treat that as the
+noise floor: draft 2 is at its edge, draft 3 is well outside it. The runs were also back-to-back
+without thermal gating, so the *mechanism* counters are the trustworthy part, not the exact deltas.
+
+## Stopping early when the head is unsure (`--mtp-p-min`)
+
+The draft loop already knows how confident the head is in each token it proposes. `--mtp-p-min F`
+stops drafting as soon as that confidence falls below `F`; at the default `0` it never stops and
+always drafts the full width.
+
+On a streamed device this pays twice, which is why it is the cheapest lever available: a draft not
+made is a pass through the MTP block — with its own MoE FFN, and therefore its own expert reads —
+that never happens, **and** one fewer position in the verify batch, so one fewer independent routing
+widening the layer's read set. A draft that is made and then rejected costs both and buys nothing,
+and at draft 3 above roughly half of them were rejected.
+
+It is a knob rather than a default because the useful value is a property of the device's balance
+between drafting cost and acceptance, and 0 is what the host numbers were measured at.
+
 Speculation requires greedy decoding: `validate()` rejects `--mtp` together with `--temp > 0`,
 because acceptance under a sampling chain would depend on which draws happened to agree and the run
 would no longer be the single-token run it claims to be.
@@ -184,7 +228,11 @@ mtp: 41/63 drafts accepted (65.1%), 2.31 tokens per verify decode (57 decodes fo
 - **Acceptance** is a property of the model's trained head, not of this engine. It bounds everything
   else: at 0% the feature is pure overhead.
 - **Tokens per verify decode** is what was actually bought — the factor the decode count fell by. It
-  is always below `1 + --mtp-draft`, and it is what `tok/s` is a function of.
+  is always below `1 + --mtp-draft`.
+- **The effective rate**, on the second line, is the one to believe. `tok/s` is computed from decode
+  time alone and drafting happens *between* decodes, so the headline rate leaves out everything
+  speculation adds. `mtp_draft_s/tok` in the CSV trailer and `mtp_draft_ms` per row measure it
+  directly, instead of leaving it to be inferred by differencing against an unspeculated run.
 
 `token_demand_MiB` keeps its mechanical meaning but changes scope: it is the distinct expert bytes
 one **decode** routes, and under speculation a decode is a group, so the figure is the group's union

--- a/docs/mtp.md
+++ b/docs/mtp.md
@@ -27,9 +27,9 @@ Measured on Qwen3.6-35B-A3B-MXFP4, 128 greedy tokens, streamed with `--overlap -
 |---|---|
 | plain vs plain (control) | identical, 608/608 chars |
 | **plain vs plain at `--ubatch 1`, no MTP at all** | **differs, 608/612 chars** |
-| plain vs `--mtp --mtp-draft 1` | diverges at char 151 — one token |
-| plain vs `--mtp --mtp-draft 3` | diverges at char 151 — the same token |
-| `--mtp-draft 1` vs `--mtp-draft 3` | **identical** |
+| plain vs `--mtp --draft 1` | diverges at char 151 — one token |
+| plain vs `--mtp --draft 3` | diverges at char 151 — the same token |
+| `--draft 1` vs `--draft 3` | **identical** |
 
 The second row is the one that settles it, and it involves **no speculation**: `--ubatch 1` only
 forces the prompt to be prefilled one token at a time instead of in one wide pass. Same model, same
@@ -127,8 +127,8 @@ and off:
 | | tok/s | MiB/token | majflt/token | cpu-s/token | cache hit | acceptance |
 |---|---|---|---|---|---|---|
 | off | 5.82 / 6.14 | 69.3 | 69–109 | 0.43–0.45 | 73.5% | — |
-| `--mtp-draft 2` | 5.59 | 93.8 | 230 | 0.57 | 65.4% | 69% |
-| `--mtp-draft 3` | 4.38 | 106.6 | 633 | 0.74 | 66.7% | 52% |
+| `--draft 2` | 5.59 | 93.8 | 230 | 0.57 | 65.4% | 69% |
+| `--draft 3` | 4.38 | 106.6 | 633 | 0.74 | 66.7% | 52% |
 
 Speculation is working — 2.35–2.52 tokens per verify decode — and still losing, because **the prize
 does not exist in this regime**. `stall_s/tok` is 0.025–0.027 in every one of those runs, MTP on or
@@ -174,7 +174,7 @@ same rule the rest of the engine follows ([seam.md](seam.md)).
 
 Self-speculation means one model and two contexts over it:
 
-- the **target** context, created with `n_rs_seq = --mtp-draft` so a rejected tail is rewound from a
+- the **target** context, created with `n_rs_seq = --draft` so a rejected tail is rewound from a
   bounded snapshot instead of replayed;
 - the **draft** context, created with `ctx_type = LLAMA_CONTEXT_TYPE_MTP` so llama.cpp builds the
   nextn graph, and carrying the **same eval callback** as the target — the router hook is per-context,
@@ -192,7 +192,7 @@ from that and are easy to get wrong:
 - Prefill goes through the driver as well. The draft context's KV must reach the last prompt
   position or the first draft is conditioned on a state that never saw the prompt.
 
-Per step the loop is: draft `--mtp-draft` tokens from the head, decode
+Per step the loop is: draft `--draft` tokens from the head, decode
 `[confirmed token, drafts…]` asking for logits at every position, accept the longest prefix whose
 argmax matches, let the draft context catch up on **that prefix**, roll the target's KV back over the
 rejected tail, and read the next token for free out of the logits at the first unverified position.
@@ -228,7 +228,7 @@ mtp: 41/63 drafts accepted (65.1%), 2.31 tokens per verify decode (57 decodes fo
 - **Acceptance** is a property of the model's trained head, not of this engine. It bounds everything
   else: at 0% the feature is pure overhead.
 - **Tokens per verify decode** is what was actually bought — the factor the decode count fell by. It
-  is always below `1 + --mtp-draft`.
+  is always below `1 + --draft`.
 - **The effective rate**, on the second line, is the one to believe. `tok/s` is computed from decode
   time alone and drafting happens *between* decodes, so the headline rate leaves out everything
   speculation adds. `mtp_draft_s/tok` in the CSV trailer and `mtp_draft_ms` per row measure it
@@ -261,9 +261,9 @@ With the host's measured best recipe (`--overlap --cache-mb auto --drop-cold-exp
 | draft width | tok/s | vs off | acceptance | tokens / verify decode | flash MiB/token |
 |---|---|---|---|---|---|
 | off | 7.12 | — | — | 1.00 | 19.7 |
-| `--mtp-draft 2` | 7.66 | +7.6% | 71.4% | 2.42 | 30.3 |
-| **`--mtp-draft 3`** | **8.19** | **+15.1%** | 60.1% | 2.78 | 33.7 |
-| `--mtp-draft 4` | 7.64 | +7.3% | 52.4% | 3.08 | 31.1 |
+| `--draft 2` | 7.66 | +7.6% | 71.4% | 2.42 | 30.3 |
+| **`--draft 3`** | **8.19** | **+15.1%** | 60.1% | 2.78 | 33.7 |
+| `--draft 4` | 7.64 | +7.3% | 52.4% | 3.08 | 31.1 |
 
 Without the lossy drop knob (`--overlap --cache-mb auto`, 128 tokens), the gain is larger — 4.28 →
 5.52 tok/s, **+29%** at draft 3 — because dropping had already removed some of the compute the

--- a/docs/ngram.md
+++ b/docs/ngram.md
@@ -1,0 +1,266 @@
+# N-gram decoding (`--ngram`)
+
+`--ngram` is the second draft source for the same self-speculative loop [`--mtp`](mtp.md) drives. It
+drafts by **looking the recent tokens up in the text**: take the last few tokens, find where that
+exact run occurred before — in the prompt or in what has been generated — and propose whatever
+followed it. No head, no draft context, no decode, no expert read. Off by default.
+
+Like `--mtp` it is not a quality trade. A draft is accepted only where it equals the target's own
+argmax, so nothing is approximated and no weight is skipped. It inherits the same caveat about
+bit-reproducibility, for the same reason — the verify batch, not the source — so read
+[mtp.md's "It is exact, but it is not bit-reproducible"](mtp.md#it-is-exact-but-it-is-not-bit-reproducible)
+as written for both, and never put either in a byte-identity gate.
+
+**Verdict up front: it does not win, on either platform, and it ships off.** It holds its floor on
+free prose and lands below baseline on a copy-heavy prompt — on the host by 4%, where `--mtp` gains
+15%; on device by 29%, where `--mtp` loses 18%. Acceptance, not drafting cost, is what pays for a
+widened verify batch, and on device the speculative loop's rollback snapshots cost memory that no
+choice of draft source avoids. The [host](#measured-it-holds-the-floor-and-it-does-not-win) and
+[device](#on-device-it-loses-too-and-one-new-cost-shows-up) measurements are the point of the page;
+what follows first is the mechanism that makes them readable.
+
+## Why this source exists
+
+Not because drafting was expensive. Because of what the flash split measured when we went looking
+for *where* MTP's cost actually was.
+
+On the desktop host, Qwen3.6-35B-A3B-MXFP4 streamed at `--draft 3`, the counter added for exactly
+this question ([telemetry.md](telemetry.md)) said:
+
+```
+mtp: of 30826.3 MiB streamed, 909.0 MiB (2.9%) was the head's own routing,
+     29917.3 MiB the widened verify batch
+```
+
+**The head's own routing was 2.9% of the extra bytes. The other 97.1% was the widened verify
+batch** — the `N` verify positions routing independently, which every draft source pays and no
+choice of source can avoid.
+
+So a cheaper draft producer, by itself, is worth almost nothing. What made this one worth building is
+a different property, and it is the only one that matters here:
+
+> **The n-gram source can decline to draft, at zero cost. The head cannot.**
+
+Below its match threshold it returns nothing, the verify batch is never widened, and the step is
+*exactly* a plain single-token decode — same batch, same single logits row, no rollback. The head has
+already spent a pass through the MTP block by the time it knows how unsure it is; `--mtp-p-min` can
+stop the *next* draft but not refund that one.
+
+That changes the shape of the bet. MTP is a wager on every token: pay the widening, hope acceptance
+covers it. The n-gram source pays only where the text is repeating — code being edited, a quotation
+from the context, structured output — and elsewhere costs nothing. Its ceiling is bounded by how
+often that happens, which is why `drafted_steps` is reported next to everything else.
+
+That was the hypothesis. **The measurement below refutes the useful half of it**: the floor is real
+per step, but the steps that *do* draft turned out to be net-negative on this engine, so the run can
+land below baseline anyway. The section is kept as written because the reasoning is what the counters
+supported at the time, and because the refutation is only legible against it.
+
+It also removes what the device A/B blamed for the fault storm: MTP's draft context reserved memory
+the expert cache would otherwise have had (measured on the host: the auto budget fell from 3219 to
+2697 MiB and the hit rate from 82.5% to 71.6%). The n-gram source allocates nothing.
+
+## How it drafts
+
+`core/include/bmoe/ngram_draft.h` — a pure function over token ids, no llama.cpp at all (see
+[seam.md](seam.md)).
+
+The corpus is the prompt plus everything generated so far, plus the token just confirmed; the pattern
+is its suffix. Every position strictly before the corpus end is a candidate match end, so the pattern
+is never matched against itself. For each, the longest common suffix is measured, capped at
+`ngram_max_match`. **The longest match wins; among equal lengths the most recent one does** — recency
+is what a code edit or a repeated quotation wants. A match may overlap the pattern, which is how a run
+of one repeated token predicts itself. Then the tokens that followed that match become the draft, up
+to `--draft` of them, clipped at the corpus end.
+
+If the best match is shorter than `--ngram-min-match`, it drafts nothing. That is the gate.
+
+Cost is one backward scan with an early exit, `O(corpus × ngram_max_match)` on a corpus bounded by
+`n_ctx` — microseconds, and measured: `mtp_draft_s/tok` reads `0.0000` on every run below. There is no
+incremental index to keep in step with the KV cache, which is deliberate; the corpus vector the loop
+already maintains for the head is the whole data structure.
+
+`tests/ngram_test.cpp` pins the selection rules — tie-breaks, clipping, the self-match exclusion, the
+gate boundary — deterministically, with no model.
+
+## Flags
+
+| flag | meaning |
+|---|---|
+| `--ngram` | draft by prompt lookup (mutually exclusive with `--mtp`) |
+| `--draft N` | tokens drafted per verify batch (default 3, max 8) — shared with `--mtp` |
+| `--ngram-min-match N` | shortest run of matching tokens allowed to draft (default 3) |
+
+`--ngram-min-match` is the knob that trades coverage for precision. At 3, free prose rarely matches —
+which is the point: the floor holds and prose runs stay on the baseline. Lower it for coverage on
+text that repeats loosely, raise it for fewer and better drafts.
+
+Unlike `--mtp` there is **no model requirement**: it drafts from the text, not from the weights, so it
+runs on any gguf. Verified on Qwen3-30B-A3B, which has no `nextn` block and which `--mtp` refuses to
+open at all.
+
+## Reading the numbers
+
+```
+ngram: 42/95 drafts accepted (44.2%), 1.20 tokens per verify decode (214 decodes for 256 tokens)
+ngram: drafting costs 0.0000 s/token on top of decode → 5.24 tok/s effective (vs 5.24 reported)
+ngram: drafted on 32 of 214 steps (15.0%); the rest decoded plainly
+```
+
+The first two lines mean what they mean under [`--mtp`](mtp.md#reading-the-numbers), and the effective
+rate on the second is still the one to believe.
+
+The third line is this source's own, and it is what makes a result interpretable. **The steps that did
+not draft ran at exactly the unspeculated cost**, so the same delta over baseline says something quite
+different at 10% coverage than at 90%. It cuts both ways, and in practice it cut the wrong way here: a
+4% loss at 15% coverage is not a small effect, it is a large per-drafted-step loss diluted by the 85%
+of steps that abstained. Divide by the coverage before believing a delta is small. Also in the CSV as
+`drafted_steps=` against `mtp_decodes=`.
+
+There is no flash-split line: the n-gram source reads no weights, so its share is zero by construction
+rather than by measurement.
+
+## Measured: it holds the floor, and it does not win
+
+Desktop host (8 cores, 14.8 GB RAM, NVMe), Qwen3.6-35B-A3B-MXFP4 (20.7 GiB, ~1.4× RAM) streamed with
+`--overlap --cache-mb auto --drop-cold-experts 0.75`, greedy, 256 tokens, `-c 4096`. All cells
+back-to-back in one session, `off` run twice as the noise floor. **Effective** tok/s includes drafting;
+it is the one to read.
+
+One confound to read these with, because `--cache-mb auto` sizes to free RAM at load and this host's
+free RAM moves between runs: the auto budget landed at 4411 MiB on the first prose cell and
+5659–6016 on the other three, which is most of why that prose pair spreads 5.80 to 6.59 — a 13.6%
+noise band on identical work. The copy-heavy cells all sized within 6195–6883 MiB, so that group is
+the one to argue from, and it is where the verdict comes from. Never compare a cell here against a
+number measured on another day.
+
+Free prose ("Explain how a solid-state drive stores data, and why it wears out."):
+
+| cell | tok/s | effective | MiB/token | hit | acceptance | tok/verify | drafted steps |
+|---|---|---|---|---|---|---|---|
+| off | 5.80 | 5.80 | 46.0 | 88.2% | — | 1.00 | — |
+| off (repeat) | 6.59 | 6.59 | 34.5 | 90.6% | — | 1.00 | — |
+| `--mtp --draft 3` | 8.80 | **7.32** | 42.2 | 88.6% | 60.4% | 2.81 | 100% |
+| `--ngram --draft 3` | 6.51 | **6.51** | 32.3 | 91.6% | 22.2% | 1.05 | **7.4%** |
+
+Copy-heavy (a C file in the prompt, "repeat it unchanged, adding a comment above each function"):
+
+| cell | tok/s | effective | MiB/token | hit | acceptance | tok/verify | drafted steps |
+|---|---|---|---|---|---|---|---|
+| off | 5.45 | 5.45 | 58.1 | 81.1% | — | 1.00 | — |
+| off (repeat) | 5.65 | 5.65 | 48.0 | 83.0% | — | 1.00 | — |
+| `--mtp --draft 3` | 7.40 | **6.43** | 65.5 | 75.6% | 82.4% | 3.46 | 100% |
+| `--ngram --draft 3` | 5.24 | **5.24** | 67.2 | 80.5% | 44.2% | 1.20 | **15.0%** |
+
+Qwen3-30B-A3B-Q4_K_M, which has **no `nextn` block** and which `--mtp` refuses to open, same
+copy-heavy prompt: off 8.84 tok/s at 44.0 MiB/token, `--ngram --draft 3` 8.52 at 58.2, coverage 8.2%,
+acceptance 41.1%. The capability is real — this source speculates where the head cannot — but it does
+not pay here either.
+
+Read three things off this.
+
+**The zero-cost claim holds exactly.** `mtp_draft_s/tok` is `0.0000` in every n-gram cell; reported
+and effective rates are the same number. The head costs 0.020–0.023 s/token, and needs a draft
+context that on this host took ~500 MiB of expert cache with it.
+
+**The floor holds per step, not per run.** On prose the run lands at 6.51 against a 5.80/6.59 noise
+band — inside it, as designed, because 92.6% of steps drafted nothing and ran as plain decodes. But
+on the copy prompt it lands at 5.24, *below* a 5.45/5.65 floor. The 15% of steps that did draft
+widened the read set (67.2 MiB/token against 48–58 at baseline) and, at 44% acceptance, bought
+1.20 tokens per decode — not enough to earn the widening back. A step that abstains costs exactly
+baseline; a step that drafts badly costs more than baseline, and a modest fraction of those is enough
+to sink the run.
+
+**Acceptance is what pays for the widening, and a trained head has it.** On the same prompt where
+n-gram accepted 44% and lost, the MTP head accepted 82% and gained 15%. Both paid the same kind of
+cost; only one bought enough with it. That is the honest summary of this feature: cheap drafting was
+never the constraint, which the 3% flash split had already said. What the head buys is not a cheaper
+guess — it is a guess right often enough to justify a batch that has already been widened.
+
+### The gate is not the fix, and the sweep says why
+
+`--ngram-min-match` does exactly what it is supposed to — and it does not rescue the result. Same
+copy-heavy prompt, same session:
+
+| cell | tok/s | MiB/token | acceptance | drafted steps | tok/verify |
+|---|---|---|---|---|---|
+| `--draft 3 --ngram-min-match 3` (defaults) | 5.24 | 67.2 | 44.2% | 15.0% | 1.20 |
+| `--draft 3 --ngram-min-match 5` | 5.31 | 71.1 | 71.8% | 5.7% | 1.12 |
+| `--draft 3 --ngram-min-match 8` | 5.49 | 66.1 | 75.0% | 3.4% | 1.08 |
+| `--draft 1 --ngram-min-match 5` | **5.56** | 59.7 | **82.6%** | 9.7% | 1.08 |
+| off | 5.45 / 5.65 | 58.1 / 48.0 | — | — | 1.00 |
+
+Precision improves exactly as designed: 44% → 75% acceptance as the gate tightens, and narrowing the
+draft to 1 — which is the smallest widening a speculated step can have — reaches **82.6%**, matching
+what the trained head managed on this prompt. But coverage collapses alongside it, and **every cell
+climbs toward baseline from below without crossing it.** The best n-gram configuration found is the
+one that speculates least, and it lands on the floor rather than above it.
+
+Read the two together and the conclusion is sharper than "it did not win": on this workload a drafting
+step is net-negative or at best neutral, so tightening the knob only reduces how much of the run is
+exposed to it, and the limit of that process is `--ngram` off. A knob whose optimum is its own
+disablement is not a tuning problem.
+
+The reason is the same one, seen from a third direction. Even at 82.6% acceptance a drafted step
+bought only 1.08 tokens per decode: a match rare enough to be trustworthy carries one or two tokens of
+evidence, while the batch it widens pays the full independent routing of every position in it. The
+head's advantage was never accuracy alone — it is accuracy *sustained across every step*, which is
+what turns 1 + N positions into 2.8–3.5 confirmed tokens instead of 1.1.
+
+`--ngram` therefore ships **off**, like `--mtp`. It is kept for three reasons and no others: it is the
+only speculation available on a model with no head; the per-step floor is real and now also protects
+`--mtp-p-min`; and the counters it added (`drafted_steps`, the zero-cost drafting measurement) are what
+make any future speculation claim on this engine falsifiable.
+
+### On device it loses too, and one new cost shows up
+
+Test phone (12 GB), Qwen3.6-35B-A3B-Q4_K_M streamed with the shipping recipe (`--overlap`, 3000 MiB
+cache, pinned dense, `--drop-cold-experts 0.75`), 4 threads, 256 greedy tokens. Unlike the earlier MTP
+device run, these cells are **thermally gated**: each waits 120 s for the SoC heat to soak into the
+battery sensor and then for the reading to come back under 36.0 °C, so every cell starts between 35.3
+and 36.4 °C instead of wherever the previous one left the device.
+
+| cell | tok/s | effective | MiB/token | hit | majflt/token | acceptance | drafted steps |
+|---|---|---|---|---|---|---|---|
+| prose off | 5.17 | 5.17 | 82.5 | 80.9% | 299 | — | — |
+| prose off (repeat) | 4.59 | 4.59 | 82.5 | 80.9% | 480 | — | — |
+| prose `--ngram --draft 3` | 4.90 | **4.90** | 105.8 | 77.1% | 330 | 22.2% | 4.8% |
+| copy off | 4.43 | 4.43 | 127.0 | 67.6% | 126 | — | — |
+| copy `--mtp --draft 3` | 4.15 | **3.64** | 151.7 | 58.6% | 958 | 74.3% | 100% |
+| copy `--ngram --draft 3` | 3.14 | **3.14** | 145.1 | 65.3% | 1427 | 50.0% | 14.2% |
+
+**MTP loses again, now with the thermal confound removed** — 3.64 effective against 4.43, at 74.3%
+acceptance and 3.20 tokens per verify decode. The earlier verdict was not an artefact of benching
+without a cooldown gate.
+
+**The flash split reproduces on device**: of 38832 MiB streamed at draft 3, 1446 (**3.7%**) was the
+head's own routing and 96.3% the widened verify batch. Host said 2.9–3.0%. The claim that drafting
+cost was never the constraint now holds on both platforms.
+
+**n-gram holds the floor on prose and loses badly on the copy prompt.** Prose lands at 4.90 inside a
+4.59–5.17 band, as on the host. The copy cell is −29%, worse than MTP — and the counter that explains
+it is one the host never showed: **major faults per token go 126 → 1427**, an 11× fault storm on a
+source that allocates no draft context at all.
+
+That is the rollback snapshots. `cparams.n_rs_seq = draft_max` is asked for by *any* speculation,
+because rejecting a draft means rewinding the KV, and on a hybrid attention/SSM model like Qwen3.6
+a recurrent-state snapshot is a real allocation that scales with the context. So the n-gram source
+avoids MTP's draft *context* but not the speculative loop's own memory, and on device that memory is
+the expert cache's. Prose, with a 16-token prompt, barely notices (majflt 330 against 299/480); the
+copy prompt, with 224 tokens of context to snapshot, storms.
+
+Two honest caveats on the exact deltas. The copy `--ngram` cell had to be re-run on its own after a
+Wi-Fi change killed it mid-generation, so it ran last, hottest (36.3 °C) and after the longest
+sustained load of the session. And the two `off` prose cells did byte-identical work — same 82.5
+MiB/token, same 80.9% hit — yet differ by 12.7% in tok/s, the difference tracking their major-fault
+counts (299 against 480). At this thermal state the band is wide. **The mechanism counters are the
+trustworthy part here, not the third decimal of a delta**: coverage, acceptance, bytes per token and
+the fault counts all say the same thing, and they say it on both platforms.
+
+## What this does not fix
+
+The widened verify batch. It is 97.1% of what speculation costs in bytes on this engine, and it is a
+property of `N` positions routing independently — the same for every source. `--ngram` avoids paying
+it *when it abstains*; it pays it in full whenever it drafts, and at a lower acceptance than a trained
+head. Anything that attacks the widening itself — making adjacent positions agree on their routing,
+or reordering the union — is a different piece of work and is not this one.

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -120,6 +120,13 @@ structurally and cannot. Both facts come from the loaded model, never from its n
 
 ### Speculative decoding
 
+Only the MTP source crosses into `common`. The verify half of the loop — the wide batch, the argmax
+acceptance, the KV rollback — is written against public `llama.h` alone, and so is the n-gram draft
+source, which is why `--ngram` needs nothing from `common` at all. `core/include/bmoe/ngram_draft.h`
+does not even include `llama.h`: it is written over `int32_t` token ids, which is what `llama_token`
+is, so the drafting policy stays on the pure-policy side of the seam and is unit-tested with no model
+and no native backend (`tests/ngram_test.cpp`). See [ngram.md](ngram.md).
+
 `--mtp` reaches `common/speculative.h`, which is a header of the same `common` library and
 includes only `llama.h` and `common.h`. The draft/verify orchestration — running the trained MTP
 head, moving hidden states from the target to it, seeding the next draft from the accepted position

--- a/docs/seam.md
+++ b/docs/seam.md
@@ -93,7 +93,8 @@ point is public, not a divergence we intend to maintain.
 ## The chat glue: llama.cpp `common` (not the streaming seam)
 
 Separate from the two streaming hooks above, `session.cpp` links llama.cpp's `common`
-library for one thing: rendering the model's own chat template and parsing reasoning output.
+library for two things: rendering the model's own chat template and parsing reasoning output, and
+(with `--mtp`) driving speculative decoding.
 `common_chat_templates_init` / `common_chat_templates_apply` run the real Jinja template the
 gguf ships (so Gemma's channel format, Qwen ChatML, etc. all format correctly, driven by the
 model rather than hardcoded), and `common_chat_parse` extracts a reasoning model's thinking so
@@ -116,6 +117,25 @@ Whether the continuation is *binding* is read off `common_chat_params::thinking_
 suggestion it can decline (LFM2.5 does), while a model that declares none separates reasoning
 structurally and cannot. Both facts come from the loaded model, never from its name.
 `tests/think_control_test.cpp` pins all of it against the vendored templates, again with no model.
+
+### Speculative decoding
+
+`--mtp` reaches `common/speculative.h`, which is a header of the same `common` library and
+includes only `llama.h` and `common.h`. The draft/verify orchestration — running the trained MTP
+head, moving hidden states from the target to it, seeding the next draft from the accepted position
+— is entirely upstream's; the engine supplies the loop around it and the two contexts it works on.
+Worth stating explicitly because the internals it needs (`llama_set_embeddings_nextn` and the
+`nextn` hidden-state getters) live in `src/llama-ext.h`, a *staging* header: they are used **inside**
+`speculative.cpp`, which is already compiled into the `llama-common` the engine links, so nothing in
+`core/` includes a private header and no in-tree patch is involved.
+
+What the engine does own is the pair of contexts. Self-speculation is one model with two contexts
+over it — the target, and a draft created with `ctx_type = LLAMA_CONTEXT_TYPE_MTP` — and the engine
+builds the draft one itself rather than through `common_speculative_init_from_params`, for a reason
+that belongs to this project: **the eval callback is per-context**. The streamer only sees the MTP
+block's expert layer if the draft context carries the same `cb_eval`, and `init_from_params` derives
+its context parameters from a full `common_params` with no way to inject one. See
+[mtp.md](mtp.md).
 
 Unlike the public-C-API streaming seam, `common` is **not a stable API** — it can change
 between upstream versions. So a submodule bump may require updating this chat glue in

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -119,15 +119,17 @@ with a `[stale-gate]` tag — same counters, different predictor (see
 [expert-prediction.md](expert-prediction.md)). The CSV preamble records which was active
 (`prefetch=` / `predict_prefetch=`).
 
-With `--mtp` a `mtp:` line is added:
+With `--mtp` or `--ngram` a summary line is added, prefixed with the source that drafted:
 
 ```
-mtp: <accepted>/<drafted> drafts accepted (<pct>%), <t> tokens per verify decode (<d> decodes for <n> tokens)
+mtp:   <accepted>/<drafted> drafts accepted (<pct>%), <t> tokens per verify decode (<d> decodes for <n> tokens)
+ngram: <accepted>/<drafted> drafts accepted (<pct>%), <t> tokens per verify decode (<d> decodes for <n> tokens)
 ```
 
-Acceptance is what decides whether speculation can pay at all — it is a property of the model's
-trained head, not of this engine. Tokens per verify decode is what it actually bought: it is the
-factor the decode count fell by. It is always below `1 + --mtp-draft`.
+Acceptance is what decides whether speculation can pay at all — for `--mtp` it is a property of the
+model's trained head, for `--ngram` a property of how repetitive the text is. Tokens per verify
+decode is what it actually bought: it is the factor the decode count fell by. It is always below
+`1 + --draft`.
 
 A second line reports what that cost:
 
@@ -139,6 +141,17 @@ mtp: drafting costs <s> s/token on top of decode → <t> tok/s effective (vs <t>
 alone, and drafting happens *between* decodes, so the headline rate does not include it. The
 effective rate does. On a run where speculation is not paying, the two can differ by tens of
 percent. See [mtp.md](mtp.md).
+
+With `--ngram` a third line reports coverage:
+
+```
+ngram: drafted on <d> of <n> steps (<pct>%); the rest decoded plainly
+```
+
+The n-gram source drafts only when it finds a confident match, and a step that drafts nothing costs
+exactly a plain decode. So this percentage is what a result *means*: the same small delta over
+baseline says something quite different at 10% coverage than at 90%. Also in the CSV trailer as
+`drafted_steps=`, against `mtp_decodes=`. See [ngram.md](ngram.md).
 
 With `--drop-cold-experts F` a `moe-drop:` line is added:
 
@@ -191,7 +204,8 @@ prints just the summary lines.
   force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1> overlap=<0|1> io_two_wave=<0|1> prefetch=<n>
   predict_prefetch=<0|1> predict_log=<0|1> predict_spec_max=<n> prefetch_sync=<0|1>
   dense_weights=<mmap|warm|anon|ahwb> drop_cold_frac=<f> drop_renorm=<0|1> drop_prefill=<0|1>
-# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n> mtp=<0|1> mtp_draft_max=<n> mtp_p_min=<f>
+# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n> spec=<off|mtp|ngram>
+  spec_draft_max=<n> mtp_p_min=<f> ngram_min_match=<n>
 ```
 
 Rows without this are not evidence: two files answer "which is faster" only if something says what
@@ -221,8 +235,8 @@ effective top-k after any override. Fields to read carefully:
   No weight is skipped and nothing is approximated, but the text is **not** guaranteed identical to
   an unspeculated greedy run: a verify decode is a wide batch, and batch width moves the last bits on
   this backend, so a near-tie can flip (see [mtp.md](mtp.md)). The per-token *accounting* differs
-  too: see `mtp_batch` below. Never average rows from an `mtp=1` file together with rows from an
-  `mtp=0` one.
+  too: see `mtp_batch` below. Never average rows from a `spec=mtp` or `spec=ngram` file together with
+  rows from a `spec=off` one, nor two speculated files from different sources.
 
 `think` is deliberately absent: it is a property of a *request*, not of the session, so one value in
 a session-wide preamble would be wrong for every turn that asked for the other. Per-turn facts belong
@@ -250,10 +264,12 @@ floor to defend; see [pressure.md](pressure.md)), `experts_routed=<n>` / `expert
 threshold, not a rate, so this is the only record of the trade a run made) and
 `layer_demand_MiB=<f>` (the widest layer's routed
 bytes: the mechanical floor the cache must be able to stage) and `loop_overhead_s/tok=<s>` (see
-[below](#what-toks-does-not-include)) and, under `--mtp`, `mtp_drafted=<n>` /
+[below](#what-toks-does-not-include)) and, under `--mtp` or `--ngram`, `mtp_drafted=<n>` /
 `mtp_accepted=<n>` / `mtp_decodes=<n>` (the acceptance rate and how many decodes the generation
 actually cost — `tokens / mtp_decodes` is the amortisation achieved) and `mtp_draft_s/tok=<s>` (what
-that amortisation cost outside the decode, which `s/tok` and `tok/s` both exclude); see the `io_ms`
+that amortisation cost outside the decode, which `s/tok` and `tok/s` both exclude) and
+`drafted_steps=<n>` (how many steps drafted at all — below `mtp_decodes` only for `--ngram`, which
+abstains); see the `io_ms`
 note above for how the read-time columns are reinterpreted under overlap.
 
 The trailing block is the memory picture, added so a run can be diagnosed from its own file:
@@ -270,8 +286,8 @@ The trailing block is the memory picture, added so a run can be diagnosed from i
 | `rss_mib` | total resident (`VmRSS`). |
 | `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |
 | `loop_overhead_ms` | wall time between the **previous** token's decode and this one's: sampling, detokenization, rendering the answer for a UI, and the sink writes. On the first token, the gap from the end of prefill to the first decode. |
-| `mtp_batch` | how many tokens the decode that produced this row confirmed. `1` without `--mtp`. A verify decode confirms a whole group and its **entire** cost — `wall_ms`, `io_ms`, `majflt`, `cpu_ms`, `read_bytes`, `loop_overhead_ms` — is charged to the group's FIRST row; the rest carry zeros. Without this column those zeros read as free tokens. Per-token cost of a group is the first row's `wall_ms / mtp_batch`. |
-| `mtp_draft_ms` | time this group spent drafting and catching the draft context up — everything speculation adds **outside** the decode. A slice of `loop_overhead_ms`, not an addition to it. `0` without `--mtp`. This is the column that makes the price of speculation measurable instead of inferable: `wall_ms` never contained it, and neither does `tok/s`. |
+| `mtp_batch` | how many tokens the decode that produced this row confirmed. `1` without speculation. A verify decode confirms a whole group and its **entire** cost — `wall_ms`, `io_ms`, `majflt`, `cpu_ms`, `read_bytes`, `loop_overhead_ms` — is charged to the group's FIRST row; the rest carry zeros. Without this column those zeros read as free tokens. Per-token cost of a group is the first row's `wall_ms / mtp_batch`. |
+| `mtp_draft_ms` | time this group spent drafting and catching the draft context up — everything speculation adds **outside** the decode. A slice of `loop_overhead_ms`, not an addition to it. `0` without speculation, and near-zero under `--ngram`, whose drafting is a scan of the token history rather than a decode. This is the column that makes the price of speculation measurable instead of inferable: `wall_ms` never contained it, and neither does `tok/s`. |
 
 All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split).
 
@@ -407,17 +423,19 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
             "stall_s_tok":<float>,"mgmt_s_tok":<float>,"majflt_tok":<float>,"cpu_s_tok":<float>,
             "token_demand_mib":<float>,"mtp_drafted":<int>,"mtp_accepted":<int>,"mtp_decodes":<int>,
-            "mtp_draft_s_tok":<float>,"loop_overhead_s_tok":<float>,
+            "mtp_draft_s_tok":<float>,"drafted_steps":<int>,"loop_overhead_s_tok":<float>,
             "reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
 
-`BMOE_DONE`'s `mtp_*` keys are the self-speculation counters (all `0` without `--mtp`):
-`mtp_accepted / mtp_drafted` is the head's acceptance on that turn, and `tokens / mtp_decodes` is
-the amortisation the turn actually achieved. `mtp_draft_s_tok` is what the drafting cost, and
-`loop_overhead_s_tok` the whole between-decode gap it lives in — `tok_s` excludes both, so
-`1 / (1/tok_s + loop_overhead_s_tok)` is the rate a user actually experiences. See
-[mtp.md](mtp.md).
+`BMOE_DONE`'s `mtp_*` keys are the self-speculation counters (all `0` without speculation, and the
+same keys whichever source drafted): `mtp_accepted / mtp_drafted` is the acceptance on that turn,
+and `tokens / mtp_decodes` is the amortisation the turn actually achieved. `mtp_draft_s_tok` is what
+the drafting cost, and `loop_overhead_s_tok` the whole between-decode gap it lives in — `tok_s`
+excludes both, so `1 / (1/tok_s + loop_overhead_s_tok)` is the rate a user actually experiences.
+`drafted_steps` is how many passes drafted at all: it equals `mtp_decodes` for the head and is lower
+for `--ngram`, which decodes plainly when it has no match. See [mtp.md](mtp.md) and
+[ngram.md](ngram.md).
 
 `BMOE_READY`'s `n_expert_used` is the **effective** routing width, after any `--n-expert-used`
 override (`0` on a non-MoE model). A UI needs it to say anything sensible about

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -119,6 +119,17 @@ with a `[stale-gate]` tag — same counters, different predictor (see
 [expert-prediction.md](expert-prediction.md)). The CSV preamble records which was active
 (`prefetch=` / `predict_prefetch=`).
 
+With `--mtp` a `mtp:` line is added:
+
+```
+mtp: <accepted>/<drafted> drafts accepted (<pct>%), <t> tokens per verify decode (<d> decodes for <n> tokens)
+```
+
+Acceptance is what decides whether speculation can pay at all — it is a property of the model's
+trained head, not of this engine. Tokens per verify decode is what it actually bought: it is the
+factor the decode count fell by, and so the factor `tok/s` rose by, minus the drafting cost. It is
+always below `1 + --mtp-draft`. See [mtp.md](mtp.md).
+
 With `--drop-cold-experts F` a `moe-drop:` line is added:
 
 ```
@@ -170,7 +181,7 @@ prints just the summary lines.
   force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1> overlap=<0|1> io_two_wave=<0|1> prefetch=<n>
   predict_prefetch=<0|1> predict_log=<0|1> predict_spec_max=<n> prefetch_sync=<0|1>
   dense_weights=<mmap|warm|anon|ahwb> drop_cold_frac=<f> drop_renorm=<0|1> drop_prefill=<0|1>
-# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n>
+# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n> mtp=<0|1> mtp_draft_max=<n>
 ```
 
 Rows without this are not evidence: two files answer "which is faster" only if something says what
@@ -196,6 +207,12 @@ effective top-k after any override. Fields to read carefully:
   not reproducible except through `seed`.
 - `load_all=1` reads the whole expert set, so its `read_bytes` means something different from a
   selective run's.
+- `mtp=1` means the run used the model's MTP head to draft and verified a whole group per decode.
+  No weight is skipped and nothing is approximated, but the text is **not** guaranteed identical to
+  an unspeculated greedy run: a verify decode is a wide batch, and batch width moves the last bits on
+  this backend, so a near-tie can flip (see [mtp.md](mtp.md)). The per-token *accounting* differs
+  too: see `mtp_batch` below. Never average rows from an `mtp=1` file together with rows from an
+  `mtp=0` one.
 
 `think` is deliberately absent: it is a property of a *request*, not of the session, so one value in
 a session-wide preamble would be wrong for every turn that asked for the other. Per-turn facts belong
@@ -206,7 +223,7 @@ next to the `turn` column.
 ```
 step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,
 dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,
-mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms
+mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,mtp_batch
 ```
 
 `stall_ms`, `mgmt_ms`, `majflt`, `cpu_ms` and `dense_resident_frac` are trailing columns appended
@@ -223,8 +240,10 @@ floor to defend; see [pressure.md](pressure.md)), `experts_routed=<n>` / `expert
 threshold, not a rate, so this is the only record of the trade a run made) and
 `layer_demand_MiB=<f>` (the widest layer's routed
 bytes: the mechanical floor the cache must be able to stage) and `loop_overhead_s/tok=<s>` (see
-[below](#what-toks-does-not-include)); see the `io_ms` note above for how the
-read-time columns are reinterpreted under overlap.
+[below](#what-toks-does-not-include)) and, under `--mtp`, `mtp_drafted=<n>` /
+`mtp_accepted=<n>` / `mtp_decodes=<n>` (the acceptance rate and how many decodes the generation
+actually cost — `tokens / mtp_decodes` is the amortisation achieved); see the `io_ms` note above for
+how the read-time columns are reinterpreted under overlap.
 
 The trailing block is the memory picture, added so a run can be diagnosed from its own file:
 
@@ -240,6 +259,7 @@ The trailing block is the memory picture, added so a run can be diagnosed from i
 | `rss_mib` | total resident (`VmRSS`). |
 | `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |
 | `loop_overhead_ms` | wall time between the **previous** token's decode and this one's: sampling, detokenization, rendering the answer for a UI, and the sink writes. On the first token, the gap from the end of prefill to the first decode. |
+| `mtp_batch` | how many tokens the decode that produced this row confirmed. `1` without `--mtp`. A verify decode confirms a whole group and its **entire** cost — `wall_ms`, `io_ms`, `majflt`, `cpu_ms`, `read_bytes`, `loop_overhead_ms` — is charged to the group's FIRST row; the rest carry zeros. Without this column those zeros read as free tokens. Per-token cost of a group is the first row's `wall_ms / mtp_batch`. |
 
 All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split).
 
@@ -374,9 +394,15 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "n_prompt":<int>,"n_past":<int>,"compute_s_tok":<float>,"io_s_tok":<float>,
             "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
             "stall_s_tok":<float>,"mgmt_s_tok":<float>,"majflt_tok":<float>,"cpu_s_tok":<float>,
-            "token_demand_mib":<float>,"reasoning":"<string>","text":"<string>"}
+            "token_demand_mib":<float>,"mtp_drafted":<int>,"mtp_accepted":<int>,"mtp_decodes":<int>,
+            "reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
+
+`BMOE_DONE`'s `mtp_*` keys are the self-speculation counters (all `0` without `--mtp`):
+`mtp_accepted / mtp_drafted` is the head's acceptance on that turn, and `tokens / mtp_decodes` is
+the amortisation the turn actually achieved. See
+[mtp.md](mtp.md).
 
 `BMOE_READY`'s `n_expert_used` is the **effective** routing width, after any `--n-expert-used`
 override (`0` on a non-MoE model). A UI needs it to say anything sensible about

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -127,8 +127,18 @@ mtp: <accepted>/<drafted> drafts accepted (<pct>%), <t> tokens per verify decode
 
 Acceptance is what decides whether speculation can pay at all — it is a property of the model's
 trained head, not of this engine. Tokens per verify decode is what it actually bought: it is the
-factor the decode count fell by, and so the factor `tok/s` rose by, minus the drafting cost. It is
-always below `1 + --mtp-draft`. See [mtp.md](mtp.md).
+factor the decode count fell by. It is always below `1 + --mtp-draft`.
+
+A second line reports what that cost:
+
+```
+mtp: drafting costs <s> s/token on top of decode → <t> tok/s effective (vs <t> reported)
+```
+
+**Read this one before believing a speculated run is faster.** `tok/s` is computed from decode time
+alone, and drafting happens *between* decodes, so the headline rate does not include it. The
+effective rate does. On a run where speculation is not paying, the two can differ by tens of
+percent. See [mtp.md](mtp.md).
 
 With `--drop-cold-experts F` a `moe-drop:` line is added:
 
@@ -181,7 +191,7 @@ prints just the summary lines.
   force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1> overlap=<0|1> io_two_wave=<0|1> prefetch=<n>
   predict_prefetch=<0|1> predict_log=<0|1> predict_spec_max=<n> prefetch_sync=<0|1>
   dense_weights=<mmap|warm|anon|ahwb> drop_cold_frac=<f> drop_renorm=<0|1> drop_prefill=<0|1>
-# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n> mtp=<0|1> mtp_draft_max=<n>
+# temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n> mtp=<0|1> mtp_draft_max=<n> mtp_p_min=<f>
 ```
 
 Rows without this are not evidence: two files answer "which is faster" only if something says what
@@ -223,7 +233,7 @@ next to the `turn` column.
 ```
 step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,
 dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,
-mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,mtp_batch
+mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,mtp_batch,mtp_draft_ms
 ```
 
 `stall_ms`, `mgmt_ms`, `majflt`, `cpu_ms` and `dense_resident_frac` are trailing columns appended
@@ -242,8 +252,9 @@ threshold, not a rate, so this is the only record of the trade a run made) and
 bytes: the mechanical floor the cache must be able to stage) and `loop_overhead_s/tok=<s>` (see
 [below](#what-toks-does-not-include)) and, under `--mtp`, `mtp_drafted=<n>` /
 `mtp_accepted=<n>` / `mtp_decodes=<n>` (the acceptance rate and how many decodes the generation
-actually cost — `tokens / mtp_decodes` is the amortisation achieved); see the `io_ms` note above for
-how the read-time columns are reinterpreted under overlap.
+actually cost — `tokens / mtp_decodes` is the amortisation achieved) and `mtp_draft_s/tok=<s>` (what
+that amortisation cost outside the decode, which `s/tok` and `tok/s` both exclude); see the `io_ms`
+note above for how the read-time columns are reinterpreted under overlap.
 
 The trailing block is the memory picture, added so a run can be diagnosed from its own file:
 
@@ -260,6 +271,7 @@ The trailing block is the memory picture, added so a run can be diagnosed from i
 | `mem_available_mib` / `mem_free_mib` / `swap_free_mib` | what the device claims about itself. `MemAvailable` counts this process's own mmap'd weights as reclaimable, so it over-states headroom — it is recorded next to what we measured ourselves because the gap between them is the story. |
 | `loop_overhead_ms` | wall time between the **previous** token's decode and this one's: sampling, detokenization, rendering the answer for a UI, and the sink writes. On the first token, the gap from the end of prefill to the first decode. |
 | `mtp_batch` | how many tokens the decode that produced this row confirmed. `1` without `--mtp`. A verify decode confirms a whole group and its **entire** cost — `wall_ms`, `io_ms`, `majflt`, `cpu_ms`, `read_bytes`, `loop_overhead_ms` — is charged to the group's FIRST row; the rest carry zeros. Without this column those zeros read as free tokens. Per-token cost of a group is the first row's `wall_ms / mtp_batch`. |
+| `mtp_draft_ms` | time this group spent drafting and catching the draft context up — everything speculation adds **outside** the decode. A slice of `loop_overhead_ms`, not an addition to it. `0` without `--mtp`. This is the column that makes the price of speculation measurable instead of inferable: `wall_ms` never contained it, and neither does `tok/s`. |
 
 All are `0` where the platform cannot report them (the Windows host build reports device memory but not the per-process split).
 
@@ -395,13 +407,16 @@ BMOE_DONE  {"id":<int>,"cancelled":<bool>,"tokens":<int>,"tok_s":<float>,
             "cache_resident_mib":<float>,"cache_budget_mib":<float>,"read_mib":<float>,
             "stall_s_tok":<float>,"mgmt_s_tok":<float>,"majflt_tok":<float>,"cpu_s_tok":<float>,
             "token_demand_mib":<float>,"mtp_drafted":<int>,"mtp_accepted":<int>,"mtp_decodes":<int>,
+            "mtp_draft_s_tok":<float>,"loop_overhead_s_tok":<float>,
             "reasoning":"<string>","text":"<string>"}
 BMOE_ERROR {"id":<int>,"fatal":<bool>,"msg":"<string>"}
 ```
 
 `BMOE_DONE`'s `mtp_*` keys are the self-speculation counters (all `0` without `--mtp`):
 `mtp_accepted / mtp_drafted` is the head's acceptance on that turn, and `tokens / mtp_decodes` is
-the amortisation the turn actually achieved. See
+the amortisation the turn actually achieved. `mtp_draft_s_tok` is what the drafting cost, and
+`loop_overhead_s_tok` the whole between-decode gap it lives in — `tok_s` excludes both, so
+`1 / (1/tok_s + loop_overhead_s_tok)` is the rate a user actually experiences. See
 [mtp.md](mtp.md).
 
 `BMOE_READY`'s `n_expert_used` is the **effective** routing width, after any `--n-expert-used`

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -58,11 +58,13 @@ check). Nothing below needs a storage permission except the last option.
 2. **Any other model** — under **Other model**, paste a direct gguf URL (e.g. a Hugging Face
    `…/resolve/main/model.gguf` link), or pick a `.gguf` already on the device to import it.
 
-   You do **not** need a special file for the **MTP decoding** setting: the catalog's Qwen3.6
-   entry already carries the `nextn` block the MTP head lives in, as do Qwen3.6's ordinary
+   You do **not** need a special file for **Guess ahead → Model's own head (MTP)**: the catalog's
+   Qwen3.6 entry already carries the `nextn` block the MTP head lives in, as do Qwen3.6's ordinary
    quantisations generally. A gguf named `-MTP-` is the same head at a different quantisation.
    On a model with no head — anything that is not Qwen3.5/3.6 — the engine refuses to open rather
    than silently decoding one token at a time, so a wrong file fails immediately and says why.
+   **Guess ahead → Repeated text (n-gram)** has no such requirement: it guesses from the text
+   rather than from the weights, so it works on every model in the catalog.
 
    In-app downloads and picker imports both land in the app's internal storage (`filesDir`, a
    real f2fs/ext4 volume), so the streamed expert reads use O_DIRECT at full speed. Only models

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -58,6 +58,12 @@ check). Nothing below needs a storage permission except the last option.
 2. **Any other model** — under **Other model**, paste a direct gguf URL (e.g. a Hugging Face
    `…/resolve/main/model.gguf` link), or pick a `.gguf` already on the device to import it.
 
+   You do **not** need a special file for the **MTP decoding** setting: the catalog's Qwen3.6
+   entry already carries the `nextn` block the MTP head lives in, as do Qwen3.6's ordinary
+   quantisations generally. A gguf named `-MTP-` is the same head at a different quantisation.
+   On a model with no head — anything that is not Qwen3.5/3.6 — the engine refuses to open rather
+   than silently decoding one token at a time, so a wrong file fails immediately and says why.
+
    In-app downloads and picker imports both land in the app's internal storage (`filesDir`, a
    real f2fs/ext4 volume), so the streamed expert reads use O_DIRECT at full speed. Only models
    read from the emulated external dirs (adb-pushed to `/sdcard/Download`) fall back to buffered

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -60,8 +60,16 @@ data class AppSettings(
     // lands is the measurement this toggle exists to make.
     val mtp: Boolean = false,
     // Tokens drafted per verify pass. 3 is the measured optimum on desktop: acceptance falls as the
-    // draft widens, and past the head's horizon the extra drafts are paid for and thrown away.
+    // draft widens, and past the head's horizon the extra drafts are paid for and thrown away. On
+    // this phone the device A/B measured 2 better than 3 and both below the baseline, which is why
+    // the confidence floor below exists.
     val mtpDraft: Int = 3,
+    // Stop drafting when the head's own probability for what it is proposing drops below this
+    // percentage (0 = never stop, draft the full width however unsure it is). Makes the width
+    // adaptive per step, which on this device pays twice: a draft not made is one fewer pass
+    // through the MTP block AND one fewer independently routed position in the verify batch. 0 is
+    // the setting the desktop numbers were measured at, so it stays the default until the A/B says.
+    val mtpPMinPct: Int = 0,
     val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
     val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
 ) {
@@ -135,7 +143,10 @@ data class AppSettings(
         // Outside the streaming block on purpose: MTP is a decode-loop change, not a residency
         // policy, so it applies to the mmap baseline too — which is what makes an A/B of the two
         // against each other meaningful.
-        if (mtp) a += listOf("--mtp", "--mtp-draft", mtpDraft.toString())
+        if (mtp) {
+            a += listOf("--mtp", "--mtp-draft", mtpDraft.toString())
+            if (mtpPMinPct > 0) a += listOf("--mtp-p-min", (mtpPMinPct / 100.0).toString())
+        }
         return a
     }
 
@@ -148,7 +159,7 @@ data class AppSettings(
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, sessionCtx, oDirect,
                overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct,
-               mtp, mtpDraft)
+               mtp, mtpDraft, mtpPMinPct)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -165,7 +176,7 @@ data class AppSettings(
             .putInt("predictSpecMax", predictSpecMax)
             .putInt("dropColdPct", dropColdPct)
             .putInt("sessionCtx", sessionCtx)
-            .putBoolean("mtp", mtp).putInt("mtpDraft", mtpDraft)
+            .putBoolean("mtp", mtp).putInt("mtpDraft", mtpDraft).putInt("mtpPMinPct", mtpPMinPct)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
             .apply()
@@ -201,6 +212,10 @@ data class AppSettings(
         // falls as the draft widens while tokens-per-decode rises, and on desktop the two cross at
         // 3 — 4 measured WORSE than 2. Stopping at 5 keeps the picker honest about that.
         val MTP_DRAFT_CHOICES = intArrayOf(1, 2, 3, 4, 5)
+
+        // Confidence floors worth offering, as percentages. 0 keeps the current behaviour (draft
+        // the full width unconditionally); the rest trade speculative reach for wasted drafts.
+        val MTP_P_MIN_CHOICES = intArrayOf(0, 40, 60, 80)
 
         /**
          * A fresh CSV path for a session about to open, under the app's own external files dir —
@@ -291,6 +306,7 @@ data class AppSettings(
                 sessionCtx = p.getInt("sessionCtx", d.sessionCtx),
                 mtp = p.getBoolean("mtp", d.mtp),
                 mtpDraft = p.getInt("mtpDraft", d.mtpDraft),
+                mtpPMinPct = p.getInt("mtpPMinPct", d.mtpPMinPct),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -51,18 +51,28 @@ data class AppSettings(
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
     val dropColdPct: Int = 75,
-    // Self-speculation through the model's own MTP head. Needs a gguf carrying the nextn block,
-    // which Qwen3.5/3.6 do in their ordinary quantisations — the catalog's Qwen3.6 included, so no
-    // special "-MTP-" download. On anything else the engine refuses to open with it on, so the UI
-    // states the requirement rather than letting the session fail. Off by default:
-    // it is a clear win where decode is DRAM-bound (desktop, +15%), but on a phone decode is
-    // flash-bound and the wider verify batch widens each layer's expert read set — which way that
-    // lands is the measurement this toggle exists to make.
-    val mtp: Boolean = false,
-    // Tokens drafted per verify pass. 3 is the measured optimum on desktop: acceptance falls as the
-    // draft widens, and past the head's horizon the extra drafts are paid for and thrown away. On
-    // this phone the device A/B measured 2 better than 3 and both below the baseline, which is why
-    // the confidence floor below exists.
+    // Which source drafts for self-speculation: "off", "mtp" or "ngram". Both verify the same way —
+    // one wider decode, greedy acceptance — and differ only in what a draft costs.
+    //
+    // "mtp" uses the model's own head, so it needs a gguf carrying the nextn block, which Qwen3.5/3.6
+    // do in their ordinary quantisations — the catalog's Qwen3.6 included, so no special "-MTP-"
+    // download. On anything else the engine refuses to open, so the UI states the requirement rather
+    // than letting the session fail.
+    //
+    // "ngram" drafts by looking the recent tokens up in the prompt and in what has been generated:
+    // no head, no draft context, no expert read, and it works on every model. It also drafts nothing
+    // when it has no confident match, so a step without one costs exactly a plain decode — the
+    // property the head does not have.
+    //
+    // Off by default. The head is a clear win where decode is DRAM-bound (desktop, +15%) and lost on
+    // this phone at every draft width; the lookup exists because the measured reason for that loss
+    // was the widened verify batch, not the drafting — which is what this toggle now lets an A/B
+    // separate.
+    val spec: String = SPEC_OFF,
+    // Tokens drafted per verify pass, shared by both sources. 3 is the measured optimum for the head
+    // on desktop: acceptance falls as the draft widens, and past its horizon the extra drafts are
+    // paid for and thrown away. On this phone the device A/B measured 2 better than 3 and both below
+    // the baseline, which is why the confidence floor below exists.
     val mtpDraft: Int = 3,
     // Stop drafting when the head's own probability for what it is proposing drops below this
     // percentage (0 = never stop, draft the full width however unsure it is). Makes the width
@@ -140,12 +150,14 @@ data class AppSettings(
             // of the uniform share; the setting is stored as a percentage.
             if (dropColdPct > 0 && cacheOn) a += listOf("--drop-cold-experts", (dropColdPct / 100.0).toString())
         }
-        // Outside the streaming block on purpose: MTP is a decode-loop change, not a residency
-        // policy, so it applies to the mmap baseline too — which is what makes an A/B of the two
-        // against each other meaningful.
-        if (mtp) {
-            a += listOf("--mtp", "--mtp-draft", mtpDraft.toString())
+        // Outside the streaming block on purpose: speculation is a decode-loop change, not a
+        // residency policy, so it applies to the mmap baseline too — which is what makes an A/B of
+        // the two against each other meaningful.
+        if (spec == SPEC_MTP) {
+            a += listOf("--mtp", "--draft", mtpDraft.toString())
             if (mtpPMinPct > 0) a += listOf("--mtp-p-min", (mtpPMinPct / 100.0).toString())
+        } else if (spec == SPEC_NGRAM) {
+            a += listOf("--ngram", "--draft", mtpDraft.toString())
         }
         return a
     }
@@ -159,7 +171,7 @@ data class AppSettings(
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, sessionCtx, oDirect,
                overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct,
-               mtp, mtpDraft, mtpPMinPct)
+               spec, mtpDraft, mtpPMinPct)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -176,7 +188,7 @@ data class AppSettings(
             .putInt("predictSpecMax", predictSpecMax)
             .putInt("dropColdPct", dropColdPct)
             .putInt("sessionCtx", sessionCtx)
-            .putBoolean("mtp", mtp).putInt("mtpDraft", mtpDraft).putInt("mtpPMinPct", mtpPMinPct)
+            .putString("spec", spec).putInt("mtpDraft", mtpDraft).putInt("mtpPMinPct", mtpPMinPct)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
             .apply()
@@ -207,6 +219,13 @@ data class AppSettings(
         // places free to disagree. 128 matches the CLI default (issue #71): shorter budgets
         // truncate most answers mid-sentence, which reads as broken rather than slow.
         const val DEFAULT_N_PREDICT = 128
+
+        // The draft sources, as stored. Strings rather than an enum ordinal: a preference that
+        // survives an app update must not depend on the order this list happens to be written in.
+        const val SPEC_OFF = "off"
+        const val SPEC_MTP = "mtp"
+        const val SPEC_NGRAM = "ngram"
+        val SPEC_CHOICES = arrayOf(SPEC_OFF, SPEC_MTP, SPEC_NGRAM)
 
         // Draft widths worth offering. The useful range is small and not monotonic: acceptance
         // falls as the draft widens while tokens-per-decode rises, and on desktop the two cross at
@@ -304,7 +323,15 @@ data class AppSettings(
                 predictSpecMax = p.getInt("predictSpecMax", d.predictSpecMax),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
                 sessionCtx = p.getInt("sessionCtx", d.sessionCtx),
-                mtp = p.getBoolean("mtp", d.mtp),
+                spec = run {
+                    val saved = p.getString("spec", null)
+                    when {
+                        saved != null && saved in SPEC_CHOICES -> saved
+                        // Migrate the old boolean pref from an install that only had the head.
+                        p.getBoolean("mtp", false) -> SPEC_MTP
+                        else -> d.spec
+                    }
+                },
                 mtpDraft = p.getInt("mtpDraft", d.mtpDraft),
                 mtpPMinPct = p.getInt("mtpPMinPct", d.mtpPMinPct),
                 thinking = p.getBoolean("thinking", d.thinking),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -8,10 +8,10 @@ import android.content.Context
  * pair of switches, which could express the same policy two ways (or contradict each other).
  */
 enum class DenseWeights(val flag: String, val label: String, val blurb: String) {
-    MMAP("mmap", "Mmap (baseline)", "Leave the dense weights mmap'd; the kernel faults them in. Slow first tokens on a >RAM model — the A/B baseline."),
-    WARM("warm", "Warm at load", "Page-cache the dense weights once at load, so the first tokens don't fault them in a page at a time. Best when the model fits in RAM."),
-    ANON("anon", "Anon (O_DIRECT)", "Read the dense weights via O_DIRECT into our own buffers so a reclaim swaps to zram (fast) instead of a slow flash refault. Costs a private copy. The default — it wins on >RAM models."),
-    AHWB("ahwb", "Pinned (dma-buf)", "As Anon, but into dma-buf memory the kernel cannot reclaim at all — not even to zram, which is what Anon still pays for. Measured +17.9% on a long generation; the gain needs a real conversation to appear, since short turns never build up enough reclaim. Off by default: measured on one device."),
+    MMAP("mmap", "Mmap (baseline)", "Leave the always-needed weights to the kernel, which faults them in as they are touched. The plain baseline to compare the others against."),
+    WARM("warm", "Warm at load", "Read them once at load so the first tokens do not fault them in a page at a time. Suits a model that fits in memory comfortably."),
+    ANON("anon", "Anon (O_DIRECT)", "Hold them in the app's own memory instead of the file cache. When the system reclaims, they are compressed rather than dropped and re-read from flash. Costs a private copy; the default."),
+    AHWB("ahwb", "Pinned (dma-buf)", "As Anon, but in memory the system cannot reclaim at all — not even by compressing it, which Anon still pays for. The gain shows up over a long conversation, once reclaim has had time to bite."),
 }
 
 /**
@@ -51,6 +51,17 @@ data class AppSettings(
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
     val dropColdPct: Int = 75,
+    // Self-speculation through the model's own MTP head. Needs a gguf carrying the nextn block,
+    // which Qwen3.5/3.6 do in their ordinary quantisations — the catalog's Qwen3.6 included, so no
+    // special "-MTP-" download. On anything else the engine refuses to open with it on, so the UI
+    // states the requirement rather than letting the session fail. Off by default:
+    // it is a clear win where decode is DRAM-bound (desktop, +15%), but on a phone decode is
+    // flash-bound and the wider verify batch widens each layer's expert read set — which way that
+    // lands is the measurement this toggle exists to make.
+    val mtp: Boolean = false,
+    // Tokens drafted per verify pass. 3 is the measured optimum on desktop: acceptance falls as the
+    // draft widens, and past the head's horizon the extra drafts are paid for and thrown away.
+    val mtpDraft: Int = 3,
     val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
     val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
 ) {
@@ -121,6 +132,10 @@ data class AppSettings(
             // of the uniform share; the setting is stored as a percentage.
             if (dropColdPct > 0 && cacheOn) a += listOf("--drop-cold-experts", (dropColdPct / 100.0).toString())
         }
+        // Outside the streaming block on purpose: MTP is a decode-loop change, not a residency
+        // policy, so it applies to the mmap baseline too — which is what makes an A/B of the two
+        // against each other meaningful.
+        if (mtp) a += listOf("--mtp", "--mtp-draft", mtpDraft.toString())
         return a
     }
 
@@ -132,7 +147,8 @@ data class AppSettings(
      */
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, sessionCtx, oDirect,
-               overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct)
+               overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct,
+               mtp, mtpDraft)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -149,6 +165,7 @@ data class AppSettings(
             .putInt("predictSpecMax", predictSpecMax)
             .putInt("dropColdPct", dropColdPct)
             .putInt("sessionCtx", sessionCtx)
+            .putBoolean("mtp", mtp).putInt("mtpDraft", mtpDraft)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
             .apply()
@@ -179,6 +196,11 @@ data class AppSettings(
         // places free to disagree. 128 matches the CLI default (issue #71): shorter budgets
         // truncate most answers mid-sentence, which reads as broken rather than slow.
         const val DEFAULT_N_PREDICT = 128
+
+        // Draft widths worth offering. The useful range is small and not monotonic: acceptance
+        // falls as the draft widens while tokens-per-decode rises, and on desktop the two cross at
+        // 3 — 4 measured WORSE than 2. Stopping at 5 keeps the picker honest about that.
+        val MTP_DRAFT_CHOICES = intArrayOf(1, 2, 3, 4, 5)
 
         /**
          * A fresh CSV path for a session about to open, under the app's own external files dir —
@@ -267,6 +289,8 @@ data class AppSettings(
                 predictSpecMax = p.getInt("predictSpecMax", d.predictSpecMax),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
                 sessionCtx = p.getInt("sessionCtx", d.sessionCtx),
+                mtp = p.getBoolean("mtp", d.mtp),
+                mtpDraft = p.getInt("mtpDraft", d.mtpDraft),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -102,6 +102,10 @@ object ConfigFields {
         ConfigField("top_p", "sampling candidates kept by cumulative probability"),
         ConfigField("seed", "sampling seed. Inert at temperature 0; otherwise the only thing that makes a run repeatable"),
         ConfigField("compute_trace_layers", "per-layer compute tracing. It instruments the graph, so a traced run is a diagnostic rather than a benchmark"),
+        ConfigField("spec", "which source drafted for speculative decoding: off, mtp (the model's own trained head) or ngram (repeated text looked up in the prompt and the answer so far). Both verify identically, so this changes what a draft cost, not what was accepted"),
+        ConfigField("spec_draft_max", "tokens drafted per verify pass. The pass is one wider than this, and every position in it routes its own experts — which is what speculation trades for confirming several tokens at once"),
+        ConfigField("mtp_p_min", "the head stopped drafting below this confidence, making the width adaptive. 0 = always draft the full width. Applies to spec=mtp only"),
+        ConfigField("ngram_min_match", "shortest run of repeated tokens the lookup would draft from. Below it the step drafted nothing and cost exactly an unspeculated decode. Applies to spec=ngram only"),
     )
 
     private val byName = all.associateBy { it.name }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
@@ -47,6 +47,10 @@ internal class Csv(
             // legends that differ only by this used to read as identical (#136).
             if (info["predict_prefetch"] == "1") "predict" else null,
             info["drop_cold_frac"]?.takeIf { (it.toFloatOrNull() ?: 0f) > 0f }?.let { "drop $it" },
+            // Same argument, and stronger: under speculation a decode confirms a whole group, so
+            // the per-token rows are not even accounted the same way (mtp_batch). Two runs that
+            // differ by this must never read as the same kind of run.
+            info["spec"]?.takeIf { it != "off" }?.let { "$it ${info["spec_draft_max"]}" },
         ).joinToString(" · ")
     }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -264,6 +264,7 @@ class RunService : Service() {
             val mtpAccepted = o.optLong("mtp_accepted", 0)
             val mtpDecodes = o.optLong("mtp_decodes", 0)
             val mtpDraftSTok = o.optDouble("mtp_draft_s_tok", 0.0)
+            val draftedSteps = o.optLong("drafted_steps", 0)
             val loopOverheadSTok = o.optDouble("loop_overhead_s_tok", 0.0)
             // What the user actually waits: tok_s counts decode time only, so drafting — which
             // happens between decodes — is invisible to it. With MTP off the gap is ~0 and this
@@ -285,12 +286,18 @@ class RunService : Service() {
                 if (hit >= 0) append(String.format(loc, " | cache %.0f%%", hit))
                 if (cancelled) append(" | cancelled")
                 if (mtpDecodes > 0 && mtpDrafted > 0) {
-                    append(String.format(loc, "\nMTP: %d/%d guesses kept (%.0f%%), %.2f tok per pass",
+                    append(String.format(loc, "\nGuessing: %d/%d kept (%.0f%%), %.2f tok per pass",
                         mtpAccepted, mtpDrafted, 100.0 * mtpAccepted / mtpDrafted,
                         tokens.toDouble() / mtpDecodes))
                     if (mtpDraftSTok > 0) {
                         append(String.format(loc, " | guessing costs %.3fs/tok → %.2f tok/s real",
                             mtpDraftSTok, effTokS))
+                    }
+                    // Only the n-gram source ever abstains, so a coverage below every step is what
+                    // says the rest of the turn ran at the plain, unspeculated cost.
+                    if (draftedSteps in 1 until mtpDecodes) {
+                        append(String.format(loc, " | guessed on %.0f%% of passes",
+                            100.0 * draftedSteps / mtpDecodes))
                     }
                 }
             }
@@ -307,7 +314,7 @@ class RunService : Service() {
                 // show what the turn really ran at, and how often the guesses were right.
                 if (mtpDecodes > 0 && mtpDrafted > 0) {
                     if (effTokS > 0) append(String.format(loc, " · %.1f real", effTokS))
-                    append(String.format(loc, " · MTP %.0f%% kept", 100.0 * mtpAccepted / mtpDrafted))
+                    append(String.format(loc, " · %.0f%% kept", 100.0 * mtpAccepted / mtpDrafted))
                 }
                 if (cancelled) append(" · cancelled")
             }
@@ -318,6 +325,7 @@ class RunService : Service() {
                 cacheResidentMib = cacheResidentMib, cacheBudgetMib = cacheBudgetMib,
                 avgMajfltPerTok = majfltPerTok, avgCpuSPerTok = cpuSPerTok,
                 mtpDrafted = mtpDrafted, mtpAccepted = mtpAccepted, mtpDecodes = mtpDecodes,
+                draftedSteps = draftedSteps,
                 mtpDraftSPerTok = mtpDraftSTok, loopOverheadSPerTok = loopOverheadSTok,
             )
             RunBus.update {

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -257,6 +257,18 @@ class RunService : Service() {
             val cacheBudgetMib = o.optDouble("cache_budget_mib", -1.0)
             val majfltPerTok = o.optDouble("majflt_tok", -1.0)
             val cpuSPerTok = o.optDouble("cpu_s_tok", -1.0)
+            // Self-speculation. All 0 with MTP off, which is what makes them safe to read
+            // unconditionally — and reading them is the only way the UI can say whether
+            // speculation ran and what it earned.
+            val mtpDrafted = o.optLong("mtp_drafted", 0)
+            val mtpAccepted = o.optLong("mtp_accepted", 0)
+            val mtpDecodes = o.optLong("mtp_decodes", 0)
+            val mtpDraftSTok = o.optDouble("mtp_draft_s_tok", 0.0)
+            val loopOverheadSTok = o.optDouble("loop_overhead_s_tok", 0.0)
+            // What the user actually waits: tok_s counts decode time only, so drafting — which
+            // happens between decodes — is invisible to it. With MTP off the gap is ~0 and this
+            // equals tokS; with it on the two can differ by tens of percent.
+            val effTokS = if (tokS > 0) 1.0 / (1.0 / tokS + loopOverheadSTok) else -1.0
             // Time-to-first-token: the model load plus this turn's prompt prefill.
             val ttft = if (loadS >= 0 && prefill >= 0) loadS + prefill else -1.0
             val cancelled = o.optBoolean("cancelled")
@@ -272,6 +284,15 @@ class RunService : Service() {
                 if (ttft >= 0) append(String.format(loc, " | TTFT %.2fs", ttft))
                 if (hit >= 0) append(String.format(loc, " | cache %.0f%%", hit))
                 if (cancelled) append(" | cancelled")
+                if (mtpDecodes > 0 && mtpDrafted > 0) {
+                    append(String.format(loc, "\nMTP: %d/%d guesses kept (%.0f%%), %.2f tok per pass",
+                        mtpAccepted, mtpDrafted, 100.0 * mtpAccepted / mtpDrafted,
+                        tokens.toDouble() / mtpDecodes))
+                    if (mtpDraftSTok > 0) {
+                        append(String.format(loc, " | guessing costs %.3fs/tok → %.2f tok/s real",
+                            mtpDraftSTok, effTokS))
+                    }
+                }
             }
             // Compact one-line metrics shown under this turn's answer in the transcript.
             val turnMetrics = buildString {
@@ -282,6 +303,12 @@ class RunService : Service() {
                 }
                 if (nPast >= 0) append(String.format(loc, " · ctx %d/%d", nPast, sessionCtx))
                 if (hit >= 0) append(String.format(loc, " · cache %.0f%%", hit))
+                // With speculation on, the headline rate leaves out the drafting between decodes;
+                // show what the turn really ran at, and how often the guesses were right.
+                if (mtpDecodes > 0 && mtpDrafted > 0) {
+                    if (effTokS > 0) append(String.format(loc, " · %.1f real", effTokS))
+                    append(String.format(loc, " · MTP %.0f%% kept", 100.0 * mtpAccepted / mtpDrafted))
+                }
                 if (cancelled) append(" · cancelled")
             }
             val tel = telemetry.current.copy(
@@ -290,6 +317,8 @@ class RunService : Service() {
                 prefillTps = prefillTps, ttftS = ttft, readMib = readMib,
                 cacheResidentMib = cacheResidentMib, cacheBudgetMib = cacheBudgetMib,
                 avgMajfltPerTok = majfltPerTok, avgCpuSPerTok = cpuSPerTok,
+                mtpDrafted = mtpDrafted, mtpAccepted = mtpAccepted, mtpDecodes = mtpDecodes,
+                mtpDraftSPerTok = mtpDraftSTok, loopOverheadSPerTok = loopOverheadSTok,
             )
             RunBus.update {
                 val answer = if (text.isNotEmpty()) text else it.answer

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -51,7 +51,7 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 // inert (the CLI omits --moe-stream and all sub-flags), so they are disabled.
                 SwitchRow(
                     "mmap baseline (no streaming)",
-                    "Load the whole model via llama.cpp mmap — the baseline to compare against",
+                    "Load the model the ordinary way, without streaming experts. The baseline to compare against",
                     current.mmap,
                 ) { onChange(current.copy(mmap = it)) }
 
@@ -69,14 +69,13 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     enabled = stream,
                 ) { onChange(current.copy(cacheMb = it)) }
                 Text(
-                    "Larger cache = fewer flash reads per token, but more RAM — and RAM the kernel takes " +
-                        "back is paid for twice. Auto sizes to free RAM once at load, then holds. On a >RAM " +
-                        "model, off is usually the ceiling. " +
+                    "Experts already in memory cost no read at all, so a bigger cache means less waiting on " +
+                        "flash — paid for in memory the rest of the system no longer has. Auto sizes it once " +
+                        "at load from what is free, then holds that budget. " +
                         if (AppSettings.cacheNeedsForce(current.cacheMb))
-                            "500 and 1000 are below the engine's floor (--force-cache): a cache under one " +
-                                "token's routed experts can only thrash. Kept for measuring where the cache " +
-                                "stops earning its memory."
-                        else "500 and 1000 sit below the engine's floor and need --force-cache.",
+                            "The smallest rungs sit below the engine's own floor: a cache too small to hold " +
+                                "one token's experts evicts them before they are reused, and only churns."
+                        else "The smallest rungs sit below the engine's floor and have to be forced.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 IntSetting(
@@ -85,25 +84,25 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     enabled = stream && current.cacheMb == AppSettings.CACHE_AUTO,
                 ) { onChange(current.copy(cacheCeilMb = it)) }
                 Text(
-                    "Upper bound on the Auto budget at load, so it does not over-ask on devices with " +
-                        "tight free RAM (MemAvailable counts the model's own weights as free).",
+                    "Caps what Auto may claim. The system reports the model's own mapped weights as free " +
+                        "memory, so left uncapped Auto can ask for more than really exists.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 IntSetting("Parallel I/O lanes", AppSettings.IO_CHOICES, current.ioThreads, enabled = stream) {
                     onChange(current.copy(ioThreads = it))
                 }
                 Text(
-                    "Number of parallel flash-read threads for the expert stream.",
+                    "How many expert reads are in flight at once. More lanes help only until the flash itself is saturated.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 SwitchRow(
                     "Direct I/O (O_DIRECT)",
-                    "Bypass the page cache for expert reads. Falls back to buffered automatically if unsupported",
+                    "Read experts straight from flash, so the system does not keep a second copy of what the cache above already holds. Falls back automatically where unsupported",
                     current.oDirect, enabled = stream,
                 ) { onChange(current.copy(oDirect = it)) }
                 SwitchRow(
                     "I/O–compute overlap",
-                    "Read the next experts while the current layer computes, hiding read latency",
+                    "Start the next reads while the current layer is still computing, so waiting for flash happens behind the work instead of after it",
                     current.overlap, enabled = stream,
                 ) { onChange(current.copy(overlap = it)) }
                 LabeledDropdown(
@@ -124,15 +123,15 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     enabled = stream && cacheOn && !current.predictPrefetch,
                 ) { onChange(current.copy(prefetchLayers = it)) }
                 Text(
-                    "Experimental. Bets each layer will reuse the experts it picked for the previous " +
-                        "token and reads them ahead on idle lanes — right ~40% of the time. Needs the cache on.",
+                    "Experimental. Bets a layer will reuse the experts it picked for the previous token, and " +
+                        "reads them ahead on lanes that would otherwise sit idle. Needs the cache.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 SwitchRow(
                     "Predictive prefetch (experimental)",
-                    "Instead of betting on the previous token, asks the next layer's own router one " +
-                        "layer early — right ~85% of the time. Reads ahead within the budget below and " +
-                        "keeps what the prediction names. Needs the cache; replaces temporal prefetch.",
+                    "Experimental. Rather than betting on the previous token, runs the next layer's own " +
+                        "router early to ask which experts it will actually want. Reads ahead within the " +
+                        "budget below and protects what it names. Needs the cache; replaces the above.",
                     current.predictPrefetch, enabled = stream && cacheOn && current.prefetchLayers == 0,
                 ) { onChange(current.copy(predictPrefetch = it)) }
                 if (current.predictPrefetch) {
@@ -147,15 +146,41 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                         enabled = stream && cacheOn,
                     ) { onChange(current.copy(predictSpecMax = it)) }
                     Text(
-                        "How much flash the prediction may spend per layer. 0 reads nothing ahead and only " +
-                            "protects predicted experts already in RAM from eviction. Measured: reading ahead " +
-                            "lost its matched A/B — the flash has no spare bandwidth — so 0 is the honest default.",
+                        "How much reading ahead the prediction may pay for. At zero it reads nothing and only " +
+                            "keeps the experts it names from being evicted — the safe setting, since reading " +
+                            "ahead competes for the same flash the current token is waiting on.",
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
 
             Section("Speed / quality") {
+                // MTP sits at the top of this section because it is the only entry here that does
+                // NOT trade quality: it changes how many tokens a decode confirms, not what the
+                // model computes. Not gated on the streamer — it is a decode-loop change, so it
+                // applies to the mmap baseline too.
+                SwitchRow(
+                    "MTP decoding (needs an MTP model)",
+                    "Some models carry a small extra head trained to guess the next few tokens. With this " +
+                        "on the model drafts its own continuation and the engine checks the whole group in " +
+                        "one pass, keeping only what the model itself would have produced. Nothing is " +
+                        "skipped or approximated.\n\nThe gain is reading the weights once for several " +
+                        "tokens instead of once each; the cost is that checking several at a time makes " +
+                        "every layer touch more experts. Which side wins depends on whether this device " +
+                        "spends its time computing or waiting on flash.",
+                    current.mtp,
+                ) { onChange(current.copy(mtp = it)) }
+                if (current.mtp) {
+                    IntSetting(
+                        "Tokens drafted per pass", AppSettings.MTP_DRAFT_CHOICES, current.mtpDraft,
+                    ) { onChange(current.copy(mtpDraft = it)) }
+                    Text(
+                        "How far ahead the head guesses. Further means more tokens confirmed per pass, but " +
+                            "the guesses grow less reliable and a wrong one is paid for and thrown away. " +
+                            "The best setting is rarely the largest.",
+                        fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 // Active-expert (top-k) override is a load-time kv_override, valid in both streaming
                 // and mmap mode, so it is not gated on the streamer.
                 IntSetting(
@@ -168,8 +193,8 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     },
                 ) { onChange(current.copy(nExpertUsed = it)) }
                 Text(
-                    "Route fewer experts per token than the model's default. Faster and lighter on flash, " +
-                        "but the output changes — a speed/quality trade-off.",
+                    "Consult fewer experts per token than the model asks for. Cuts both the computing and " +
+                        "the reading, and changes the reply — a deliberate trade of quality for speed.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 IntSetting(
@@ -191,14 +216,12 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                         (current.cacheMb == AppSettings.CACHE_AUTO || current.cacheMb > 0),
                 ) { onChange(current.copy(dropColdPct = it)) }
                 Text(
-                    "Reading an expert that is not already in RAM is what slows a token down. This skips " +
-                        "one — but only if the router barely wanted it, below the chosen share of an even " +
-                        "split. With 8 active experts an even split is 12.5%, so 75% skips anything under " +
-                        "9.4%. Experts already in RAM always run; the strongest is never skipped.\n\n" +
-                        "50% barely fires and changes little. 75% measured +55% faster and 100% +84% on one " +
-                        "model, but the top rung discards twice as much of the routing for that extra speed." +
+                    "Waiting for an expert that is not already in memory is what slows a token down. This " +
+                        "skips one — but only when it is missing AND the router barely wanted it, below the " +
+                        "chosen share of an even split. Experts already in memory always run, and the " +
+                        "strongest is never skipped, so quality is spent only where it buys back a read." +
                         "\n\nThe reply changes, and unlike Active experts not the same way twice: what gets " +
-                        "skipped depends on what the cache happened to hold.",
+                        "skipped depends on what the cache happened to be holding.",
                     fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 // The threshold is a share of 1/top-k, so a narrow routing changes what the same
@@ -208,10 +231,9 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 val topk = ui.nExpertUsed
                 if (current.dropColdPct > 0 && topk != null && topk in 1..4) {
                     Text(
-                        "⚠ This model routes only $topk experts per token, so ${current.dropColdPct}% here " +
-                            "means \"skip below ${"%.1f".format(current.dropColdPct.toDouble() / topk)}%\" — a much " +
-                            "bigger share of the reply than the 9.4% this setting was measured at (8 experts). " +
-                            "Check the answers, or turn it off for this model.",
+                        "⚠ This model routes only $topk experts per token, so the same share covers far more " +
+                            "of the reply than it does on a model that routes many. Check the answers, or " +
+                            "turn this off for this model.",
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.error,
                     )
                 }
@@ -258,9 +280,8 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
             Section("Diagnostics") {
                 SwitchRow(
                     "Metrics CSV",
-                    "Write one CSV per session with every token's timings, page faults (count and MiB), " +
-                        "cache budget, and the memory split — anon (the expert cache), file (the model), " +
-                        "swap. Takes effect on the next session; share it from the menu",
+                    "Write one CSV per session: every token's timings, its page faults, the cache budget " +
+                        "and where memory sat. Takes effect on the next session; share it from the menu",
                     current.metricsCsv,
                 ) { onChange(current.copy(metricsCsv = it)) }
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -180,6 +180,16 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                             "The best setting is rarely the largest.",
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    IntSetting(
+                        "Guess only when confident", AppSettings.MTP_P_MIN_CHOICES, current.mtpPMinPct,
+                        format = { if (it == 0) "Always guess" else "Above $it%" },
+                    ) { onChange(current.copy(mtpPMinPct = it)) }
+                    Text(
+                        "Stop guessing as soon as the model is unsure, instead of always filling the pass. " +
+                            "A guess not made costs nothing and keeps the pass narrow, so fewer experts have " +
+                            "to be read — but it also gives up the tokens that guess might have won.",
+                        fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
                 // Active-expert (top-k) override is a load-time kv_override, valid in both streaming
                 // and mmap mode, so it is not gated on the streamer.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -155,31 +155,39 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
             }
 
             Section("Speed / quality") {
-                // MTP sits at the top of this section because it is the only entry here that does
-                // NOT trade quality: it changes how many tokens a decode confirms, not what the
+                // Speculation sits at the top of this section because it is the only entry here that
+                // does NOT trade quality: it changes how many tokens a decode confirms, not what the
                 // model computes. Not gated on the streamer — it is a decode-loop change, so it
                 // applies to the mmap baseline too.
-                SwitchRow(
-                    "MTP decoding (needs an MTP model)",
-                    "Some models carry a small extra head trained to guess the next few tokens. With this " +
-                        "on the model drafts its own continuation and the engine checks the whole group in " +
-                        "one pass, keeping only what the model itself would have produced. Nothing is " +
-                        "skipped or approximated.\n\nThe gain is reading the weights once for several " +
-                        "tokens instead of once each; the cost is that checking several at a time makes " +
-                        "every layer touch more experts. Which side wins depends on whether this device " +
-                        "spends its time computing or waiting on flash.",
-                    current.mtp,
-                ) { onChange(current.copy(mtp = it)) }
-                if (current.mtp) {
+                LabeledDropdown(
+                    "Guess ahead",
+                    listOf("Off", "Model's own head (MTP)", "Repeated text (n-gram)"),
+                    AppSettings.SPEC_CHOICES.indexOf(current.spec).coerceAtLeast(0),
+                ) { onChange(current.copy(spec = AppSettings.SPEC_CHOICES[it])) }
+                Text(
+                    "Guess the next few tokens, then check the whole group in one pass and keep only what " +
+                        "the model itself would have produced. Nothing is skipped or approximated. The gain " +
+                        "is reading the weights once for several tokens instead of once each; the cost is " +
+                        "that checking several at a time makes every layer touch more experts.\n\n" +
+                        "The head is a small extra part of the model trained to guess — accurate, but only " +
+                        "some models carry it, and running it costs a pass of its own. The n-gram guess " +
+                        "instead looks for the text repeating itself, which costs nothing at all and works " +
+                        "on every model, but only has something to say when the model is quoting or " +
+                        "editing. When it has nothing, that token runs exactly as if this were off.",
+                    fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (current.spec != AppSettings.SPEC_OFF) {
                     IntSetting(
-                        "Tokens drafted per pass", AppSettings.MTP_DRAFT_CHOICES, current.mtpDraft,
+                        "Tokens guessed per pass", AppSettings.MTP_DRAFT_CHOICES, current.mtpDraft,
                     ) { onChange(current.copy(mtpDraft = it)) }
                     Text(
-                        "How far ahead the head guesses. Further means more tokens confirmed per pass, but " +
-                            "the guesses grow less reliable and a wrong one is paid for and thrown away. " +
+                        "How far ahead to guess. Further means more tokens confirmed per pass, but the " +
+                            "guesses grow less reliable and a wrong one is paid for and thrown away. " +
                             "The best setting is rarely the largest.",
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+                if (current.spec == AppSettings.SPEC_MTP) {
                     IntSetting(
                         "Guess only when confident", AppSettings.MTP_P_MIN_CHOICES, current.mtpPMinPct,
                         format = { if (it == 0) "Always guess" else "Above $it%" },

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -46,8 +46,36 @@ data class Telemetry(
     // Run averages of the compute decomposition, from the final summary (BMOE_DONE); -1 until done.
     var avgMajfltPerTok: Double = -1.0, // major page faults per token over the run
     var avgCpuSPerTok: Double = -1.0,   // CPU-seconds per token (summed across threads) over the run
+    // Self-speculation counters from BMOE_DONE; all 0 when MTP was off. Without these the UI cannot
+    // tell whether speculation ran at all, let alone whether it earned its keep.
+    var mtpDrafted: Long = 0,
+    var mtpAccepted: Long = 0,
+    var mtpDecodes: Long = 0,
+    // Seconds per token spent drafting, and the whole between-decode gap. tok/s counts decode time
+    // ONLY, so these are time the user waits that the headline rate does not include.
+    var mtpDraftSPerTok: Double = 0.0,
+    var loopOverheadSPerTok: Double = 0.0,
 ) {
     val tokensPerSecond: Double get() = if (wallMs > 0) 1000.0 / wallMs else 0.0
+
+    /** Share of drafts the model itself confirmed, or -1 when nothing was drafted. */
+    val mtpAcceptancePct: Double get() =
+        if (mtpDrafted > 0) 100.0 * mtpAccepted / mtpDrafted else -1.0
+
+    /** Tokens confirmed per verify pass — what the speculation actually bought. */
+    val mtpTokensPerDecode: Double get() =
+        if (mtpDecodes > 0 && step > 0) step.toDouble() / mtpDecodes else -1.0
+
+    /**
+     * The rate the user actually experiences: decode time PLUS the gap between decodes, where
+     * drafting lives. Reporting only the decode rate flatters speculation, because the drafting it
+     * adds happens outside the measured window.
+     */
+    val effectiveTokensPerSecond: Double get() {
+        if (avgTokensPerSecond <= 0) return -1.0
+        val perTok = 1.0 / avgTokensPerSecond + loopOverheadSPerTok
+        return if (perTok > 0) 1.0 / perTok else -1.0
+    }
 }
 
 /**

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/Telemetry.kt
@@ -46,11 +46,15 @@ data class Telemetry(
     // Run averages of the compute decomposition, from the final summary (BMOE_DONE); -1 until done.
     var avgMajfltPerTok: Double = -1.0, // major page faults per token over the run
     var avgCpuSPerTok: Double = -1.0,   // CPU-seconds per token (summed across threads) over the run
-    // Self-speculation counters from BMOE_DONE; all 0 when MTP was off. Without these the UI cannot
-    // tell whether speculation ran at all, let alone whether it earned its keep.
+    // Self-speculation counters from BMOE_DONE; all 0 when speculation was off. Without these the UI
+    // cannot tell whether it ran at all, let alone whether it earned its keep. They describe the
+    // loop, not a source: the n-gram lookup and the MTP head report through the same fields.
     var mtpDrafted: Long = 0,
     var mtpAccepted: Long = 0,
     var mtpDecodes: Long = 0,
+    // Passes that guessed anything. Below mtpDecodes it means the source abstained on the rest,
+    // which ran at exactly the unspeculated cost — only the n-gram source ever does that.
+    var draftedSteps: Long = 0,
     // Seconds per token spent drafting, and the whole between-decode gap. tok/s counts decode time
     // ONLY, so these are time the user waits that the headline rate does not include.
     var mtpDraftSPerTok: Double = 0.0,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,12 @@ add_executable(bmoe_config_test config_test.cpp)
 target_link_libraries(bmoe_config_test PRIVATE bmoe_core)
 add_test(NAME config_validate COMMAND bmoe_config_test)
 
+# The n-gram draft matcher. Pure policy over token ids (no llama.cpp, no model), so the drafting
+# decision is covered exhaustively here; what it costs is a bench question, not a test.
+add_executable(bmoe_ngram_test ngram_test.cpp)
+target_link_libraries(bmoe_ngram_test PRIVATE bmoe_core)
+add_test(NAME ngram_draft COMMAND bmoe_ngram_test)
+
 find_program(PYTHON3 NAMES python3 python)
 
 if(PYTHON3)

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -185,6 +185,40 @@ int main() {
         expect_fail("a negative n_ubatch is rejected", c);
     }
 
+    // Speculation: lossless only under greedy, and the draft width is bounded on both sides.
+    {
+        RunConfig c = ok_base();
+        expect_ok("speculation off is the default and valid", c);
+        c.mtp.enabled = true;
+        expect_ok("speculation on with the default draft width is valid", c);
+        c.mtp.draft_max = MtpConfig::draft_max_limit;
+        expect_ok("the largest allowed draft width is valid", c);
+        c.mtp.draft_max = MtpConfig::draft_max_limit + 1;
+        expect_fail("a draft width above the limit is rejected", c);
+        c.mtp.draft_max = 0;
+        expect_fail("drafting zero tokens is rejected", c);
+        c.mtp.draft_max = 3;
+        c.sampling.temp = 0.8f;
+        expect_fail("speculation with a sampling chain is rejected", c);
+        // The same temperature is fine once speculation is off: the rejection is about the pair.
+        c.mtp.enabled = false;
+        expect_ok("sampling without speculation stays valid", c);
+    }
+
+    // The verify batch must fit in one graph, or the amortisation it exists for is split away.
+    {
+        RunConfig c = ok_base();
+        c.mtp.enabled = true;
+        c.mtp.draft_max = 3;
+        expect_ok("the default ubatch (0 = as wide as the context) is valid with mtp", c);
+        c.n_ubatch = 4; // exactly 1 + draft_max
+        expect_ok("a ubatch exactly as wide as the verify batch is valid", c);
+        c.n_ubatch = 3;
+        expect_fail("a ubatch narrower than the verify batch is rejected", c);
+        c.mtp.enabled = false;
+        expect_ok("the same narrow ubatch is fine without mtp", c);
+    }
+
     if (failures == 0) {
         std::printf("all config checks passed\n");
         return 0;

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -198,6 +198,18 @@ int main() {
         c.mtp.draft_max = 0;
         expect_fail("drafting zero tokens is rejected", c);
         c.mtp.draft_max = 3;
+        // The confidence floor is a probability, so both ends are bounded.
+        c.mtp.draft_p_min = 0.0f;
+        expect_ok("no confidence floor is the default and valid", c);
+        c.mtp.draft_p_min = 0.6f;
+        expect_ok("a confidence floor inside (0,1) is valid", c);
+        c.mtp.draft_p_min = 1.0f;
+        expect_ok("a confidence floor of 1 is valid (draft only what is certain)", c);
+        c.mtp.draft_p_min = 1.5f;
+        expect_fail("a confidence floor above 1 is rejected", c);
+        c.mtp.draft_p_min = -0.1f;
+        expect_fail("a negative confidence floor is rejected", c);
+        c.mtp.draft_p_min = 0.0f;
         c.sampling.temp = 0.8f;
         expect_fail("speculation with a sampling chain is rejected", c);
         // The same temperature is fine once speculation is off: the rejection is about the pair.

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -186,49 +186,87 @@ int main() {
     }
 
     // Speculation: lossless only under greedy, and the draft width is bounded on both sides.
+    // These rules are shared by every draft source, so they are checked against the MTP one.
     {
         RunConfig c = ok_base();
         expect_ok("speculation off is the default and valid", c);
-        c.mtp.enabled = true;
+        c.spec.source = DraftSource::mtp;
         expect_ok("speculation on with the default draft width is valid", c);
-        c.mtp.draft_max = MtpConfig::draft_max_limit;
+        c.spec.draft_max = SpecConfig::draft_max_limit;
         expect_ok("the largest allowed draft width is valid", c);
-        c.mtp.draft_max = MtpConfig::draft_max_limit + 1;
+        c.spec.draft_max = SpecConfig::draft_max_limit + 1;
         expect_fail("a draft width above the limit is rejected", c);
-        c.mtp.draft_max = 0;
+        c.spec.draft_max = 0;
         expect_fail("drafting zero tokens is rejected", c);
-        c.mtp.draft_max = 3;
+        c.spec.draft_max = 3;
         // The confidence floor is a probability, so both ends are bounded.
-        c.mtp.draft_p_min = 0.0f;
+        c.spec.draft_p_min = 0.0f;
         expect_ok("no confidence floor is the default and valid", c);
-        c.mtp.draft_p_min = 0.6f;
+        c.spec.draft_p_min = 0.6f;
         expect_ok("a confidence floor inside (0,1) is valid", c);
-        c.mtp.draft_p_min = 1.0f;
+        c.spec.draft_p_min = 1.0f;
         expect_ok("a confidence floor of 1 is valid (draft only what is certain)", c);
-        c.mtp.draft_p_min = 1.5f;
+        c.spec.draft_p_min = 1.5f;
         expect_fail("a confidence floor above 1 is rejected", c);
-        c.mtp.draft_p_min = -0.1f;
+        c.spec.draft_p_min = -0.1f;
         expect_fail("a negative confidence floor is rejected", c);
-        c.mtp.draft_p_min = 0.0f;
+        c.spec.draft_p_min = 0.0f;
         c.sampling.temp = 0.8f;
         expect_fail("speculation with a sampling chain is rejected", c);
         // The same temperature is fine once speculation is off: the rejection is about the pair.
-        c.mtp.enabled = false;
+        c.spec.source = DraftSource::none;
         expect_ok("sampling without speculation stays valid", c);
+    }
+
+    // The n-gram source: the same shared rules, plus its own gate, and no cross-talk with the
+    // MTP-only knob — a flag the chosen source cannot act on is rejected, not silently ignored.
+    {
+        RunConfig c = ok_base();
+        c.spec.source = DraftSource::ngram;
+        expect_ok("the n-gram source with its defaults is valid", c);
+        c.sampling.temp = 0.8f;
+        expect_fail("the n-gram source with a sampling chain is rejected", c);
+        c.sampling.temp = 0.0f;
+        c.spec.draft_max = SpecConfig::draft_max_limit + 1;
+        expect_fail("the draft-width limit applies to the n-gram source too", c);
+        c.spec.draft_max = 3;
+        c.spec.draft_p_min = 0.6f;
+        expect_fail("the MTP confidence floor is rejected with the n-gram source", c);
+        c.spec.draft_p_min = 0.0f;
+        c.spec.ngram_min_match = 1;
+        expect_ok("a minimum match of 1 is valid (draft on any repeated token)", c);
+        c.spec.ngram_min_match = 0;
+        expect_fail("a minimum match of 0 is rejected", c);
+        c.spec.ngram_min_match = c.spec.ngram_max_match + 1;
+        expect_fail("a minimum match above the longest suffix considered is rejected", c);
+        c.spec.ngram_min_match = 3;
+        c.spec.ngram_max_match = SpecConfig::ngram_match_limit + 1;
+        expect_fail("a maximum match above the limit is rejected", c);
+        c.spec.ngram_max_match = 0;
+        expect_fail("a maximum match of 0 is rejected", c);
+        c.spec.ngram_max_match = 12;
+        expect_ok("the n-gram bounds back in range are valid", c);
+        // The n-gram knobs are inert for the MTP source, so asking for both is a caller error.
+        c.spec.source = DraftSource::mtp;
+        c.spec.draft_p_min = 0.6f;
+        expect_ok("the confidence floor is valid for the source that has one", c);
     }
 
     // The verify batch must fit in one graph, or the amortisation it exists for is split away.
     {
         RunConfig c = ok_base();
-        c.mtp.enabled = true;
-        c.mtp.draft_max = 3;
-        expect_ok("the default ubatch (0 = as wide as the context) is valid with mtp", c);
+        c.spec.source = DraftSource::mtp;
+        c.spec.draft_max = 3;
+        expect_ok("the default ubatch (0 = as wide as the context) is valid with speculation", c);
         c.n_ubatch = 4; // exactly 1 + draft_max
         expect_ok("a ubatch exactly as wide as the verify batch is valid", c);
         c.n_ubatch = 3;
         expect_fail("a ubatch narrower than the verify batch is rejected", c);
-        c.mtp.enabled = false;
-        expect_ok("the same narrow ubatch is fine without mtp", c);
+        // The rule is about the verify batch, so it binds the n-gram source identically.
+        c.spec.source = DraftSource::ngram;
+        expect_fail("the narrow ubatch is rejected with the n-gram source too", c);
+        c.spec.source = DraftSource::none;
+        expect_ok("the same narrow ubatch is fine without speculation", c);
     }
 
     if (failures == 0) {

--- a/tests/ngram_test.cpp
+++ b/tests/ngram_test.cpp
@@ -1,0 +1,113 @@
+// Unit tests for ngram_draft() (core/src/engine/ngram_draft.cpp) — the prompt-lookup draft source.
+//
+// The matcher is pure policy over token ids: no model, no llama.cpp, fully deterministic, so it runs
+// unconditionally in ctest. That is the point of keeping it on this side of the seam — the drafting
+// decision is testable exhaustively, while what it costs is a bench question.
+//
+// Nothing here can be a byte-identity gate: what the loop does with a draft is verified by a batched
+// decode, which is not bit-identical to single-token decodes (see docs/mtp.md). These tests cover the
+// decision, not the arithmetic.
+//
+// Checks are explicit (not <cassert>): the Release build defines NDEBUG, which compiles assert out.
+
+#include "bmoe/ngram_draft.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace bmoe;
+
+static int failures = 0;
+
+static std::string show(const std::vector<int32_t> & v) {
+    std::string s = "[";
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (i) s += ", ";
+        s += std::to_string(v[i]);
+    }
+    return s + "]";
+}
+
+// Draft against `corpus` where the last element plays the part of the just-confirmed token, which is
+// how the session calls it: ctx holds everything already emitted, `last` is not yet appended.
+static void expect_draft(const char * name,
+                         const std::vector<int32_t> & corpus,
+                         int n_max,
+                         int min_match,
+                         int max_match,
+                         const std::vector<int32_t> & want) {
+    std::vector<int32_t> ctx(corpus.begin(), corpus.end() - 1);
+    const int32_t last = corpus.back();
+
+    std::vector<int32_t> got;
+    const int n = ngram_draft(ctx, last, n_max, min_match, max_match, got);
+
+    if (n == (int) got.size() && got == want) {
+        std::printf("[PASS] %s -> %s\n", name, show(got).c_str());
+    } else {
+        std::printf("[FAIL] %s\n  want %s, got %s (returned %d)\n", name, show(want).c_str(), show(got).c_str(), n);
+        ++failures;
+    }
+}
+
+int main() {
+    // A corpus with nothing to go on cannot draft. These are the steps that must cost exactly a
+    // plain decode — the floor the whole source rests on.
+    expect_draft("an empty corpus drafts nothing", {7}, 3, 3, 12, {});
+    expect_draft("a corpus shorter than the minimum match drafts nothing", {1, 2}, 3, 3, 12, {});
+    expect_draft("a corpus with no repetition drafts nothing", {1, 2, 3, 4, 5, 6}, 3, 3, 12, {});
+    // A repetition shorter than the gate is not evidence: 2 tokens match, the floor is 3.
+    expect_draft("a match shorter than the minimum drafts nothing", {1, 2, 3, 9, 9, 2, 3}, 3, 3, 12, {});
+
+    // The base case: the trigram (1,2,3) occurred before and was followed by 4,5,6.
+    expect_draft("a repeated trigram drafts its continuation", {1, 2, 3, 4, 5, 6, 0, 1, 2, 3}, 3, 3, 12, {4, 5, 6});
+    // The draft width caps what is proposed, not what is matched.
+    expect_draft("the draft width caps the proposal", {1, 2, 3, 4, 5, 6, 0, 1, 2, 3}, 2, 3, 12, {4, 5});
+    // Only what actually followed exists. Here the best match ends two tokens from the corpus end,
+    // so a width of 3 is clipped to the 2 tokens that are actually evidence.
+    expect_draft("the continuation is clipped at the corpus end", {1, 2, 1, 2, 1, 2}, 3, 3, 12, {1, 2});
+
+    // Selection is by match length first. The pattern (8,1,2,3) matches 4 tokens at the earlier
+    // occurrence and only 3 at the later one, so the longer — and older — match must win.
+    expect_draft("the longest match wins over a more recent shorter one", {8, 1, 2, 3, 40, 9, 1, 2, 3, 50, 8, 1, 2, 3},
+                 1, 3, 12, {40});
+    // With the lengths genuinely equal — each occurrence of (1,2,3) is preceded by a different
+    // token, so both match exactly 3 — recency breaks the tie and the later continuation wins.
+    expect_draft("the most recent wins among equal-length matches", {7, 1, 2, 3, 40, 8, 1, 2, 3, 50, 9, 1, 2, 3}, 1, 3,
+                 12, {50});
+
+    // max_match is a scan bound. Capping it at 3 makes the two candidates below tie at 3 instead of
+    // ranking 5 against 3, which hands the pick to recency — the observable effect of the cap.
+    expect_draft("capping the match length lets recency decide", {7, 7, 1, 2, 3, 40, 0, 0, 1, 2, 3, 50, 7, 7, 1, 2, 3},
+                 1, 3, 3, {50});
+
+    // The just-confirmed token is part of the pattern, not a spectator: without it, the suffix
+    // (1,2) matches in two places and the trigram gate would reject. With it the match is (1,2,3).
+    expect_draft("the confirmed token participates in the pattern", {1, 2, 3, 77, 5, 1, 2, 3}, 1, 3, 12, {77});
+
+    // A match may overlap the pattern, which is how a run of one token predicts itself: the corpus
+    // is four 9s, the pattern the last three, the match the three before it. Only one token of
+    // evidence follows that match, so a width of 2 still drafts one.
+    expect_draft("a repeated token predicts itself", {9, 9, 9, 9}, 2, 3, 12, {9});
+
+    // The pattern itself is never its own match — otherwise every step would "match" at the end and
+    // draft nothing meaningful. Here the only occurrence of (1,2,3) is the pattern.
+    expect_draft("the pattern is not matched against itself", {0, 0, 0, 1, 2, 3}, 3, 3, 12, {});
+
+    // Boundary of the gate: the same corpus drafts at min_match 2 and not at 3.
+    expect_draft("a two-token match is rejected at a floor of three", {5, 6, 42, 0, 5, 6}, 2, 3, 12, {});
+    expect_draft("the same two-token match is accepted at a floor of two", {5, 6, 42, 0, 5, 6}, 2, 2, 12, {42, 0});
+
+    // Degenerate arguments are answered, not asserted on: the caller's validation already rejects
+    // them, and a draft source that throws would be a decode-loop crash.
+    expect_draft("a draft width of zero drafts nothing", {1, 2, 3, 4, 1, 2, 3}, 0, 3, 12, {});
+    expect_draft("a maximum match below the minimum drafts nothing", {1, 2, 3, 4, 1, 2, 3}, 3, 3, 2, {});
+
+    if (failures == 0) {
+        std::printf("all n-gram draft checks passed\n");
+        return 0;
+    }
+    std::printf("%d n-gram draft check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
**Draft on purpose — not for merge.** The flag ships off by default and the on-device A/B is still
owed; this PR is the mechanism plus the host measurement, so the device numbers decide whether it is
ever recommended on.

## What it does

Qwen3.5/3.6 ship a trained multi-token-prediction block inside the gguf. With `--mtp`, that head
drafts `--mtp-draft` continuation tokens and the target verifies all of them in one wider decode,
confirming the longest prefix whose argmax equals what the target itself would have produced.

The prize is that a decode's dominant cost — moving the dense weights and the routed expert slices —
is paid once per group instead of once per token. On a DRAM-bandwidth-bound host that amortises the
measured bottleneck directly; on a flash-streamed device it amortises latency-to-ready.

The counterweight is that the `N` verify positions route **independently**, so a layer's read set
widens toward `N × k` wherever adjacent tokens disagree, and the draft pass routes through the MTP
block's own expert layer on top.

## It is exact, but it is not bit-reproducible

Read this precisely, because it is a weaker claim than the rest of the engine makes. No weight is
skipped and nothing is approximated — the quality is the full model's. But `--mtp` is **not**
byte-identical the way `--overlap` and `--prefetch` are, and **must not be used in a byte-identity
gate**: a verify pass evaluates `1 + N` positions in one batch, and a batched matmul is not
bit-identical to N single-token ones, so a near-tie can flip.

This was isolated without involving speculation at all: the same model at `--ubatch 1`, no MTP,
already changes the greedy output. Batch width moves the last bits on this backend; speculation
merely makes every decode a wide batch and inherits it. Draft widths 1 and 3 agree with each other
exactly, which rules out the accept/rollback path as the cause. See `docs/mtp.md`.

## Measured — desktop host

8 cores, 14.8 GB RAM, NVMe. Qwen3.6-35B-A3B-MXFP4_MOE (20.7 GiB, ~1.4× RAM), streamed, greedy,
256 tokens, with the host's best recipe (`--overlap --cache-mb auto --drop-cold-experts 0.75`):

| draft width | tok/s | vs off | acceptance | tokens / verify decode | flash MiB/token |
|---|---|---|---|---|---|
| off | 7.12 | — | — | 1.00 | 19.7 |
| `--mtp-draft 2` | 7.66 | +7.6% | 71.4% | 2.42 | 30.3 |
| **`--mtp-draft 3`** | **8.19** | **+15.1%** | 60.1% | 2.78 | 33.7 |
| `--mtp-draft 4` | 7.64 | +7.3% | 52.4% | 3.08 | 31.1 |

Without the lossy drop knob the gain is larger: 4.28 → 5.52 tok/s, **+29%** at draft 3.

Two things to read off it. Acceptance falls as the draft widens while tokens-per-decode still rises,
and the two effects cross — 3 is the optimum here and 4 is worse than 2. And the widening is real and
visible: flash bytes per token rise from 19.7 to 33.7 MiB. It still wins because compute per token
falls further (0.115 → 0.088 s) than the extra I/O costs on this host. **On a flash-I/O-bound device
that balance can invert**, which is the whole reason the flag ships off.

## How it is wired

The draft/verify orchestration is llama.cpp's own, reached through `common/speculative.h`, which
depends only on public headers. **No fork, no patch, no submodule bump** — the same rule the rest of
the engine follows.

Self-speculation is one model with two contexts over it: the target, created with `n_rs_seq` so a
rejected tail is rewound from a bounded snapshot instead of replayed, and a draft context created
with `ctx_type = LLAMA_CONTEXT_TYPE_MTP`. The engine builds the draft context itself rather than
through `common_speculative_init_from_params` for a reason that belongs to this project: **the eval
callback is per-context**, and the streamer only sees the MTP block's expert layer if the draft
context carries the same `cb_eval`.

The MTP block is streamed like any other layer. It sits at layer index `n_layer`, contiguous with the
trunk and using the same tensor naming, so the hook and the expert source are sized
`n_layer + n_layer_nextn`; left at `n_layer` its experts stay silently mmap-resident — the fault storm
streaming exists to avoid. Two consequences that are easy to get wrong and are handled here: the
capture warm-up has to run on the draft context too (the MTP graph is built nowhere else), and
prefill is fed through the driver so the draft context's KV reaches the last prompt position.

Nothing is model-specific: the head is discovered at runtime through `llama_model_n_layer_nextn()`,
so a future model carrying a nextn block needs no code change.

### The catch-up runs on the accepted prefix, not the whole batch

The catch-up re-runs the MTP block so the draft context holds rows conditioned on the target's own
hidden states rather than the head's guesses, and the next draft is seeded from the accepted row. The
obvious place for it is right after the decode, on the whole verify batch — which is what upstream's
own loop does. But that computes the rejected tail too, and the tail is deleted a few statements
later: those drafts were wrong and nothing ever reads their rows.

Acceptance depends only on the target's logits, which are already in hand once the decode returns, so
the tail never has to be submitted. Accepting first and handing the catch-up only the accepted prefix
leaves **identical state** — the driver seeds from row `min(n_accepted, n_rows-1)`, the same row
under either batch, and the surviving KV is exactly the range the rollback used to carve out — while
skipping `n_draft − n_accepted` positions through the MTP block per group. It also removes the draft
context's rollback entirely: it is never given a tail to drop. Since that block carries its own MoE
FFN, on a streamed device those skipped positions are expert reads that no longer happen.

## Rejected loudly, never silently degraded

- A gguf with no `nextn` block fails at load with a message naming the requirement, rather than
  quietly decoding one token at a time. Note that Qwen3.6's **ordinary** quantisations do carry the
  head — verified from the gguf headers, bartowski's `Q4_0` and `Q4_K_M` and unsloth's `MXFP4_MOE`
  are identical in every MTP-relevant key and tensor — so no `-MTP-` conversion is needed, and an
  A/B has to be the same file with the flag on and off.
- `--mtp` together with `--temp > 0` is rejected: acceptance under a sampling chain would depend on
  which draws happened to agree, which is a different distribution from the one the caller asked for.
- An `n_ubatch` narrower than the verify batch is rejected: the graph would be split back into
  single-token passes, spending the draft and keeping none of the amortisation, with nothing in the
  output to show it happened.

## Telemetry

An `mtp:` summary line; an `mtp_batch` per-token CSV column (a verify decode confirms a whole group
and its **entire** cost is charged to the group's first row, the rest carry zeros — without the
column those zeros read as free tokens); `mtp_drafted` / `mtp_accepted` / `mtp_decodes` in the CSV
trailer and in `BMOE_DONE`; `mtp` / `mtp_draft_max` in the CSV preamble so a speculated file can
never be averaged together with an unspeculated one by accident.

The Android app exposes the flag and the draft width, off by default.

## Validation

- Host gates: 7/7 pass. They do not cover MTP (no nextn model in the fixtures), so they prove the
  unspeculated path is unchanged.
- On Qwen3.6-35B-A3B-MXFP4 with the streamed recipe: `--mtp-draft 1` and `--mtp-draft 3` produce
  **identical text**, which is the invariant a broken accept/rollback path would violate — a
  rollback bug scales with how much is rolled back.
- clang-format 18 clean.

## Owed before this leaves draft

- The device A/B, including draft width 2 vs 3 vs 4, run as the **same gguf with the flag on and
  off**. The host optimum is 3, but the optimum shortens as a platform gets more memory-bound, and
  flash streaming is the most memory-bound regime we have.
- The app does not read `mtp_drafted` / `mtp_accepted` / `mtp_decodes` out of `BMOE_DONE`, so the UI
  cannot report whether speculation actually ran or what it accepted — only the session CSV can. Not
  a blocker for the A/B, but it makes the A/B harder to run from the phone alone.
- No version bump here on purpose: per the project rule the bump belongs to the PR that releases.

## Docs

`docs/mtp.md` is new and covers the whole feature. `docs/telemetry.md`, `docs/seam.md`,
`docs/README.md`, `examples/android/README.md`, `README.md` and `CHANGELOG.md` are updated in this
same PR.
