### PR TITLE
fix(app): show the whole run configuration a metrics CSV carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.18.1] - 2026-07-29
+
+### Fixed
+- **A saved metrics CSV now states its whole configuration in the app (#136).** The engine has
+  written every resolved knob into the `# bmoe_metrics v2` preamble for several releases, but the
+  app displayed hand-picked subsets of it: the header card of an opened file listed eight fields,
+  and the compare view rendered a 17-key whitelist that had quietly drifted behind the metrics
+  sink. Expert dropping, predictive prefetch and its speculation width, the sampling parameters and
+  the engine build that produced the rows were all in the file and none of them reachable — so a
+  run could not say whether it dropped experts, let alone at what fraction, and an A/B whose only
+  difference was one of those levers showed two configuration cards that looked identical. Both
+  views now share one renderer over the whole preamble: the curated keys in order, then every
+  remaining key under its own name, so a knob added to the sink shows up without an app change.
+  `drop` and `predict` also joined the short run label, which is what a compare legend shows.
+- App version bumped to 0.18.1 (versionCode 33).
+
 ## [0.18.0] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Semantic Versioning.
   views now share one renderer over the whole preamble: the curated keys in order, then every
   remaining key under its own name, so a knob added to the sink shows up without an app change.
   `drop` and `predict` also joined the short run label, which is what a compare legend shows.
+- **The main screen states the whole configuration too.** The reminder line under the prompt was a
+  hand-picked subset of the same kind: it named the cache, the lanes and the threads but not the
+  dense-weight policy, prefetch, predictive prefetch, or expert dropping — which is on by default at
+  75%, so the default configuration changed the answers without the screen saying so. The line now
+  carries the levers that make a run a different kind of run, and the full flag list is one tap
+  below it, read back from the argv the session actually opens with rather than from a second list
+  kept by hand.
 - App version bumped to 0.18.1 (versionCode 33).
 
 ## [0.18.0] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ Semantic Versioning.
   carries the levers that make a run a different kind of run, and the full flag list is one tap
   below it, read back from the argv the session actually opens with rather than from a second list
   kept by hand.
+- **The glossary explains the configuration too, in its own section.** The `?` reference covered the
+  per-token columns only, so surfacing thirty-odd settings would have surfaced thirty-odd unexplained
+  names. It now has two halves — the columns, and every preamble key described in the words its own
+  definition uses — and it is reachable from Compare, where the configuration table matters most.
+- **`loop_overhead_ms` is described at last.** The engine has written the column since 0.17.0 and the
+  app never explained it: the time between two decodes, outside `wall_ms` and therefore outside the
+  reported tok/s.
+- **`predict_spec_max` no longer reads as a setting when the prediction was off.** The engine records
+  its own default (2) whenever predictive prefetch is disabled — it is the one field of that block
+  `session.cpp` does not neutralise — so a file claimed two speculated misses per layer for a run
+  that speculated nothing. It now renders as inert. The engine-side fix is tracked separately;
+  nothing about how those runs executed changes, since the value is never read with the feature off.
 - App version bumped to 0.18.1 (versionCode 33).
 
 ## [0.18.0] - 2026-07-28

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -51,8 +51,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 32
-        versionName '0.18.0'
+        versionCode 33
+        versionName '0.18.1'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -293,8 +293,46 @@ private fun MainScreen(
                         }
                     }
 
-                    // A quick reminder of the active config (full controls in Settings).
+                    // A quick reminder of the active config (full controls in Settings), with the
+                    // rest of it one tap away: the line above names the levers that change the kind
+                    // of run, but "what exactly was this answer produced under" is a question the
+                    // main screen has to be able to answer too, not only a saved CSV (#136).
                     Text(configSummary(settings), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    var showConfig by rememberSaveable { mutableStateOf(false) }
+                    val flags = remember(settings, models, modelIdx) {
+                        models.getOrNull(modelIdx.coerceIn(0, (models.size - 1).coerceAtLeast(0)))
+                            ?.let { configFlags(settings, it.absolutePath, settings.metricsCsv) }
+                            .orEmpty()
+                    }
+                    if (flags.isNotEmpty()) {
+                        TextButton(
+                            onClick = { showConfig = !showConfig },
+                            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
+                        ) {
+                            Text(
+                                if (showConfig) "Hide full configuration"
+                                else "Full configuration (${flags.size} flags)",
+                                fontSize = 12.sp,
+                            )
+                        }
+                        if (showConfig) {
+                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                // The engine's own flag names rather than prose labels: this is the
+                                // command line the session runs on, and a name that matches the CLI
+                                // is what makes a screenshot of it reproducible off-device.
+                                flags.forEach { (flag, value) ->
+                                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                        Text(
+                                            flag, fontSize = 11.sp, fontFamily = FontFamily.Monospace,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.weight(1f),
+                                        )
+                                        Text(value, fontSize = 11.sp, fontFamily = FontFamily.Monospace)
+                                    }
+                                }
+                            }
+                        }
+                    }
 
                     if (ui.loading) {
                         Row(
@@ -413,20 +451,71 @@ private fun ReasoningBlock(reasoning: String, initiallyExpanded: Boolean) {
     }
 }
 
-/** One-line reminder of the active configuration, mirroring the key Settings knobs. */
+/**
+ * One-line reminder of the active configuration. A glance, not the record — [configFlags] is what
+ * states the run in full. What earns a place here is what makes this a different KIND of run from
+ * the next one: the lossy levers above all (dropping experts and a narrowed top-k change the
+ * ANSWER, not just the speed), then the residency policies that decide where the time goes.
+ */
 private fun configSummary(s: AppSettings): String {
-    val core = if (s.mmap) {
-        "mmap baseline (no streaming) · ${s.threads} threads"
+    val parts = mutableListOf<String>()
+    if (s.mmap) {
+        parts += "mmap baseline (no streaming)"
     } else {
-        val cache = when {
+        parts += when {
             s.cacheMb == AppSettings.CACHE_AUTO -> if (s.cacheCeilMb > 0) "cache auto≤${s.cacheCeilMb}" else "cache auto"
             s.cacheMb == 0 -> "cache off"
             else -> "cache ${s.cacheMb} MiB"
         }
-        "$cache · ${s.ioThreads} lanes${if (s.overlap) " · overlap" else ""} · ${s.threads} threads"
+        parts += "${s.ioThreads} lanes"
+        if (s.overlap) parts += "overlap"
+        if (!s.oDirect) parts += "buffered"
+        parts += "dense ${s.denseWeights.flag}"
+        // Gated exactly as sessionArgv gates the flags themselves: a lever the CLI will not be told
+        // about must not be named here, or the line goes back to describing a run that never ran.
+        val cacheOn = s.cacheMb == AppSettings.CACHE_AUTO || s.cacheMb > 0
+        if (cacheOn) {
+            if (s.prefetchLayers > 0) parts += "prefetch ${s.prefetchLayers}"
+            else if (s.predictPrefetch) parts += "predict" + if (s.predictSpecMax > 0) " ${s.predictSpecMax}" else ""
+            if (s.dropColdPct > 0) parts += "drop ${s.dropColdPct}%"
+        }
     }
-    val topk = if (s.nExpertUsed > 0) " · top-k ${s.nExpertUsed}" else ""
-    return "$core$topk · thinking ${if (s.thinking) "on" else "off"} · build ${BuildConfig.GIT_SHA}"
+    parts += "${s.threads} threads"
+    if (s.nExpertUsed > 0) parts += "top-k ${s.nExpertUsed}"
+    parts += "thinking ${if (s.thinking) "on" else "off"}"
+    parts += "build ${BuildConfig.GIT_SHA}"
+    return parts.joinToString(" · ")
+}
+
+/**
+ * The whole configuration as (flag, value) pairs, read back from the argv these settings would
+ * actually open the session with. Deliberately NOT a second hand-kept list beside
+ * [AppSettings.sessionArgv]: a knob added there appears here on its own, and a knob the argv gates
+ * off (dropping without a cache, prefetch under mmap) is absent here for the same reason it is
+ * absent from the run. A curated subset is what left the metrics views unable to state their own
+ * drop fraction (#136); this display starts out unable to drift.
+ */
+private fun configFlags(s: AppSettings, modelPath: String, csv: Boolean): List<Pair<String, String>> {
+    // Placeholders for the two paths the argv needs but that say nothing about the configuration;
+    // the CSV one only has to be non-null for --csv to be emitted at all.
+    val argv = s.sessionArgv("bmoe-cli", modelPath, if (csv) "metrics.csv" else null)
+    val out = mutableListOf<Pair<String, String>>()
+    var i = 1 // argv[0] is the binary
+    while (i < argv.size) {
+        val flag = argv[i]
+        val next = argv.getOrNull(i + 1)
+        // Every value here is a path, a number or a keyword — none of them start with a dash, so
+        // the next token being one is what distinguishes a value from the following flag.
+        if (next != null && !next.startsWith("-")) {
+            // Paths are the user's own storage layout, not configuration: name the file, not where it lives.
+            out += flag to (if (flag == "-m" || flag == "--csv") File(next).name else next)
+            i += 2
+        } else {
+            out += flag to "on"
+            i += 1
+        }
+    }
+    return out
 }
 
 /**

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -297,7 +297,11 @@ private fun MainScreen(
                     // rest of it one tap away: the line above names the levers that change the kind
                     // of run, but "what exactly was this answer produced under" is a question the
                     // main screen has to be able to answer too, not only a saved CSV (#136).
-                    Text(configSummary(settings), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    // Remembered, not recomputed: this item redraws on every streamed token (it holds
+                    // the telemetry card), and the configuration it describes changes only when the
+                    // user changes a setting.
+                    val summary = remember(settings) { configSummary(settings) }
+                    Text(summary, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     var showConfig by rememberSaveable { mutableStateOf(false) }
                     val flags = remember(settings, models, modelIdx) {
                         models.getOrNull(modelIdx.coerceIn(0, (models.size - 1).coerceAtLeast(0)))

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -42,6 +42,8 @@ object MetricFields {
         MetricField("swap_mib", "our memory in zram", "anonymous memory already compressed into swap — cache we have effectively lost", Better.LOWER),
         MetricField("rss_mib", "total resident", "everything resident (VmRSS)", Better.NEUTRAL),
 
+        MetricField("loop_overhead_ms", "time between tokens", "everything outside llama_decode: sampling, detokenization, rendering the answer, writing the sinks. It falls outside wall_ms and so outside the reported tok/s, which is why it needs a column — work that moves only this number is paid on every token and shows up nowhere else. On the first token, the gap from the end of prefill to the first decode", Better.LOWER),
+
         MetricField("mem_available_mib", "device 'available' (it lies)", "what the kernel claims is free — it counts our own mmap'd weights as reclaimable, so it over-states headroom", Better.NEUTRAL),
         MetricField("mem_free_mib", "device free", "truly free RAM, before any reclaim", Better.NEUTRAL),
         MetricField("swap_free_mib", "swap free", "zram space left before the device is truly out of room", Better.NEUTRAL),
@@ -49,4 +51,59 @@ object MetricFields {
 
     private val byName = all.associateBy { it.name }
     fun of(name: String): MetricField? = byName[name]
+}
+
+/** One configuration key from the CSV preamble, in the words its own source uses. */
+data class ConfigField(val name: String, val what: String)
+
+/**
+ * What each key of the `# bmoe_metrics v2` preamble means. Same contract as [MetricFields], one
+ * level up: those describe what the run measured, these describe what it was measured UNDER. A key
+ * the engine adds and this list does not mention still displays — under its raw name, unexplained,
+ * which is the right failure and not a reason to hide it.
+ *
+ * The wording is taken from where each knob is defined (`core/include/bmoe/config.h`) rather than
+ * re-invented here, so a reader who follows a setting into the engine finds the same sentence.
+ */
+object ConfigFields {
+    val all: List<ConfigField> = listOf(
+        ConfigField("engine", "the engine build that produced these rows. Runs from different builds are not a comparison"),
+        ConfigField("model", "the gguf, by filename"),
+        ConfigField("arch", "architecture the gguf declares; it selects the streaming recipe"),
+        ConfigField("n_layer", "transformer layers"),
+        ConfigField("n_expert", "experts per layer the model holds"),
+        ConfigField("n_expert_used", "experts routed per token — the model's own width, or an override. Fewer is faster and changes the answer"),
+        ConfigField("n_ctx", "context window reserved for the session"),
+        ConfigField("n_ubatch", "prefill batch width (0 = default). Decode is one token wide regardless, so this trades prefill throughput for memory"),
+        ConfigField("threads", "compute threads"),
+        ConfigField("chatml", "the model's own chat template was applied; the key name is historical"),
+        ConfigField("moe_stream", "expert streaming. Off is the mmap baseline that streamed runs are measured against"),
+        ConfigField("cache_mb", "expert-cache budget the run resolved to, whether given explicitly or chosen by auto-sizing"),
+        ConfigField("cache_auto", "the budget was sized from free RAM once at load, then held for the run"),
+        ConfigField("cache_floor_mb", "RAM auto-sizing leaves free for the rest of the system. Applies only with cache_auto"),
+        ConfigField("cache_ceil_mb", "upper bound on the auto budget; 0 caps only at the full expert-set size"),
+        ConfigField("force_cache", "a budget below the engine's floor was permitted. Such a cache thrashes by design and is slower than no cache — reserved for probing where the floor lies"),
+        ConfigField("io_threads", "parallel flash read lanes, including the calling thread. 1 is the serial baseline"),
+        ConfigField("o_direct", "expert reads bypassed the page cache"),
+        ConfigField("overlap", "reads ran during compute instead of blocking before it"),
+        ConfigField("io_two_wave", "the first projection's reads were published to the lanes as soon as they were staged, rather than after the whole layer"),
+        ConfigField("load_all", "every expert was loaded each token, routing ignored. An A/B baseline"),
+        ConfigField("prefetch", "temporal prefetch depth in layers, betting this token routes like the last. 0 = off"),
+        ConfigField("predict_prefetch", "the next layer's router ran early, and the cache acted on that prediction instead of the previous token's routing"),
+        ConfigField("predict_spec_max", "how many predicted, non-resident experts were read ahead. 0 = retention only, which spends no flash and merely protects predicted residents from eviction. Recorded but unused when predict_prefetch is off"),
+        ConfigField("predict_log", "prediction-accuracy probe. A diagnostic, not a shipping setting"),
+        ConfigField("prefetch_sync", "reads completed synchronously so the byte-identity gates could reach a path a timing race rarely hits. Not for production"),
+        ConfigField("dense_weights", "residency policy for the non-expert weights: mmap (baseline), warm (page-cached at load), anon (O_DIRECT into our own buffers, so reclaim goes to zram rather than flash), ahwb (as anon, in dma-buf memory the kernel cannot reclaim; shown as Pinned in Settings)"),
+        ConfigField("drop_cold_frac", "dropping threshold as a fraction of the uniform share 1/top-k. A routed expert below it was skipped when not already in RAM. Lossy, and not repeatably so: what was skipped depended on cache contents"),
+        ConfigField("drop_renorm", "surviving weights were rescaled so the routing summed to what it did before the drop"),
+        ConfigField("drop_prefill", "dropping was applied during prefill as well. Off by default, since a cold cache makes the same threshold discard far more weight there"),
+        ConfigField("temp", "sampling temperature. 0 is greedy decoding — reproducible, and what the gates rely on"),
+        ConfigField("top_k", "sampling candidates kept by rank. Unrelated to n_expert_used, which is the routing width"),
+        ConfigField("top_p", "sampling candidates kept by cumulative probability"),
+        ConfigField("seed", "sampling seed. Inert at temperature 0; otherwise the only thing that makes a run repeatable"),
+        ConfigField("compute_trace_layers", "per-layer compute tracing. It instruments the graph, so a traced run is a diagnostic rather than a benchmark"),
+    )
+
+    private val byName = all.associateBy { it.name }
+    fun of(name: String): ConfigField? = byName[name]
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsCsv.kt
@@ -42,6 +42,11 @@ internal class Csv(
             info["io_threads"]?.let { "$it lanes" },
             if (info["overlap"] == "1") "overlap" else null,
             info["prefetch"]?.takeIf { it != "0" }?.let { "prefetch $it" },
+            // The lossy levers belong in the identity, not only in the config table: a run that
+            // dropped experts is not the same KIND of run as one that did not, and two compare
+            // legends that differ only by this used to read as identical (#136).
+            if (info["predict_prefetch"] == "1") "predict" else null,
+            info["drop_cold_frac"]?.takeIf { (it.toFloatOrNull() ?: 0f) > 0f }?.let { "drop $it" },
         ).joinToString(" · ")
     }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -200,6 +200,9 @@ private fun CsvView(file: File, modifier: Modifier) {
     // One horizontal scroll shared by the header and every row, so the columns stay aligned. Each
     // scrollable Row observes and mutates this one state, so dragging any of them moves them all.
     val hscroll = rememberScrollState()
+    // Held here rather than inside the lazy item so scrolling the config card off-screen does not
+    // collapse it again.
+    var showConfig by remember(file) { mutableStateOf(false) }
     // The whole view is one vertical scroller. The config card, the per-turn summaries and the
     // caption are lazy items, NOT a fixed block above the list — a fixed block grows one summary
     // card per turn and eventually pushes the last token rows off-screen with nothing able to
@@ -226,6 +229,24 @@ private fun CsvView(file: File, modifier: Modifier) {
                             ).joinToString(" · "),
                             fontSize = 11.sp,
                         )
+                        // The lines above are a glance, not the record: they name a handful of
+                        // settings out of the thirty-odd the preamble carries, and the ones they
+                        // leave out (expert dropping above all, which changes the OUTPUT and not
+                        // just the speed) are the ones a saved run is least able to state
+                        // otherwise. Everything the file says is one tap away, and stays one tap
+                        // away as the engine grows knobs. See #136.
+                        val rows = remember(csv) { configRows(csv.info) }
+                        TextButton(
+                            onClick = { showConfig = !showConfig },
+                            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
+                        ) {
+                            Text(
+                                if (showConfig) "Hide full configuration"
+                                else "Full configuration (${rows.size} settings)",
+                                fontSize = 11.sp,
+                            )
+                        }
+                        if (showConfig) ConfigRows(csv.info, MaterialTheme.colorScheme.primary, emptySet())
                     }
                 }
                 Spacer(Modifier.height(4.dp))
@@ -361,33 +382,76 @@ private fun Legend(name: String, label: String, color: Color, series: List<Float
     }
 }
 
-// The run preamble, every field, in the settings screen's order. Kept in full — not just what
-// differs — because a setting that did NOT change between two runs is still worth seeing: "was warm
-// dense on in both?" is a real question, and a diff that hides it cannot answer it.
+// Display order and labels for the preamble keys this build knows about. It is NOT a filter: a key
+// the engine writes and this list does not mention is still rendered, after these, under its own
+// name (see [configRows]). That is the invariant — a knob added to the metrics sink must never need
+// an app change before a saved run can say whether it was on. The previous whitelist quietly drifted
+// behind the engine until a file could not tell you its own drop fraction (#136).
 private val CONFIG_ORDER = listOf(
     "model" to "Model",
+    "engine" to "Engine build",
     "arch" to "Architecture",
     "n_layer" to "Layers",
     "n_expert" to "Experts",
     "n_expert_used" to "Active experts (top-k)",
     "n_ctx" to "Context",
+    "n_ubatch" to "Compute batch (n_ubatch)",
     "threads" to "Compute threads",
+    "chatml" to "Chat template",
     "moe_stream" to "MoE streaming",
     "cache_mb" to "Cache budget (MiB)",
     "cache_auto" to "Cache auto-size",
+    "cache_floor_mb" to "Cache floor (MiB)",
     "cache_ceil_mb" to "Cache ceiling (MiB)",
     "force_cache" to "Force cache",
     "io_threads" to "I/O lanes",
     "o_direct" to "Direct I/O",
     "overlap" to "I/O–compute overlap",
+    "io_two_wave" to "Two-wave publish",
+    "load_all" to "Load all experts",
     "prefetch" to "Temporal prefetch",
+    "predict_prefetch" to "Predictive prefetch",
+    "predict_spec_max" to "Speculated misses/layer",
+    "predict_log" to "Prediction probe",
+    "prefetch_sync" to "Synchronous prefetch",
     "dense_weights" to "Dense weights",
+    "drop_cold_frac" to "Drop cold experts",
+    "drop_renorm" to "Drop renormalise",
+    "drop_prefill" to "Drop in prefill",
+    "temp" to "Temperature",
+    "top_k" to "top-k",
+    "top_p" to "top-p",
+    "seed" to "Seed",
+    "compute_trace_layers" to "Compute trace (layers)",
 )
-private val CONFIG_BOOLS = setOf("moe_stream", "cache_auto", "force_cache", "o_direct", "overlap")
+private val CONFIG_LABELS = CONFIG_ORDER.toMap()
+private val CONFIG_BOOLS = setOf(
+    "moe_stream", "cache_auto", "force_cache", "o_direct", "overlap", "io_two_wave", "load_all",
+    "predict_prefetch", "predict_log", "prefetch_sync", "drop_renorm", "drop_prefill", "chatml",
+    "compute_trace_layers",
+)
+
+/**
+ * The run's whole configuration as (key, label, value), curated keys first and everything else after
+ * — so a file written by a newer engine still shows what it was run with, under raw key names, on a
+ * build that predates the setting. Keys the preamble does not carry are simply absent: an older
+ * engine wrote fewer, and inventing a default for them would be a claim the file never made.
+ */
+private fun configRows(info: Map<String, String>): List<Triple<String, String, String>> {
+    val known = CONFIG_ORDER.mapNotNull { (k, label) -> info[k]?.let { Triple(k, label, prettyConfigValue(k, it)) } }
+    val rest = info.keys.filter { it !in CONFIG_LABELS }.sorted()
+        .map { k -> Triple(k, k, prettyConfigValue(k, info.getValue(k))) }
+    return known + rest
+}
 
 private fun prettyConfigValue(key: String, v: String): String = when {
     key in CONFIG_BOOLS -> if (v == "1") "on" else "off"
-    key == "prefetch" && v == "0" -> "off"
+    // A zero here is not a small setting, it is the feature being off, and reading "0" as "some
+    // dropping happened" is exactly the misreading this display exists to prevent. The drop
+    // fraction is shown as the engine took it (a fraction of the uniform share 1/top-k, not of the
+    // routing) so it matches --drop-cold-experts and the settings screen.
+    (key == "prefetch" || key == "drop_cold_frac") && v.toFloatOrNull() == 0f -> "off"
+    key == "predict_spec_max" && v == "0" -> "0 (retention only)"
     else -> v
 }
 
@@ -409,22 +473,30 @@ private fun FullConfig(csv: Csv, accent: Color, changed: Set<String>) {
                 Canvas(Modifier.size(12.dp)) { drawRect(accent) }
                 Text(csv.info["model"] ?: "run", fontSize = 12.sp, fontWeight = FontWeight.Bold, maxLines = 1)
             }
-            CONFIG_ORDER.forEach { (key, label) ->
-                val v = csv.info[key] ?: return@forEach // a field an older engine did not write
-                val isChanged = key in changed
-                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    Text("$label:", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
-                         modifier = Modifier.weight(1f))
-                    Text(
-                        prettyConfigValue(key, v),
-                        fontSize = 11.sp,
-                        fontFamily = FontFamily.Monospace,
-                        // A changed setting is the reason to be here; make it the thing the eye lands on.
-                        fontWeight = if (isChanged) FontWeight.Bold else FontWeight.Normal,
-                        color = if (isChanged) accent else MaterialTheme.colorScheme.onSurface,
-                    )
-                }
-            }
+            ConfigRows(csv.info, accent, changed)
+        }
+    }
+}
+
+/**
+ * Every configuration row of one run, [changed] ones highlighted in [accent]. Shared by the single
+ * file view and the compare view so the two can never disagree about what a file says it was.
+ */
+@Composable
+private fun ConfigRows(info: Map<String, String>, accent: Color, changed: Set<String>) {
+    configRows(info).forEach { (key, label, value) ->
+        val isChanged = key in changed
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text("$label:", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                 modifier = Modifier.weight(1f))
+            Text(
+                value,
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+                // A changed setting is the reason to be here; make it the thing the eye lands on.
+                fontWeight = if (isChanged) FontWeight.Bold else FontWeight.Normal,
+                color = if (isChanged) accent else MaterialTheme.colorScheme.onSurface,
+            )
         }
     }
 }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -77,7 +77,7 @@ fun MetricsScreen(onBack: () -> Unit) {
                         when (view) {
                             View.COMPARE -> "Compare files"
                             View.CORRELATE -> "Correlate fields"
-                            View.GLOSSARY -> "What the columns mean"
+                            View.GLOSSARY -> "What the fields mean"
                             View.FILE -> picked?.name ?: "Metrics"
                             View.LIST -> "Metrics"
                         },
@@ -94,7 +94,7 @@ fun MetricsScreen(onBack: () -> Unit) {
                         TextButton(onClick = { view = View.CORRELATE }) { Text("Correlate") }
                         picked?.let { f -> TextButton(onClick = { shareCsv(context, listOf(f)) }) { Text("Share") } }
                     }
-                    if (view == View.LIST || view == View.FILE) {
+                    if (view == View.LIST || view == View.FILE || view == View.COMPARE) {
                         TextButton(onClick = { view = View.GLOSSARY }) { Text("?") }
                     }
                 },
@@ -438,13 +438,24 @@ private val CONFIG_BOOLS = setOf(
  * engine wrote fewer, and inventing a default for them would be a claim the file never made.
  */
 private fun configRows(info: Map<String, String>): List<Triple<String, String, String>> {
-    val known = CONFIG_ORDER.mapNotNull { (k, label) -> info[k]?.let { Triple(k, label, prettyConfigValue(k, it)) } }
+    val known = CONFIG_ORDER.mapNotNull { (k, label) ->
+        info[k]?.let { Triple(k, label, prettyConfigValue(k, it, info)) }
+    }
     val rest = info.keys.filter { it !in CONFIG_LABELS }.sorted()
-        .map { k -> Triple(k, k, prettyConfigValue(k, info.getValue(k))) }
+        .map { k -> Triple(k, k, prettyConfigValue(k, info.getValue(k), info)) }
     return known + rest
 }
 
-private fun prettyConfigValue(key: String, v: String): String = when {
+/**
+ * One preamble value, rendered as what it MEANT for the run — which sometimes takes the rest of
+ * [info] to know, because a knob the run never consulted is recorded all the same.
+ */
+private fun prettyConfigValue(key: String, v: String, info: Map<String, String>): String = when {
+    // Read ahead is a property of the prediction, so with the prediction off the engine's own
+    // default (2, config.h) lands in the preamble governing nothing at all — it is the one field of
+    // that block session.cpp does not neutralise when the feature is off. Printing the bare number
+    // reads as "this run speculated two misses per layer", which is exactly false.
+    key == "predict_spec_max" && info["predict_prefetch"] != "1" -> "— (predictive prefetch off)"
     key in CONFIG_BOOLS -> if (v == "1") "on" else "off"
     // A zero here is not a small setting, it is the feature being off, and reading "0" as "some
     // dropping happened" is exactly the misreading this display exists to prevent. The drop
@@ -585,12 +596,14 @@ private fun FieldNote(name: String) {
 @Composable
 private fun GlossaryView(modifier: Modifier) {
     LazyColumn(modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        // Two halves, in the order a file is read: the preamble says what the run was configured
+        // with, the columns say what it then measured.
         item {
-            Text(
-                "Every column the metrics CSV can hold. \"depends\" means neither direction is simply " +
-                    "good — a bigger cache buys hits but risks the reclaim war, and mem_available lies.",
-                fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(vertical = 10.dp),
+            GlossarySection(
+                "Per-token columns",
+                "One row per generated token. \"depends\" means neither direction is simply good — a " +
+                    "bigger cache buys hits but risks the reclaim war, and mem_available lies.",
+                top = 10.dp,
             )
         }
         items(MetricFields.all) { f ->
@@ -604,6 +617,34 @@ private fun GlossaryView(modifier: Modifier) {
             }
             HorizontalDivider()
         }
+        // The configuration half. Showing a run's whole preamble (#136) is only half an answer while
+        // the settings it names go unexplained — several are unguessable from the key alone, and one
+        // (predict_spec_max) is actively misleading read as a bare number.
+        item {
+            GlossarySection(
+                "Run configuration",
+                "The preamble at the top of every file: what the run was configured with, as opposed " +
+                    "to what it measured. Two files whose engine, dropping or prediction differ are " +
+                    "two experiments, not a comparison.",
+                top = 24.dp,
+            )
+        }
+        items(ConfigFields.all) { c ->
+            Column(Modifier.padding(vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(c.name, fontFamily = FontFamily.Monospace, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                Text(c.what, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+/** A glossary section heading and its one-paragraph framing, so both halves are introduced alike. */
+@Composable
+private fun GlossarySection(title: String, blurb: String, top: androidx.compose.ui.unit.Dp) {
+    Column(Modifier.padding(top = top, bottom = 10.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(title, fontSize = 15.sp, fontWeight = FontWeight.Bold)
+        Text(blurb, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 


### PR DESCRIPTION
Closes #136.

Opening a metrics CSV in the app showed a hand-picked subset of what the run was configured with. The engine was never at fault: `csv_metrics_sink.cpp` writes every resolved knob into the `# bmoe_metrics v2` preamble, and `MetricsCsv.kt` parses all of it, unknown keys included. Two display sites then threw most of it away — the single-file header card (eight fields) and the compare view's `CONFIG_ORDER` (a 17-key whitelist that had drifted behind the sink release after release).

The practical cost: a saved run could not tell you whether it dropped experts or at what fraction, whether predictive prefetch was armed, what the sampling parameters were, or which engine build produced the rows. Worse in Compare, where the diff is computed over *all* preamble keys but only whitelisted ones are drawn — an A/B whose only difference was one of those levers rendered two configuration cards that looked byte-for-byte identical.

**What changed**

- One renderer (`configRows` + `ConfigRows`) over the whole preamble, shared by the single-file view and the compare view. Curated keys keep their order and labels; every remaining key is appended under its own name. The order list is no longer a filter, so a knob added to the metrics sink appears without an app change — that is the fix, the missing keys were the symptom.
- The curated list itself grew the keys it had fallen behind on: `engine`, `n_ubatch`, `chatml`, `cache_floor_mb`, `load_all`, `io_two_wave`, `predict_prefetch`, `predict_spec_max`, `predict_log`, `prefetch_sync`, `drop_cold_frac`, `drop_renorm`, `drop_prefill`, `temp`, `top_k`, `top_p`, `seed`, `compute_trace_layers`.
- The single-file card keeps its glance line and gains the full table behind a tap ("Full configuration (N settings)"), so opening a file does not start with thirty rows of settings.
- `Csv.label()` — the short run identity under a chart line and in the compare legends — now carries `drop <frac>` and `predict`. A run that dropped experts is not the same kind of run as one that did not, and the legend is where that has to show.
- A zero renders as `off` for `prefetch` and `drop_cold_frac`, and `predict_spec_max=0` as `0 (retention only)`, so a disabled feature is not read as a small setting.
- Version bumped to 0.18.1 / versionCode 33; CHANGELOG entry added.

**Testing**

`gradlew :app:compileDevDebugKotlin` clean (the one warning is pre-existing, in `Components.kt`). Display-only change: no engine, streaming or seam code is touched, so the byte-identity gates are unaffected. Wants a look on device against an existing CSV before it goes into a release.
