### PR TITLE
feat(dense): --dense-embd-mmap, keep the embedding table out of the pinned set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- **`--dense-embd-mmap` — keep the embedding table out of the pinned dense set (off by default).**
+  The dense policy applied one mode to every non-expert byte, which treated the two vocabulary
+  tensors as equals. A compute trace says they are not: on Qwen3-30B the output head is 243 MiB and
+  **all of it** is read every token (a matmul over the whole vocabulary, 8.94 ms/token), while
+  `token_embd` is 167 MiB of which **one row, 1152 bytes**, is read (a `GET_ROWS`, 0.26 ms). Pinning
+  both spends 167 MiB — 273 on Qwen3.6, 380 on gpt-oss-120b — for about a kilobyte of use per token.
+  With the flag on, the table stays mmap'd and the kernel keeps only the pages a conversation
+  touches; the anon set drops from 951 to 784 MiB on Qwen3-30B. Refused, with a message, on a model
+  that ties the table to the head, where the table is the head. The win is memory handed back to the
+  expert cache, so it converts to tok/s only where more cache buys hits — the flag stays off until
+  that A/B runs on device. `dense_embd_mmap` joins the CSV config line.
+
+### Documented
+- **The head is bandwidth-bound; the final norm is not a cost.** Halving the threads leaves the
+  `result_output` node at 8.94 → 8.97 ms and two head sizes run at the same 26.6 / 27.5 GB/s, so its
+  time is exactly `bytes / bandwidth` and no kernel or threading change can move it — only fewer
+  bytes, i.e. a lower `--output-tensor-type` at quantization time. All 49 `RMS_NORM` nodes together
+  are 1.4 ms. `docs/android-memory.md` gains the measurements.
+
 ## [0.18.0] - 2026-07-28
 
 ### Added

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -399,6 +399,11 @@ static void print_usage(const char * argv0) {
         "                          ahwb = as anon, but into dma-buf memory the kernel may not reclaim\n"
         "                          at all — not even to zram, which is what anon still pays for.\n"
         "                          Android-only; measured +17.9%% on a long generation, off by default)\n"
+        "      --dense-embd-mmap   keep the embedding table OUT of the anon/ahwb dense set, mmap'd.\n"
+        "                          It is read one row (~1 KiB) per token but is as large as the\n"
+        "                          output head, which IS read whole every token, so pinning both\n"
+        "                          spends hundreds of MiB the expert cache could hold. Ignored on a\n"
+        "                          model that ties the embedding to the head. Off by default\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -582,7 +587,8 @@ int main(int argc, char ** argv) {
                 std::fprintf(stderr, "bmoe: --dense-weights expects mmap|warm|anon|ahwb, got '%s'\n", m.c_str());
                 return 2;
             }
-        }
+        } else if (a == "--dense-embd-mmap")
+            cfg.moe.dense_embd_mmap = true;
         // Deprecated aliases, kept so existing scripts and the app keep working: --no-warm-dense is
         // the Mmap policy, --dense-odirect is Anonymous. Prefer --dense-weights.
         else if (a == "--no-warm-dense")

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -103,6 +103,22 @@ struct MoeStreamConfig {
     //             and the policy the Android app ships by default — the CLI matches it here.
     DenseWeightsMode dense_weights = DenseWeightsMode::Anonymous;
 
+    // Leave the input embedding table OUT of the anon/pinned dense set, mmap'd (Anonymous and Pinned
+    // only; the other policies already leave everything mmap'd). Off by default — the mechanism ships
+    // ahead of the device A/B that decides whether it earns its place.
+    //
+    // The two vocabulary tensors are the same size and are read in opposite ways. The output head is
+    // a matmul over the whole vocabulary: every one of its bytes is read every token, so it must be
+    // resident or each token pays a flash refault of the entire tensor. The embedding table is a
+    // GET_ROWS of ONE row — 1152 bytes of 167 MiB on Qwen3-30B — so a policy that pins it holds
+    // hundreds of MiB for about a kilobyte of use per token. Left mmap'd, the kernel keeps only the
+    // 4 KiB pages actually touched, which converges to the distinct token ids a conversation uses;
+    // the cost is one minor-or-major fault the first time an id appears, not one per token.
+    //
+    // Refused when the model ties the embedding to the output head (no separate output tensor in the
+    // gguf), because there the table IS the head and the access pattern above does not hold.
+    bool dense_embd_mmap = false;
+
     // ── cache-aware expert dropping (lossy; opt-in) ──────────────────────────────────
     // Skip a routed expert when it is a cache MISS *and* the router weighted it below
     // drop_cold_frac × (1 / n_expert_used) — i.e. below that fraction of the uniform share a

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -196,6 +196,7 @@ struct RunInfo {
     int predict_spec_max = 0;           // how many predicted misses a layer may speculate (0 = retention only)
     bool prefetch_sync = false;         // test path: speculative reads served inline, no latency hiding
     std::string dense_weights = "anon"; // dense (non-expert) policy: "mmap" | "warm" | "anon" | "ahwb"
+    bool dense_embd_mmap = false;       // embedding table held back from the anon/pinned set
     float drop_cold_frac = 0.0f;        // cache-aware expert dropping threshold (0 = off)
     bool drop_renorm = true;            // survivors rescaled to keep the routing's total mass
     bool drop_prefill = false;          // dropping armed during prefill too, where it discards far more

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -476,6 +476,17 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // an empty list.
         if (cfg.moe.dense_weights == DenseWeightsMode::Anonymous || cfg.moe.dense_weights == DenseWeightsMode::Pinned) {
             const std::unordered_set<std::string> expert_names = expert_tensor_names(layers);
+            // --dense-embd-mmap: hold back the embedding table, which is read one row per token, and
+            // let the kernel keep only the pages a conversation touches. These are llama.cpp's
+            // canonical tensor names across every architecture, not model-specific constants. A model
+            // that ties the two has no separate output tensor, and then the table is the head and is
+            // read whole every token — so the skip is refused rather than silently applied.
+            const bool untied = offs.off_by_name.count("output.weight") != 0;
+            const bool skip_embd = cfg.moe.dense_embd_mmap && untied;
+            if (cfg.moe.dense_embd_mmap && !untied)
+                std::fprintf(stderr, "bmoe: --dense-embd-mmap ignored — this model ties the embedding to the "
+                                     "output head, so the table is read whole every token\n");
+            uint64_t held_back = 0;
             std::vector<DenseTensorRef> dense;
             for (const auto & kv : im.hook->captured_weights()) {
                 const std::string & name = kv.first;
@@ -483,12 +494,19 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                 auto off = offs.off_by_name.find(name);
                 auto sz = offs.size_by_name.find(name);
                 if (off == offs.off_by_name.end() || sz == offs.size_by_name.end()) continue; // not a file tensor
+                if (skip_embd && name == "token_embd.weight") {
+                    held_back = sz->second;
+                    continue;
+                }
                 DenseTensorRef d;
                 d.tensor = kv.second;
                 d.file_off = off->second;
                 d.size = sz->second;
                 dense.push_back(d);
             }
+            if (held_back)
+                std::fprintf(stderr, "bmoe: --dense-embd-mmap — token_embd (%llu MiB) left mmap'd\n",
+                             (unsigned long long) (held_back >> 20));
             im.source.set_dense_tensors(std::move(dense));
         }
 
@@ -597,6 +615,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                            : cfg.moe.dense_weights == DenseWeightsMode::Anonymous ? "anon"
                            : cfg.moe.dense_weights == DenseWeightsMode::Pinned    ? "ahwb"
                                                                                   : "warm";
+        ri.dense_embd_mmap = cfg.moe.dense_embd_mmap;
         if (cfg.moe.enabled) {
             const IExpertSource::Stats st = im.source.stats();
             ri.cache_mb = (int) (st.cache_budget_bytes / (1024ull * 1024ull));

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -38,11 +38,11 @@ public:
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_floor_mb=%d cache_ceil_mb=%d "
                      "force_cache=%d load_all=%d io_threads=%d o_direct=%d overlap=%d io_two_wave=%d prefetch=%d "
                      "predict_prefetch=%d predict_log=%d predict_spec_max=%d prefetch_sync=%d "
-                     "dense_weights=%s drop_cold_frac=%.4g drop_renorm=%d drop_prefill=%d\n",
+                     "dense_weights=%s dense_embd_mmap=%d drop_cold_frac=%.4g drop_renorm=%d drop_prefill=%d\n",
                      r.moe_stream, r.cache_mb, r.cache_auto, r.cache_floor_mb, r.cache_ceil_mb, r.force_cache,
                      r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave, r.prefetch_layers,
                      r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync, r.dense_weights.c_str(),
-                     (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
+                     r.dense_embd_mmap, (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
         std::fprintf(f_, "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d\n", (double) r.temp, r.top_k,
                      (double) r.top_p, r.seed, r.compute_trace_layers);
         write_header();

--- a/docs/android-memory.md
+++ b/docs/android-memory.md
@@ -64,6 +64,29 @@ This is the unnoticed cost of the O_DIRECT design. O_DIRECT buys large sequentia
 4 KiB demand-fault storm — real and worth having — but it also converts free evictions into paid
 ones. Any future design should weigh both halves.
 
+## The two vocabulary tensors are the same size and nothing alike
+
+The dense policy applies one mode to every non-expert byte, which quietly treats the two largest
+dense tensors as equals. They are not. Measured with `--compute-trace` on a host, per decoded token:
+
+| tensor | Qwen3-30B | bytes read per token | node cost |
+|---|---|---|---|
+| `output.weight` (head) | 243 MiB Q6_K | **all of it** — a matmul over the whole vocabulary | 8.94 ms |
+| `token_embd.weight` | 167 MiB Q4_K | **one row, 1152 bytes** — a `GET_ROWS` lookup | 0.26 ms |
+
+The head must be resident: were it evicted, every token would refault the entire tensor from flash.
+The table need not be. Pinned, it holds 167 MiB (273 on Qwen3.6, 380 on gpt-oss-120b) for about a
+kilobyte of use per token — memory the expert cache could hold instead. Left mmap'd, the kernel keeps
+only the 4 KiB pages actually touched, which converges to the distinct token ids a conversation uses;
+the cost is one fault the first time an id appears, not one per token. That is what
+`--dense-embd-mmap` does, and it is refused on a model that ties the table to the head, where the
+table *is* the head and the row above does not hold.
+
+The head itself is bandwidth-bound and has no software lever: halving the threads (8 → 4) leaves its
+node at 8.94 → 8.97 ms, and two different head sizes run at the same 26.6 / 27.5 GB/s. Its cost is
+exactly `bytes / bandwidth`, so only fewer bytes — a lower `--output-tensor-type` at quantization
+time — can move it. The final norm is not a cost at all: all 49 `RMS_NORM` nodes together are 1.4 ms.
+
 ## The hit rate is what decides whether the kernel keeps your cache
 
 The LRU promotes a page from *inactive* to *active* only on a **second reference** — and a cache hit

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -169,7 +169,8 @@ prints just the summary lines.
 # moe_stream=<0|1> cache_mb=<n> cache_auto=<0|1> cache_floor_mb=<n> cache_ceil_mb=<n>
   force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1> overlap=<0|1> io_two_wave=<0|1> prefetch=<n>
   predict_prefetch=<0|1> predict_log=<0|1> predict_spec_max=<n> prefetch_sync=<0|1>
-  dense_weights=<mmap|warm|anon|ahwb> drop_cold_frac=<f> drop_renorm=<0|1> drop_prefill=<0|1>
+  dense_weights=<mmap|warm|anon|ahwb> dense_embd_mmap=<0|1> drop_cold_frac=<f> drop_renorm=<0|1>
+  drop_prefill=<0|1>
 # temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n>
 ```
 


### PR DESCRIPTION
## What this is

The dense-weights policy applies **one mode to every non-expert byte**. That quietly treats the two
largest dense tensors as equals, and a compute trace says they are nothing alike.

Measured with `--compute-trace` on a host, per decoded token:

| tensor | Qwen3-30B | bytes read per token | node cost |
|---|---|---|---|
| `output.weight` (head) | 243 MiB Q6_K | **all of it** — a matmul over the whole vocabulary | 8.94 ms |
| `token_embd.weight` | 167 MiB Q4_K | **one row, 1152 bytes** — a `GET_ROWS` lookup | 0.26 ms |

The head must stay resident: evicted, every token would refault the entire tensor from flash. The
table need not. Pinned, it holds 167 MiB — 273 on Qwen3.6, 380 on gpt-oss-120b — for about a
kilobyte of use per token, memory the expert cache could hold instead.

`--dense-embd-mmap` (off by default) holds the embedding table back from the anon/`ahwb` set and
leaves it mmap'd, so the kernel keeps only the 4 KiB pages a conversation actually touches. That
converges to the distinct token ids in use; the cost is one fault the first time an id appears, not
one per token.

Verified on Qwen3-30B: the anon set drops from **951 MiB to 784 MiB**, 435 buffers to 434,
generation unchanged.

```
bmoe: --dense-embd-mmap — token_embd (166 MiB) left mmap'd
bmoe: dense-weights=anon — 784 MiB in 434 anon buffers
```

## Why it is off by default

The win is **memory handed back to the expert cache**, not time. It converts to tok/s only in a
regime where more cache buys hits — below the `token_demand` cliff it buys nothing. The mechanism
ships now; the flag flips after the A/B on device, which this PR does not claim to have run (no
device was attached while writing it).

## Tied models

Refused, with a message, when the gguf has no separate `output.weight`: there the table *is* the
head, read whole every token, and the argument inverts. The check is a runtime lookup of llama.cpp's
canonical tensor names, not an architecture list. **Untested** — no tied MoE gguf was available
locally; the untied path is what the verification above exercises.

## What else the trace settled

Recorded in `docs/android-memory.md` because it closes two questions rather than opening them:

- **The head is bandwidth-bound and has no software lever.** Halving the threads (8 → 4) leaves the
  `result_output` node at 8.94 → 8.97 ms, and two different head sizes run at the same 26.6 /
  27.5 GB/s. Its cost is exactly `bytes / bandwidth`, so no kernel, threading or coalescing change
  can move it — only fewer bytes, i.e. a lower `--output-tensor-type` at quantization time. On
  gpt-oss-120b the head is 587 MiB Q8_0, where that would be worth the most.
- **The final norm is not a cost.** All 49 `RMS_NORM` nodes together are 1.0–1.4 ms/token.

## Gates

`ctest` 7/7 pass. The change touches which tensors the dense policy adopts, not the streamer or the
seam, and the streamed-equals-resident gates are unaffected — but they were run before and after
`clang-format` anyway.

## Not in this PR

No Android settings toggle yet: the app should expose this once the device A/B says which way it
goes, so the setting arrives with a measured default rather than a guess.
