### PR TITLE
research(moe): price a row-sparse expert matmul, and refute it

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -423,6 +423,10 @@ static void print_usage(const char * argv0) {
         "                          predicted below the drop threshold are not speculated.\n"
         "      --predict-spec-max N  speculated predicted misses per layer [0..8] (default 2;\n"
         "                          0 = retention only, the prediction spends no flash at all)\n"
+        "      --gate-sparsity     diagnostics: measure how concentrated the vector each routed\n"
+        "                          expert's down projection consumes is — what a row-sparse expert\n"
+        "                          matmul could skip. Observes only; costs a barrier per layer and\n"
+        "                          a sort per routed slot, on every token including the prompt.\n"
         "      --list-archs        print supported MoE architectures and exit\n"
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
@@ -486,6 +490,46 @@ static void print_predict_report(const RunSummary & s) {
         char ba[16], bb[16], bc[16];
         std::printf("  %5d  %s  %s %s     %6lld\n", (int) il, pct(a, ba, sizeof ba), pct(b, bb, sizeof bb),
                     pct(c, bc, sizeof bc), a.rows);
+    }
+}
+
+// The intra-expert sparsity probe's report (see RunConfig::gate_sparsity).
+//
+// Two curves over the same measurement, because the two questions a row-sparse expert matmul raises
+// are inverses of each other. "rows for N% of mass" says what a quality target costs in rows; "mass
+// at a K% row budget" says what a bandwidth target costs in quality. A lever exists only if the
+// first is small — the routed slot's output is carried by a few of its neurons — and the second
+// stays near 1.0 well below half the rows.
+//
+// Read the aggregate against the per-layer table, not instead of it. A model can be concentrated
+// everywhere except its first layers and still be worth exploiting; the reverse — concentrated on
+// average because a handful of layers are extremely sparse — is not a lever, and only the table
+// tells the two apart.
+static void print_sparsity_report(const RunSummary & s) {
+    const SparsityStats & a = s.sparsity;
+    if (a.slots == 0) {
+        std::printf("moe-sparsity: no routed slots observed (is this a MoE model?)\n");
+        return;
+    }
+    std::printf("moe-sparsity: %lld slots over %.0f intermediate rows each; %.2f%% exactly zero\n", a.slots,
+                a.mean_width(), 100.0 * a.zero_frac());
+    std::printf("moe-sparsity: rows needed for");
+    for (int i = 0; i < 4; ++i)
+        std::printf("  %.0f%% mass %.1f%%", 100.0 * kMassTargets[i], 100.0 * a.row_frac_for(i));
+    std::printf("\n");
+    std::printf("moe-sparsity: mass kept at  ");
+    for (int i = 0; i < 4; ++i)
+        std::printf("  %.2f%% rows %.1f%%", 100.0 * kRowBudgets[i], 100.0 * a.mass_frac_at(i));
+    std::printf("\n");
+
+    const size_t n = s.sparsity_by_layer.size();
+    if (n == 0) return;
+    std::printf("  layer   rows@95%%  mass@25%%  mass@12.5%%     slots\n");
+    for (size_t il = 0; il < n; ++il) {
+        const SparsityStats & L = s.sparsity_by_layer[il];
+        if (L.slots == 0) continue; // a dense layer routes nothing
+        std::printf("  %5d   %7.1f%%  %7.1f%%    %7.1f%%  %8lld\n", (int) il, 100.0 * L.row_frac_for(2),
+                    100.0 * L.mass_frac_at(2), 100.0 * L.mass_frac_at(1), L.slots);
     }
 }
 
@@ -613,6 +657,8 @@ int main(int argc, char ** argv) {
             cfg.moe.predict_prefetch = true;
         else if (a == "--predict-spec-max")
             cfg.moe.predict_spec_max = std::atoi(next("--predict-spec-max"));
+        else if (a == "--gate-sparsity")
+            cfg.gate_sparsity = true;
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)
@@ -643,6 +689,7 @@ int main(int argc, char ** argv) {
     if (!seen.count("--n-expert-used")) cfg.n_expert_used = env_int("BMOE_N_EXPERT_USED", 0);
     if (!seen.count("--predict-log")) cfg.moe.predict_log = env_int("BMOE_PREDICT_LOG", 0) != 0;
     if (!seen.count("--predict-prefetch")) cfg.moe.predict_prefetch = env_int("BMOE_PREDICT_PREFETCH", 0) != 0;
+    if (!seen.count("--gate-sparsity")) cfg.gate_sparsity = env_int("BMOE_GATE_SPARSITY", 0) != 0;
 
     if (cfg.model_path.empty()) {
         print_usage(argv[0]);
@@ -774,5 +821,8 @@ int main(int argc, char ** argv) {
                         (double) cfg.moe.drop_cold_frac);
         if (cfg.moe.predict_log) print_predict_report(s);
     }
+    // Outside the streaming block on purpose: the probe reads a graph intermediate, so it measures
+    // the same model whether its experts arrived from flash or from mmap.
+    if (cfg.gate_sparsity) print_sparsity_report(s);
     return 0;
 }

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -666,8 +666,8 @@ int main(int argc, char ** argv) {
             cfg.gate_sparsity = true;
         else if (a == "--expert-row-sparsity")
             cfg.expert_row_sparsity = (float) std::atof(next("--expert-row-sparsity"));
-        else if (a == "--expert-row-keep-pct")
-            cfg.expert_row_keep_pct = std::atoi(next("--expert-row-keep-pct"));
+        else if (a == "--expert-row-stride")
+            cfg.expert_row_stride = std::atoi(next("--expert-row-stride"));
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -427,6 +427,11 @@ static void print_usage(const char * argv0) {
         "                          expert's down projection consumes is — what a row-sparse expert\n"
         "                          matmul could skip. Observes only; costs a barrier per layer and\n"
         "                          a sort per routed slot, on every token including the prompt.\n"
+        "      --expert-row-sparsity F  LOSSY, and a measurement: zero the lowest-magnitude F of\n"
+        "                          each routed expert's intermediate vector before its down\n"
+        "                          projection. Nothing is skipped — same bytes read, same matmul —\n"
+        "                          so this prices the QUALITY cost of a row-sparse kernel, not its\n"
+        "                          speed. Changes the output. 0 = off.\n"
         "      --list-archs        print supported MoE architectures and exit\n"
         "\n"
         "  Env overrides (flag wins): BMOE_CACHE_MB, BMOE_IO_THREADS, BMOE_PROGRESS, BMOE_OVERLAP, BMOE_PREFETCH, "
@@ -659,6 +664,10 @@ int main(int argc, char ** argv) {
             cfg.moe.predict_spec_max = std::atoi(next("--predict-spec-max"));
         else if (a == "--gate-sparsity")
             cfg.gate_sparsity = true;
+        else if (a == "--expert-row-sparsity")
+            cfg.expert_row_sparsity = (float) std::atof(next("--expert-row-sparsity"));
+        else if (a == "--expert-row-keep-pct")
+            cfg.expert_row_keep_pct = std::atoi(next("--expert-row-keep-pct"));
         else if (a == "--list-archs") {
             std::printf("supported MoE architectures:\n");
             for (int k = 0; k < n_moe_recipes(); ++k)
@@ -823,6 +832,10 @@ int main(int argc, char ** argv) {
     }
     // Outside the streaming block on purpose: the probe reads a graph intermediate, so it measures
     // the same model whether its experts arrived from flash or from mmap.
+    if (cfg.expert_row_sparsity > 0.0f)
+        std::printf("moe-rows: zeroed %lld of %lld intermediate rows (%.1f%%), requested %.0f%%\n", s.rows_zeroed,
+                    s.rows_seen, s.rows_seen > 0 ? 100.0 * s.rows_zeroed / s.rows_seen : 0.0,
+                    100.0 * (double) cfg.expert_row_sparsity);
     if (cfg.gate_sparsity) print_sparsity_report(s);
     return 0;
 }

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -254,13 +254,13 @@ struct RunConfig {
     // See bmoe/sparsity_stats.h and docs/expert-dropping.md for the sibling lossy knob.
     float expert_row_sparsity = 0.0f;
 
-    // EXPERIMENTAL measurement, and it makes the output MEANINGLESS. Percentage of the expert
+    // EXPERIMENTAL measurement, and it makes the output MEANINGLESS. Evaluate only every Nth output row of the expert
     // up-projection's output rows the CPU kernel evaluates; the rest are written as zero and
     // their dot products never run. It prices what a row-sparse expert matmul could save in
     // wall-clock -- a matmul's cost depends on how many rows are computed, not which -- but the
     // kept rows are a fixed stride, not the ones a magnitude threshold would keep. Never a
     // benchmark of quality, only of speed. 100 = off. Requires the forked CPU backend.
-    int expert_row_keep_pct = 100;
+    int expert_row_stride = 1;
 
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -237,6 +237,15 @@ struct RunConfig {
     // bmoe/decode_trace.h for what the layer-mode rows contain.
     bool compute_trace_layers = false;
 
+    // Diagnostics: measure the intra-expert activation sparsity — how concentrated the vector each
+    // routed expert's down projection consumes is. It prices a row-sparse expert matmul before one
+    // is built: rows that hold no mass are rows neither read nor multiplied. Independent of
+    // streaming (a dense run is measurable too) and of quality — it observes and changes nothing.
+    // Expensive by construction: one isolated node per MoE layer plus a sort per routed slot, on
+    // every token of every batch including prefill, so a probed run is not a benchmark run.
+    // See bmoe/sparsity_stats.h.
+    bool gate_sparsity = false;
+
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
 };

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -246,6 +246,22 @@ struct RunConfig {
     // See bmoe/sparsity_stats.h.
     bool gate_sparsity = false;
 
+    // LOSSY, and a measurement rather than an optimisation. Zero the lowest-magnitude fraction of
+    // each routed expert's intermediate vector before its down projection — the CATS/TEAL row
+    // policy, applied to a MoE expert. Nothing is skipped: the rows are zeroed, so the same bytes
+    // are read and the same matmul runs. What it prices is the question a row-sparse kernel cannot
+    // answer for itself, which is whether the model survives losing those rows. 0 = off.
+    // See bmoe/sparsity_stats.h and docs/expert-dropping.md for the sibling lossy knob.
+    float expert_row_sparsity = 0.0f;
+
+    // EXPERIMENTAL measurement, and it makes the output MEANINGLESS. Percentage of the expert
+    // up-projection's output rows the CPU kernel evaluates; the rest are written as zero and
+    // their dot products never run. It prices what a row-sparse expert matmul could save in
+    // wall-clock -- a matmul's cost depends on how many rows are computed, not which -- but the
+    // kept rows are a fixed stride, not the ones a magnitude threshold would keep. Never a
+    // benchmark of quality, only of speed. 100 = off. Requires the forked CPU backend.
+    int expert_row_keep_pct = 100;
+
     SamplingConfig sampling; // greedy by default (temp <= 0); opt-in stochastic decoding
     MoeStreamConfig moe;
 };

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "bmoe/predict_stats.h"
+#include "bmoe/sparsity_stats.h"
 
 #include <cstdint>
 #include <string>
@@ -154,6 +155,12 @@ struct RunSummary {
     PredictorStats predict_stale, predict_stale2, predict_prev, predict_self;
     std::vector<PredictorStats> predict_stale_by_layer, predict_prev_by_layer, predict_self_by_layer;
     long long predict_unscored = 0; // routings the stale-gate probe could not rank (see RouterHook)
+
+    // Intra-expert activation sparsity (all zero unless RunConfig::gate_sparsity). Session totals,
+    // for the same reason the prediction stats are: this estimates a distribution, and every
+    // routing is a sample of it. See bmoe/sparsity_stats.h.
+    SparsityStats sparsity;
+    std::vector<SparsityStats> sparsity_by_layer;
 };
 
 // What this run IS: the model and the configuration every row below it was produced under.

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -161,6 +161,10 @@ struct RunSummary {
     // routing is a sample of it. See bmoe/sparsity_stats.h.
     SparsityStats sparsity;
     std::vector<SparsityStats> sparsity_by_layer;
+
+    // What RunConfig::expert_row_sparsity actually zeroed. The requested fraction is a target;
+    // ties at the cutoff keep more rows than asked for, so the achieved figure is the honest one.
+    long long rows_zeroed = 0, rows_seen = 0;
 };
 
 // What this run IS: the model and the configuration every row below it was produced under.

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -52,6 +52,12 @@ struct SessionConfig {
     // Measure intra-expert activation sparsity. Observes only; expensive. See
     // RunConfig::gate_sparsity and bmoe/sparsity_stats.h.
     bool gate_sparsity = false;
+    // Zero the lowest-magnitude fraction of each routed expert's intermediate vector (LOSSY).
+    // See RunConfig::expert_row_sparsity.
+    float expert_row_sparsity = 0.0f;
+    // Row-sparse up-projection measurement; makes the output meaningless. See
+    // RunConfig::expert_row_keep_pct.
+    int expert_row_keep_pct = 100;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
 };

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -57,7 +57,7 @@ struct SessionConfig {
     float expert_row_sparsity = 0.0f;
     // Row-sparse up-projection measurement; makes the output meaningless. See
     // RunConfig::expert_row_keep_pct.
-    int expert_row_keep_pct = 100;
+    int expert_row_stride = 1;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
 };

--- a/core/include/bmoe/session.h
+++ b/core/include/bmoe/session.h
@@ -17,10 +17,12 @@
 #include "bmoe/config.h"
 #include "bmoe/metrics.h"
 #include "bmoe/runtime.h"
+#include "bmoe/sparsity_stats.h"
 
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace bmoe {
 
@@ -47,6 +49,9 @@ struct SessionConfig {
     // Compute-trace granularity: false = a barrier per graph node, true = per layer boundary.
     // Only read when a compute-trace sink is attached. See RunConfig::compute_trace_layers.
     bool compute_trace_layers = false;
+    // Measure intra-expert activation sparsity. Observes only; expensive. See
+    // RunConfig::gate_sparsity and bmoe/sparsity_stats.h.
+    bool gate_sparsity = false;
     SamplingConfig sampling; // fixed for the session; greedy by default (temp <= 0)
     MoeStreamConfig moe;
 };
@@ -143,6 +148,13 @@ public:
     // flight — call it between generations (e.g. from an app's memory-pressure callback). A no-op
     // when the cache is off. The only way the budget moves after init sizes it.
     void set_cache_budget_mb(int mib);
+
+    // The intra-expert sparsity probe's totals, aggregated over every token the session has run,
+    // and the same broken out per layer (index = layer). All zero unless RunConfig::gate_sparsity
+    // was set. Session totals rather than a per-generation delta: this is a distribution estimate,
+    // and every routing is an equally valid sample of it. See bmoe/sparsity_stats.h.
+    SparsityStats sparsity() const;
+    std::vector<SparsityStats> sparsity_by_layer() const;
 
 private:
     Session();

--- a/core/include/bmoe/sparsity_stats.h
+++ b/core/include/bmoe/sparsity_stats.h
@@ -1,0 +1,54 @@
+// Intra-expert activation sparsity: how concentrated is the vector a routed expert's down
+// projection consumes?
+//
+// The question this exists to answer is whether the "LLM in a Flash" family of ideas has anything
+// left to offer a MoE engine. Top-k routing already skips whole experts; the open question is
+// whether, INSIDE a routed expert, a small share of the intermediate neurons carries the output —
+// in which case a row-sparse down projection would cut both the bytes read and the matmul.
+//
+// It measures only. Nothing here reaches the loading path, and no row is skipped: a probed run
+// reads the same bytes and produces the same tokens as an unprobed one. It is not free (one
+// isolated node per MoE layer, and a sort per routed slot), so a probed run is not a benchmark run.
+#pragma once
+
+namespace bmoe {
+
+// The two curves are read in opposite directions and come from the same sort:
+//   rows_for[i]  — how many rows you must keep to retain kMassTargets[i] of the slot's L1 mass.
+//   mass_at[i]   — how much L1 mass survives if you keep the top kRowBudgets[i] of the rows.
+// L1 (Σ|h|) rather than L2 because the down projection is linear in h: a row's contribution to the
+// output is proportional to its magnitude, not to its square.
+inline constexpr float kMassTargets[4] = {0.50f, 0.90f, 0.95f, 0.99f};
+inline constexpr float kRowBudgets[4] = {0.0625f, 0.125f, 0.25f, 0.50f};
+
+struct SparsityStats {
+    long long slots = 0; // routed (layer, token, expert-slot) triples observed
+    long long rows = 0;  // intermediate width summed over slots — the denominator for row fractions
+    long long zeros = 0; // entries that are exactly 0 (what a ReLU model would hand you for free)
+
+    long long rows_for[4] = {0, 0, 0, 0};     // rows needed per mass target, summed over slots
+    double mass_at[4] = {0.0, 0.0, 0.0, 0.0}; // mass retained per row budget, summed over slots
+
+    // Mean intermediate width of the slots observed; 0 when none were.
+    double mean_width() const { return slots > 0 ? (double) rows / (double) slots : 0.0; }
+
+    // Fraction of rows needed to hold kMassTargets[i], averaged over slots.
+    double row_frac_for(int i) const { return rows > 0 ? (double) rows_for[i] / (double) rows : -1.0; }
+
+    // Fraction of L1 mass retained at kRowBudgets[i], averaged over slots.
+    double mass_frac_at(int i) const { return slots > 0 ? mass_at[i] / (double) slots : -1.0; }
+
+    double zero_frac() const { return rows > 0 ? (double) zeros / (double) rows : -1.0; }
+
+    void add(const SparsityStats & o) {
+        slots += o.slots;
+        rows += o.rows;
+        zeros += o.zeros;
+        for (int i = 0; i < 4; ++i) {
+            rows_for[i] += o.rows_for[i];
+            mass_at[i] += o.mass_at[i];
+        }
+    }
+};
+
+} // namespace bmoe

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -17,6 +17,8 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
     sc.compute_trace_layers = cfg.compute_trace_layers;
     sc.gate_sparsity = cfg.gate_sparsity;
+    sc.expert_row_sparsity = cfg.expert_row_sparsity;
+    sc.expert_row_keep_pct = cfg.expert_row_keep_pct;
     sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
     return sc;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -16,6 +16,7 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.chatml = cfg.chatml;
     sc.n_expert_used = cfg.n_expert_used; // active-expert (top-k) override; 0 = model default
     sc.compute_trace_layers = cfg.compute_trace_layers;
+    sc.gate_sparsity = cfg.gate_sparsity;
     sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
     return sc;

--- a/core/src/engine/runtime.cpp
+++ b/core/src/engine/runtime.cpp
@@ -18,7 +18,7 @@ SessionConfig session_config_from(const RunConfig & cfg) {
     sc.compute_trace_layers = cfg.compute_trace_layers;
     sc.gate_sparsity = cfg.gate_sparsity;
     sc.expert_row_sparsity = cfg.expert_row_sparsity;
-    sc.expert_row_keep_pct = cfg.expert_row_keep_pct;
+    sc.expert_row_stride = cfg.expert_row_stride;
     sc.sampling = cfg.sampling; // greedy by default; opt-in stochastic decoding
     sc.moe = cfg.moe;
     return sc;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -391,7 +391,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.hook->set_row_sparsity(cfg.expert_row_sparsity);
     // Process-global and forked-backend-only: set it here, next to the other expert-path
     // policies, so a session that does not ask for it still clears whatever a previous one set.
-    ggml_cpu_set_expert_row_keep_pct(cfg.expert_row_keep_pct);
+    ggml_cpu_set_expert_row_stride(cfg.expert_row_stride);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -270,6 +270,12 @@ void Session::set_cache_budget_mb(int mib) {
 void Session::cancel() {
     impl_->cancel_requested.store(true, std::memory_order_relaxed);
 }
+SparsityStats Session::sparsity() const {
+    return impl_->hook ? impl_->hook->sparsity() : SparsityStats{};
+}
+std::vector<SparsityStats> Session::sparsity_by_layer() const {
+    return impl_->hook ? impl_->hook->sparsity_by_layer() : std::vector<SparsityStats>{};
+}
 
 std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                                        std::string & error,
@@ -380,6 +386,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.hook->set_drop_policy(cfg.moe.drop_cold_frac, cfg.moe.drop_renorm, cfg.moe.drop_prefill);
     im.hook->set_predict_log(cfg.moe.predict_log);
     im.hook->set_predict_prefetch(cfg.moe.predict_prefetch, cfg.moe.predict_spec_max);
+    im.hook->set_gate_sparsity(cfg.gate_sparsity);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
@@ -391,7 +398,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // The streamer needs the callback to see routing; the compute trace needs it to time nodes.
     // Installing it for the trace alone is what lets a NON-streamed run be measured — the dense
     // mmap baseline the streamed numbers are argued against.
-    if (cfg.moe.enabled || compute_trace) {
+    if (cfg.moe.enabled || compute_trace || cfg.gate_sparsity) {
         cparams.cb_eval = &RouterHook::c_eval;
         cparams.cb_eval_user_data = im.hook.get();
     }
@@ -1025,6 +1032,11 @@ RunResult Session::generate(const GenerateRequest & req,
         s.predict_prev_by_layer = im.hook->predict_prev_by_layer();
         s.predict_self_by_layer = im.hook->predict_self_by_layer();
         s.predict_unscored = im.hook->predict_unscored();
+    }
+    if (im.cfg.gate_sparsity) {
+        // Session totals for the same reason: a distribution estimate wants every sample.
+        s.sparsity = im.hook->sparsity();
+        s.sparsity_by_layer = im.hook->sparsity_by_layer();
     }
     if (sink) sink->on_summary(s);
 

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -12,6 +12,7 @@
 
 #include "llama.h"
 #include "ggml.h"
+#include "ggml-cpu.h"
 
 // llama.cpp's `common` layer (NOT the stable public API): chat-template rendering and
 // reasoning parsing. See the note in the root CMakeLists / docs/seam.md.
@@ -387,6 +388,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     im.hook->set_predict_log(cfg.moe.predict_log);
     im.hook->set_predict_prefetch(cfg.moe.predict_prefetch, cfg.moe.predict_spec_max);
     im.hook->set_gate_sparsity(cfg.gate_sparsity);
+    im.hook->set_row_sparsity(cfg.expert_row_sparsity);
+    // Process-global and forked-backend-only: set it here, next to the other expert-path
+    // policies, so a session that does not ask for it still clears whatever a previous one set.
+    ggml_cpu_set_expert_row_keep_pct(cfg.expert_row_keep_pct);
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = cfg.n_ctx;
@@ -398,7 +403,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // The streamer needs the callback to see routing; the compute trace needs it to time nodes.
     // Installing it for the trace alone is what lets a NON-streamed run be measured — the dense
     // mmap baseline the streamed numbers are argued against.
-    if (cfg.moe.enabled || compute_trace || cfg.gate_sparsity) {
+    if (cfg.moe.enabled || compute_trace || cfg.gate_sparsity || cfg.expert_row_sparsity > 0.0f) {
         cparams.cb_eval = &RouterHook::c_eval;
         cparams.cb_eval_user_data = im.hook.get();
     }
@@ -1032,6 +1037,10 @@ RunResult Session::generate(const GenerateRequest & req,
         s.predict_prev_by_layer = im.hook->predict_prev_by_layer();
         s.predict_self_by_layer = im.hook->predict_self_by_layer();
         s.predict_unscored = im.hook->predict_unscored();
+    }
+    if (im.cfg.expert_row_sparsity > 0.0f) {
+        s.rows_zeroed = im.hook->rows_zeroed();
+        s.rows_seen = im.hook->rows_seen();
     }
     if (im.cfg.gate_sparsity) {
         // Session totals for the same reason: a distribution estimate wants every sample.

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -3,9 +3,11 @@
 #include "ggml.h"
 #include "../io/platform_io.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <string_view>
 
@@ -657,6 +659,95 @@ void RouterHook::score_layer(int il, const int32_t * actual, int nu) {
     pred_self_[il].clear();
 }
 
+void RouterHook::set_gate_sparsity(bool on) {
+    sparsity_on_ = on;
+    sp_by_layer_.assign(n_layer_ > 0 ? n_layer_ : 0, SparsityStats{});
+}
+
+SparsityStats RouterHook::sparsity() const {
+    SparsityStats agg;
+    for (const SparsityStats & L : sp_by_layer_)
+        agg.add(L);
+    return agg;
+}
+
+// One routed slot's concentration curve, from the vector the down projection is about to consume.
+//
+// t is ffn_moe_down-<il>; t->src[1] is that vector, shaped [n_ff_exp, n_expert_used, n_tokens]. Its
+// rows correspond one-to-one with the columns of down_exps, so "how few rows hold the mass" IS the
+// row budget a sparse down projection would need — the reason this is measured here rather than at
+// the gate, whose rows only predict it.
+void RouterHook::sparsity_at_down(const ggml_tensor * t, int il) {
+    const ggml_tensor * h = t->src[1];
+    if (!h || !h->data || h->type != GGML_TYPE_F32 || !ggml_is_contiguous(h)) return;
+    if (il < 0 || il >= (int) sp_by_layer_.size()) return;
+
+    const int nf = (int) h->ne[0]; // intermediate width
+    const int nu = (int) h->ne[1]; // routed experts per token
+    const int nt = (int) h->ne[2]; // tokens in this batch
+    if (nf <= 0 || nu <= 0 || nt <= 0) return;
+
+    SparsityStats & L = sp_by_layer_[il];
+    sp_scratch_.resize((size_t) nf);
+
+    for (int j = 0; j < nt; ++j) {
+        for (int k = 0; k < nu; ++k) {
+            const float * row =
+                (const float *) ((const char *) h->data + (size_t) j * h->nb[2] + (size_t) k * h->nb[1]);
+            double total = 0.0;
+            long long zeros = 0;
+            for (int i = 0; i < nf; ++i) {
+                const float a = std::fabs(row[i]);
+                sp_scratch_[(size_t) i] = a;
+                total += a;
+                if (a == 0.0f) ++zeros;
+            }
+            L.slots += 1;
+            L.rows += nf;
+            L.zeros += zeros;
+            if (total <= 0.0) {
+                // A slot with no mass is perfectly sparse rather than undefined: zero rows hold all
+                // of it. Counting it as "needs every row" would be the opposite of the truth.
+                for (int c = 0; c < 4; ++c)
+                    L.mass_at[c] += 1.0;
+                continue;
+            }
+
+            std::sort(sp_scratch_.begin(), sp_scratch_.end(), std::greater<float>());
+
+            // One descending walk answers both curves: the mass targets are crossings of a running
+            // prefix, the row budgets are readings of it at fixed indices.
+            int next_target = 0;
+            int next_budget = 0;
+            int budget_at[4];
+            for (int c = 0; c < 4; ++c) {
+                // ceil, so a budget always keeps at least one row: floor would round the tightest
+                // budget to zero on a narrow expert and report it as holding no mass.
+                int b = (int) std::ceil((double) kRowBudgets[c] * (double) nf);
+                if (b < 1) b = 1;
+                if (b > nf) b = nf;
+                budget_at[c] = b;
+            }
+            double acc = 0.0;
+            for (int i = 0; i < nf; ++i) {
+                acc += sp_scratch_[(size_t) i];
+                const int kept = i + 1;
+                while (next_target < 4 && acc >= (double) kMassTargets[next_target] * total)
+                    L.rows_for[next_target++] += kept;
+                while (next_budget < 4 && kept >= budget_at[next_budget])
+                    L.mass_at[next_budget++] += acc / total;
+                if (next_target >= 4 && next_budget >= 4) break;
+            }
+            // Floating-point summation can leave the running total a hair under the highest target
+            // even after every row; that is the whole vector, not a missing measurement.
+            while (next_target < 4)
+                L.rows_for[next_target++] += nf;
+            while (next_budget < 4)
+                L.mass_at[next_budget++] += 1.0;
+        }
+    }
+}
+
 void RouterHook::set_trace(bool on) {
     trace_on_ = on;
     pending_ = PendingLayer{};
@@ -885,6 +976,11 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     const int gl =
         (moe_node && predict_on() && source_ && batch_phase_ == 1) ? match_layer_node(t->name, "ffn_moe_logits-") : -1;
     const bool is_logits = gl >= 0;
+    // The sparsity probe's anchor. The trailing "-" keeps the post-matmul chain
+    // (ffn_moe_down_scaled-<il>, ffn_moe_down_biased-<il>) from matching: those carry the layer's
+    // OUTPUT, whereas the probe wants the matmul's input, which only this node's src[1] holds.
+    const int dl = (moe_node && sparsity_on_) ? match_layer_node(t->name, "ffn_moe_down-") : -1;
+    const bool is_down = dl >= 0;
     if (ask && is_logits && gl < n_layer_) {
         ggml_tensor * w = t->src[0];
         if (w && w->op == GGML_OP_NONE && w->data && ggml_is_contiguous(w)) gate_w_[gl] = w;
@@ -908,8 +1004,14 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 }
             }
         }
-        return ctrace_iso || is_topk || weights_iso || (is_logits && predict_log_);
+        return ctrace_iso || is_topk || weights_iso || is_down || (is_logits && predict_log_);
     }
+
+    // The probe reads the down matmul's INPUT, in the callback that fires once that matmul has run.
+    // The buffer is necessarily still live at this instant — ggml cannot have handed it to a later
+    // node before the node consuming it finished — which is why this needs none of the watchdog
+    // the barrier-less prefetch read requires.
+    if (is_down) sparsity_at_down(t, dl);
 
     // The probe attaches to the gate matmul rather than to the topk node because this is where the
     // router's own two inputs are reachable: a graph intermediate cannot be found by name later, and

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -748,6 +748,53 @@ void RouterHook::sparsity_at_down(const ggml_tensor * t, int il) {
     }
 }
 
+void RouterHook::set_row_sparsity(float frac) {
+    row_frac_ = (frac > 0.0f && frac < 1.0f) ? frac : 0.0f;
+    act_name_.assign(n_layer_ > 0 ? n_layer_ : 0, std::string{});
+    rows_zeroed_ = rows_seen_ = 0;
+}
+
+// Zero the lowest-magnitude row_frac_ of each routed slot, in the buffer the down matmul is about
+// to read. Per slot, so every routing keeps the same PROPORTION of its own rows — a global
+// threshold would strip a quiet routing bare and leave a loud one untouched.
+void RouterHook::apply_row_sparsity(ggml_tensor * t) {
+    if (!t->data || t->type != GGML_TYPE_F32 || !ggml_is_contiguous(t)) return;
+    const int nf = (int) t->ne[0], nu = (int) t->ne[1], nt = (int) t->ne[2];
+    if (nf <= 0 || nu <= 0 || nt <= 0) return;
+
+    // How many to keep, not how many to drop: rounding the survivors up means a slot always keeps
+    // at least one row, and the count is exact rather than the complement of a rounded drop.
+    int keep = (int) std::ceil((1.0 - (double) row_frac_) * (double) nf);
+    if (keep < 1) keep = 1;
+    if (keep >= nf) return;
+
+    row_scratch_.resize((size_t) nf);
+    for (int j = 0; j < nt; ++j) {
+        for (int k = 0; k < nu; ++k) {
+            float * row = (float *) ((char *) t->data + (size_t) j * t->nb[2] + (size_t) k * t->nb[1]);
+            for (int i = 0; i < nf; ++i)
+                row_scratch_[(size_t) i] = std::fabs(row[i]);
+            // The keep-th largest magnitude is the cutoff. nth_element is linear, which matters:
+            // this runs for every routed slot of every layer of every token.
+            std::nth_element(row_scratch_.begin(), row_scratch_.begin() + (keep - 1), row_scratch_.end(),
+                             std::greater<float>());
+            const float cut = row_scratch_[(size_t) (keep - 1)];
+            // Ties at the cutoff keep more than `keep` rows rather than fewer — dropping an
+            // arbitrary subset of equal-magnitude rows would make the policy depend on the
+            // partition order, and a run would not reproduce itself.
+            long long zeroed = 0;
+            for (int i = 0; i < nf; ++i) {
+                if (std::fabs(row[i]) < cut) {
+                    row[i] = 0.0f;
+                    ++zeroed;
+                }
+            }
+            rows_zeroed_ += zeroed;
+            rows_seen_ += nf;
+        }
+    }
+}
+
 void RouterHook::set_trace(bool on) {
     trace_on_ = on;
     pending_ = PendingLayer{};
@@ -979,8 +1026,22 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     // The sparsity probe's anchor. The trailing "-" keeps the post-matmul chain
     // (ffn_moe_down_scaled-<il>, ffn_moe_down_biased-<il>) from matching: those carry the layer's
     // OUTPUT, whereas the probe wants the matmul's input, which only this node's src[1] holds.
-    const int dl = (moe_node && sparsity_on_) ? match_layer_node(t->name, "ffn_moe_down-") : -1;
+    const int dl = (moe_node && (sparsity_on_ || row_frac_ > 0.0f)) ? match_layer_node(t->name, "ffn_moe_down-") : -1;
     const bool is_down = dl >= 0;
+    // Learn, once per layer, the name of the node feeding the down matmul, so the next graph can
+    // isolate it and the row policy can edit it before that matmul consumes it.
+    if (ask && is_down && row_frac_ > 0.0f && dl < (int) act_name_.size() && act_name_[dl].empty()) {
+        const ggml_tensor * h = t->src[1];
+        if (h && h->name[0] != '\0') act_name_[dl] = h->name;
+    }
+    // Is THIS node the one a layer learned? Names are unique per layer, so one compare against the
+    // layer parsed out of the name is enough — and a layer that has not learned yet simply runs
+    // undisturbed, exactly as with the policy off. That costs the first token of a run its sparsity.
+    bool is_act = false;
+    if (moe_node && row_frac_ > 0.0f) {
+        const int al = node_layer(t->name);
+        if (al >= 0 && al < (int) act_name_.size() && !act_name_[al].empty()) is_act = act_name_[al] == t->name;
+    }
     if (ask && is_logits && gl < n_layer_) {
         ggml_tensor * w = t->src[0];
         if (w && w->op == GGML_OP_NONE && w->data && ggml_is_contiguous(w)) gate_w_[gl] = w;
@@ -1004,8 +1065,13 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 }
             }
         }
-        return ctrace_iso || is_topk || weights_iso || is_down || (is_logits && predict_log_);
+        return ctrace_iso || is_topk || weights_iso || is_down || is_act || (is_logits && predict_log_);
     }
+
+    // Sparsify BEFORE the probe below reads anything: with both on, the probe should report what the
+    // down matmul actually consumed, and its zero count is then a free check that the policy zeroed
+    // the fraction it was asked for.
+    if (is_act) apply_row_sparsity(t);
 
     // The probe reads the down matmul's INPUT, in the callback that fires once that matmul has run.
     // The buffer is necessarily still live at this instant — ggml cannot have handed it to a later

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -31,6 +31,7 @@
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
 #include "bmoe/predict_stats.h"
+#include "bmoe/sparsity_stats.h"
 #include "expert_stream_source.h"
 
 #include <chrono>
@@ -110,6 +111,25 @@ public:
     // spec_max: how many predicted misses a layer may speculate (0 = retention only). Retention of
     // predicted residents happens at every value — it costs zero bytes.
     void set_predict_prefetch(bool on, int spec_max = 2);
+
+    // ── intra-expert sparsity probe (diagnostics; see bmoe/sparsity_stats.h) ─────────
+    // Measures how concentrated the vector feeding each routed expert's down projection is — the
+    // quantity that decides whether a row-sparse expert matmul could pay. It attaches to the down
+    // matmul rather than to the activation node it consumes: src[1] of ffn_moe_down IS that vector
+    // by construction, whichever activation the architecture used (swiglu, geglu, relu, the clamped
+    // OAI variant), so the probe needs no per-architecture node list and cannot pick up the
+    // gate-only intermediate that some of those branches also emit under a matching name.
+    //
+    // Every token of every batch is sampled, prefill included — a prompt is as valid a sample of
+    // activation sparsity as a generated token, and it delivers hundreds of slots in one graph.
+    // Costs one isolated node per MoE layer plus a sort per routed slot; off by default.
+    void set_gate_sparsity(bool on);
+
+    // Aggregated on read rather than kept alongside the per-layer blocks: the probe runs inside the
+    // eval callback, and a second set of accumulators there would be bookkeeping on a hot path to
+    // save a sum over a few dozen layers once per run.
+    SparsityStats sparsity() const;
+    const std::vector<SparsityStats> & sparsity_by_layer() const { return sp_by_layer_; }
 
     // ── route trace (diagnostics; see bmoe/route_trace.h) ────────────────────────────
     // When on, the hook additionally asks for each layer's router-weight node and records one
@@ -370,6 +390,12 @@ private:
     PendingLayer pending_;
     std::vector<RouteTraceRow> trace_rows_;
     std::unordered_set<int32_t> charged_; // per-flush scratch: experts already charged for a read
+
+    // Intra-expert sparsity probe. All of this is inert unless sparsity_on_.
+    bool sparsity_on_ = false;
+    std::vector<SparsityStats> sp_by_layer_;
+    std::vector<float> sp_scratch_; // one slot's |h|, sorted in place
+    void sparsity_at_down(const ggml_tensor * t, int il);
 
     // Compute trace. All of this is inert unless ctrace_on_. `ctrace_mark_` is the previous
     // isolation boundary: the node reported by the next callback is charged the wall since it.

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -131,6 +131,19 @@ public:
     SparsityStats sparsity() const;
     const std::vector<SparsityStats> & sparsity_by_layer() const { return sp_by_layer_; }
 
+    // ── row sparsity (LOSSY; see RunConfig::expert_row_sparsity) ─────────────────────
+    // Zero the lowest-magnitude `frac` of each routed slot's intermediate vector, so the down
+    // projection sums only the surviving rows. This is the CATS/TEAL policy applied to a MoE
+    // expert, and here it is a MEASUREMENT of that policy's quality cost, not an optimisation: no
+    // byte goes unread and no matmul shrinks, because the rows are zeroed rather than skipped. What
+    // it prices is the only question a row-sparse kernel cannot answer for itself — whether the
+    // model survives losing them. Build the kernel after this says yes, not before.
+    //
+    // The threshold is per slot (keep the top 1-frac of THIS routing's rows) rather than a global
+    // per-layer percentile calibrated offline, as CATS uses. Per-slot needs no calibration pass and
+    // no shipped artifact, which is the difference between a knob and a model conversion.
+    void set_row_sparsity(float frac);
+
     // ── route trace (diagnostics; see bmoe/route_trace.h) ────────────────────────────
     // When on, the hook additionally asks for each layer's router-weight node and records one
     // RouteTraceRow per routed expert. Rows buffer in RAM — the callback runs on a compute
@@ -153,6 +166,8 @@ public:
 
     long long experts_routed() const { return experts_routed_; }
     long long experts_dropped() const { return experts_dropped_; }
+    long long rows_zeroed() const { return rows_zeroed_; }
+    long long rows_seen() const { return rows_seen_; }
 
     // Prediction accuracy, aggregate and per layer (index = layer). Empty/zero unless the probe
     // was armed. `predict_unscored` counts routings the probe had to skip: the first token, whose
@@ -396,6 +411,20 @@ private:
     std::vector<SparsityStats> sp_by_layer_;
     std::vector<float> sp_scratch_; // one slot's |h|, sorted in place
     void sparsity_at_down(const ggml_tensor * t, int il);
+
+    // Row sparsity. Inert unless row_frac_ > 0.
+    //
+    // The node to edit is the one feeding the down matmul, and its NAME is learned from the graph
+    // rather than matched against a list of activation names: the ask pass sees ffn_moe_down-<il>
+    // and its sources, so src[1]->name says exactly which node to isolate on the next graph. A list
+    // would have to know that the clamped SwiGLU branch emits ffn_moe_silu for its gate-only
+    // intermediate as well as ffn_moe_swiglu_limited for the product — and would silently sparsify
+    // the wrong one on any architecture whose branch it did not anticipate.
+    float row_frac_ = 0.0f;
+    std::vector<std::string> act_name_; // per layer, the learned name of the down matmul's input
+    std::vector<float> row_scratch_;    // magnitudes, partitioned by nth_element
+    long long rows_zeroed_ = 0, rows_seen_ = 0;
+    void apply_row_sparsity(ggml_tensor * t);
 
     // Compute trace. All of this is inert unless ctrace_on_. `ctrace_mark_` is the previous
     // isolation boundary: the node reported by the next callback is charged the wall since it.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -47,6 +47,17 @@ data class AppSettings(
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
     val dropColdPct: Int = 75,
+    // ── row-sparsity diagnostics (see docs; both default to off) ─────────────────────────────
+    // Zero the lowest-magnitude percentage of each routed expert's intermediate vector before its
+    // down projection. Quality-preserving in principle (the rows dropped are the ones that carry
+    // no mass) and it costs nothing and SAVES nothing: the rows are zeroed, not skipped. Answers
+    // "does the model survive losing them", which is the only question the kernel cannot answer.
+    val expertRowSparsityPct: Int = 0,
+    // Evaluate only every Nth output row of the expert up-projection in the CPU kernel. This one
+    // really does skip the work, so the tok/s it reports is real — but the rows it keeps are a
+    // fixed stride rather than the ones that matter, so THE REPLY IS MEANINGLESS. A stopwatch,
+    // not a feature. 1 = off; 0 skips the projection entirely (the ceiling).
+    val expertRowStride: Int = 1,
     val thinking: Boolean = false,      // reasoning; off passes --no-think (enable_thinking=false)
     val metricsCsv: Boolean = true,     // write the engine's per-token CSV for this session (--csv)
 ) {
@@ -115,6 +126,11 @@ data class AppSettings(
             // of the uniform share; the setting is stored as a percentage.
             if (dropColdPct > 0 && cacheOn) a += listOf("--drop-cold-experts", (dropColdPct / 100.0).toString())
         }
+        // Both diagnostics act on the expert FFN, which exists with or without streaming, so they
+        // sit outside the mmap gate: the row policy is measurable against the mmap baseline too.
+        if (expertRowSparsityPct > 0)
+            a += listOf("--expert-row-sparsity", (expertRowSparsityPct / 100.0).toString())
+        if (expertRowStride != 1) a += listOf("--expert-row-stride", expertRowStride.toString())
         return a
     }
 
@@ -126,7 +142,8 @@ data class AppSettings(
      */
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, oDirect,
-               overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct)
+               overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct,
+               expertRowSparsityPct, expertRowStride)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -142,6 +159,8 @@ data class AppSettings(
             .putBoolean("predictPrefetch", predictPrefetch)
             .putInt("predictSpecMax", predictSpecMax)
             .putInt("dropColdPct", dropColdPct)
+            .putInt("expertRowSparsityPct", expertRowSparsityPct)
+            .putInt("expertRowStride", expertRowStride)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
             .apply()
@@ -214,6 +233,10 @@ data class AppSettings(
         // above it the threshold could exceed every weight in a routing. The rungs below it are the
         // conservative half of the curve, where the replay already beats a top-k cut on both axes.
         val DROP_COLD_CHOICES = intArrayOf(0, 50, 75, 100)
+        val ROW_SPARSITY_CHOICES = intArrayOf(0, 25, 50, 75)
+        // Powers of two, plus 0 = skip the projection outright. The kernel rounds anything else
+        // down to a power of two, so offering values it would silently change would be a lie.
+        val ROW_STRIDE_CHOICES = intArrayOf(1, 2, 4, 8, 0)
         val THREAD_CHOICES = intArrayOf(2, 4, 6, 8)
         val NPREDICT_CHOICES = intArrayOf(16, 32, 48, 64, 128, 256, 512, 1024, 2048)
 
@@ -245,6 +268,8 @@ data class AppSettings(
                 predictPrefetch = p.getBoolean("predictPrefetch", d.predictPrefetch),
                 predictSpecMax = p.getInt("predictSpecMax", d.predictSpecMax),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
+                expertRowSparsityPct = p.getInt("expertRowSparsityPct", d.expertRowSparsityPct),
+                expertRowStride = p.getInt("expertRowStride", d.expertRowStride),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -217,6 +217,51 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 }
             }
 
+            // Two diagnostics for the row-sparsity question ("LLM in a flash" applied inside an
+            // expert). They are deliberately NOT one setting: one changes quality without changing
+            // speed, the other changes speed without leaving the answer usable, and the whole point
+            // is that each is read on its own.
+            Section("Row sparsity (diagnostics)") {
+                IntSetting(
+                    "Zero low-magnitude rows (%)", AppSettings.ROW_SPARSITY_CHOICES,
+                    current.expertRowSparsityPct,
+                    format = { if (it == 0) "off" else "$it%" },
+                ) { onChange(current.copy(expertRowSparsityPct = it)) }
+                Text(
+                    "Inside each routed expert, discards the quietest share of its neurons before the " +
+                        "final projection — the rows that carry almost none of the output. Nothing is read " +
+                        "or computed any faster: this measures whether the model still answers correctly, " +
+                        "not whether it answers sooner. Watch the replies, not the tok/s.",
+                    fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                IntSetting(
+                    "Skip up-projection rows (stopwatch)", AppSettings.ROW_STRIDE_CHOICES,
+                    current.expertRowStride,
+                    format = {
+                        when (it) {
+                            1 -> "off"
+                            0 -> "skip all — the ceiling"
+                            else -> "1 row in $it"
+                        }
+                    },
+                ) { onChange(current.copy(expertRowStride = it)) }
+                Text(
+                    "This one really does skip the arithmetic, so the tok/s it shows is real. But it keeps " +
+                        "an arbitrary stride of rows instead of the ones that matter, so the reply is " +
+                        "nonsense by construction — often a repeated loop. That is expected and is not a bug.",
+                    fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (current.expertRowStride != 1) {
+                    Text(
+                        "⚠ The reply is meaningless while this is on. Read only the speed, and compare it " +
+                            "against the same prompt with this off. Beware that a degenerate reply routes to " +
+                            "very few experts, which lifts the cache hit rate and cuts flash reads on its own " +
+                            "— so the honest figure is the compute term in the metrics panel, not tok/s.",
+                        fontSize = 12.sp, color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+
             Section("Compute") {
                 IntSetting("Compute threads", AppSettings.THREAD_CHOICES, current.threads) {
                     onChange(current.copy(threads = it))


### PR DESCRIPTION
**Draft on purpose — not for merge.** This prices the "LLM in a Flash" neuron-selection idea,
adapted to a MoE engine, and the answer is that it does not pay here. Opening it so the
measurement and the reason are on the record rather than in a chat log.

## The question

Top-k routing already skips whole experts. The open question was whether, *inside* a routed
expert, a small share of the intermediate neurons carries the output — in which case a
row-sparse expert matmul would cut the bytes read and the arithmetic together.

## What was built

Two knobs on the engine and a kernel on the fork, all off by default, all measurements
rather than features:

| flag | what it does | what it prices |
|---|---|---|
| `--gate-sparsity` | observes how concentrated each routed expert's intermediate vector is | is there sparsity at all |
| `--expert-row-sparsity F` | zeroes the lowest-magnitude `F` of that vector | **quality** — costs nothing, saves nothing |
| `--expert-row-stride N` | evaluates only every `N`th output row of the up-projection | **speed** — reply is meaningless by construction |

The last one needs `ggml_cpu_set_expert_row_stride` from
[`Helldez/llama.cpp@bmoe/row-sparse-experiment`](https://github.com/Helldez/llama.cpp/tree/bmoe/row-sparse-experiment),
one commit on top of the existing expert-ready-hook branch. No in-tree patch, per the
project's first hard rule; the fork branch is the sanctioned fallback and was agreed before
it was written.

They are deliberately three knobs and not one: quality and speed cannot be read off the same
cell, and merging them would produce a number nobody could interpret.

## The measurements

**Sparsity exists, but it is not structure.** `--gate-sparsity` over two models:

| | rows for 95% of L1 mass | mass at 25% of rows | at 12.5% | exact zeros |
|---|---|---|---|---|
| Qwen3.6-35B-A3B (512-wide experts) | 65.2% | 64.6% | 44.1% | 1.14% |
| Qwen3-30B-A3B (768-wide experts) | 65.6% | 65.0% | 44.9% | 0.00% |
| swiglu of gaussian noise | 61.9% | 71.6% | 53.0% | — |
| plain gaussian | 75.0% | 51.6% | 30.8% | — |

Read the third row first: a SwiGLU of *independent gaussian noise* is more concentrated than
either real model. The concentration these models show is what the nonlinearity does to an
unstructured vector, and slightly less of it.

**Quality is not the blocker, though.** A mass-retention criterion turned out to be far too
conservative — the literature (CATS at 50%, TEAL at 40-50%, and an MoE intra-expert result at
up to 90%) says these rows can go for 1-2% on downstream tasks, and a smoke test held the
exact answer with 75% of rows zeroed. The blocker is on the other side.

**The ceiling, measured rather than deduced.** Prefill of a fixed 588-token prompt, so every
cell does identical work; cache pinned at 3000 MiB; baseline run first *and* last:

| stride | rows of up computed | compute | vs baseline |
|---|---|---|---|
| 1 | 100% | 20.49 s | +0.6% |
| 2 | 50% | 19.62 s | −3.6% |
| 4 | 25% | 18.74 s | −8.0% |
| 8 | 12.5% | 18.62 s | −8.5% |
| **0** | **0%** | **18.37 s** | **−9.8%** |
| 1 | 100% | 20.23 s | −0.6% |

Deleting the up-projection outright costs **9.8% of prefill compute**. No row policy can beat
cancelling every row, so that is the bound. On the reference device (compute ~77% of wall) a
CATS-style policy is worth ~+2.9% tok/s at 50% sparsity and ~+6.5% at 75%.

For comparison, both already shipped and neither needs a kernel: `--n-expert-used 6` measured
+22-24%, `--drop-cold-experts` +55-84%.

## Why the down-projection cannot be included

`ffn_up_exps` is `{n_embd, n_ff, n_expert}`: a neuron is a whole output row spanning an integer
number of quantization blocks, so skipping it is clean. `ffn_down_exps` is
`{n_ff, n_embd, n_expert}`, where those same neurons are scattered positions *inside* every
block along the reduction axis — nothing is skippable there without dequantizing the block
regardless. CATS and TEAL do not meet this because they run fp16 on GPU, where a gather along
K is cheap and quantization blocks do not exist. On a quantized gguf the symmetry breaks.

The I/O half fails for a related reason: the reads are issued at the routing node, before the
gate that would decide the mask exists, and a magnitude mask selects *scattered* ~1.1 KB rows —
the sub-256 KB regime `tools/bmoe-iobench` already measured as bandwidth death, and the
mechanism that closed the sidecar (#90).

## Two traps this measurement fell into, recorded so the next one does not

1. **A tok/s that was not real.** The first decode sweep showed +70%. It was an artefact: with
   the numerics broken the model degenerates into a `<think></think>` loop, which routes to a
   tiny repeating expert set, lifts the cache hit rate to 90.7% and collapses flash reads. The
   kernel runs *after* the reads and cannot touch them — when a number improves where a change
   cannot reach, the experiment is broken, not the change. Only the compute term is readable.

2. **`--compute-trace` overstates small nodes.** It budgeted the up-projection at 19.1% of
   decode compute; removing the work entirely says ~10%. A barrier per node inflates small
   nodes by roughly 2x. **Any attribution in this repo taken from a per-op trace deserves
   re-reading against a measurement that removes work and watches what disappears.** That is
   probably worth more than the feature this PR set out to build.

## Validation

- Host gates 7/7 green on this branch (the diagnostics are off by default, so the byte-identity
  path is untouched).
- `--expert-row-sparsity` zeroes what it is asked to: 1,965,696 of 2,621,440 rows at F=0.75.
- clang-format 18 clean.
- Android app compiles; the two settings ship off.

## Disposition

Closing unmerged. The engine keeps nothing; the fork branch stays as the record of what the
kernel looked like. What is worth carrying forward is a docs entry — the layout argument, the
9.8% ceiling, and the `--compute-trace` correction — which belongs in `docs/roadmap.md`
alongside the other measured negatives, in its own PR.
