### PR TITLE
perf(io): read expert slices straight into the cache, with no bounce copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,14 @@ Semantic Versioning.
   (Qwen3.6-35B-A3B Q4_0, cache 2000 MiB, overlap, interleaved cells so thermal drift hits both):
   **+20% tok/s**, 3.65 → 4.40 median, with the compute residual down 0.180 → 0.143 s/token, the
   same bytes read (230.77 MiB/token in every cell) and the generated text **byte-identical** with
-  the flag on and off. This is not specific to any decode feature: every expert read goes through
+  the flag on and off. That figure comes from short single-turn CLI runs, and it hid a leak: off
+  the page boundary the first and last page of every slice is shared with the neighbouring expert,
+  and eviction — which may never free a page a neighbour still uses — left two pages behind each
+  time. Over a long app session that grew the anonymous footprint tens of MiB a turn, went to zram,
+  and came back as major faults (1-7 per token without the flag; 66 then 332 with it, rising turn
+  over turn), making the flag a net LOSS in the app: 4.41-4.57 tok/s against 5.02-5.58. Eviction now
+  releases a boundary page once the neighbour sharing it is gone, and **both numbers are owed a
+  re-measurement on a long session** before either is quotable. This is not specific to any decode feature: every expert read goes through
   this path. The host gates cannot prove it — a tiny test model's per-expert stride is not a
   multiple of the page size, so the placement declines and the gates show only that the flag is
   harmless — so the engine reports which happened (`odirect-zero-copy ON|INERT — n/m layer buffers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,32 @@ Semantic Versioning.
   (compressed sparse attention, the lightning indexer and its dedicated KV cache) is dense-side
   llama.cpp code, invisible to the streaming seam. Requires a llama.cpp with DeepSeek V4 support
   (the pinned submodule has it).
+- **`--odirect-zero-copy` — read expert slices straight into the cache, with no bounce copy
+  (off by default).** O_DIRECT wants the file offset, the length and the buffer address aligned.
+  Expert slices are a whole number of pages long, but a gguf's tensor data does not start on a page
+  boundary — `general.alignment` is 32 by default, so on the measured model family every expert
+  offset sits a constant 1152 bytes past one. The reader therefore pulled the enclosing aligned
+  window into a per-lane bounce buffer and `memcpy`'d the payload back by that remainder: over
+  200 MiB a token of pure shift correction, on a device whose decode is already memory-bound. The
+  shift exists only because the destination did not share the file's remainder — and it can, since
+  this engine reserves the per-layer buffers itself. With the flag on, each buffer is placed at an
+  address carrying its own tensor's remainder; every expert inherits it (the per-expert stride is a
+  multiple of the page size), so the aligned window maps onto the buffer in place and the read
+  needs no copy at all. The window overhangs its neighbours' slices, which is safe by construction
+  rather than by luck: buffer and file differ by a constant offset under this placement, so the
+  overhung bytes get their own correct file contents, into pages the entry's commit already covers
+  exactly (eviction never releases a page shared with a neighbour). Measured on device
+  (Qwen3.6-35B-A3B Q4_0, cache 2000 MiB, overlap, interleaved cells so thermal drift hits both):
+  **+20% tok/s**, 3.65 → 4.40 median, with the compute residual down 0.180 → 0.143 s/token, the
+  same bytes read (230.77 MiB/token in every cell) and the generated text **byte-identical** with
+  the flag on and off. This is not specific to any decode feature: every expert read goes through
+  this path. The host gates cannot prove it — a tiny test model's per-expert stride is not a
+  multiple of the page size, so the placement declines and the gates show only that the flag is
+  harmless — so the engine reports which happened (`odirect-zero-copy ON|INERT — n/m layer buffers
+  placed`) rather than letting a silent no-op read as a pass. Falls back to the bounce when the
+  remainder would leave the tensor under-aligned for the compute kernels, when the stride is not a
+  multiple of the alignment, or when O_DIRECT was refused. Off by default pending a confirmation
+  run on a cool device. See `docs/moe-streaming.md`.
 
 ## [0.18.1] - 2026-07-29
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -392,6 +392,9 @@ static void print_usage(const char * argv0) {
         "      --cache-ceil-mb N   with --cache-mb auto: upper bound on the budget (0 = no cap)\n"
         "      --io-threads N      parallel expert-read lanes [1..%d] (default 4)\n"
         "      --no-odirect        do not bypass the page cache for expert reads\n"
+        "      --odirect-zero-copy read expert slices straight into the cache, with no bounce copy\n"
+        "                          (places the layer buffers to match the file's alignment; off by\n"
+        "                          default pending the device A/B)\n"
         "      --dense-weights M   dense (non-expert) weight policy: mmap | warm | anon (default) | ahwb\n"
         "                          (warm = page-cache them at load, best when the model fits in RAM;\n"
         "                          anon = read via O_DIRECT into our own buffers and rebind, so a\n"
@@ -568,6 +571,8 @@ int main(int argc, char ** argv) {
             cfg.moe.io_threads = std::atoi(next("--io-threads"));
         else if (a == "--no-odirect")
             cfg.moe.o_direct = false;
+        else if (a == "--odirect-zero-copy")
+            cfg.moe.odirect_zero_copy = true;
         else if (a == "--dense-weights") {
             const std::string m = next("--dense-weights");
             if (m == "mmap")

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -61,7 +61,29 @@ struct MoeStreamConfig {
     // Clamped to [1, io_threads_max]. 4 is the measured sweet spot on UFS4 phones.
     int io_threads = 4;
 
-    bool o_direct = true;     // bypass the page cache (O_DIRECT / FILE_FLAG_NO_BUFFERING)
+    bool o_direct = true; // bypass the page cache (O_DIRECT / FILE_FLAG_NO_BUFFERING)
+
+    // Read expert slices straight into the cache buffers, with no bounce copy.
+    //
+    // O_DIRECT dictates that the file offset, the length and the buffer address all be aligned,
+    // and a gguf's expert tensor data does not start on a page boundary (the default
+    // `general.alignment` is 32, so on this file family every expert offset sits a constant 1152
+    // bytes past one). The reader therefore pulls the enclosing aligned window into a per-lane
+    // bounce buffer and memcpy's the payload back by that remainder — 200+ MiB a token of pure
+    // shift correction, on a device whose decode is already memory-bound.
+    //
+    // The shift is only needed because the destination does NOT share the file's sub-page
+    // remainder. It can: this engine reserves the per-layer buffers itself, so with this on they
+    // are placed at an address carrying the tensor's own remainder. Every expert inherits it (the
+    // per-expert stride is a multiple of the page size), the aligned window then maps onto the
+    // buffer at the same relative position, and the read lands where mul_mat_id expects it with
+    // no copy at all. The window's overhang writes a neighbouring expert's boundary bytes — with
+    // the identical values from the same file, into pages the commit already covers exactly.
+    //
+    // Off by default until the device A/B; falls back to the bounce whenever the remainder would
+    // leave the tensor under-aligned for the compute kernels, or the reader is in buffered mode.
+    bool odirect_zero_copy = false;
+
     bool load_all = false;    // debug/A-B: load ALL experts each token (full-sweep baseline)
     bool force_cache = false; // allow a cache_mb in the pathological band (tests/experiments)
 

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -188,6 +188,7 @@ struct RunInfo {
     bool load_all = false; // whole-expert-set baseline: reads everything, so its bytes mean something else
     int io_threads = 0;
     bool o_direct = false;
+    bool odirect_zero_copy = false; // expert slices read straight into the cache, no bounce copy
     bool overlap = false;
     bool io_two_wave = false; // two-wave batch publish (#118): first projection published early
     int prefetch_layers = 0;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -584,6 +584,7 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         ri.load_all = cfg.moe.enabled && cfg.moe.load_all;
         ri.io_threads = cfg.moe.enabled ? cfg.moe.io_threads : 0;
         ri.o_direct = cfg.moe.enabled && cfg.moe.o_direct;
+        ri.odirect_zero_copy = cfg.moe.enabled && cfg.moe.o_direct && cfg.moe.odirect_zero_copy;
         ri.overlap = cfg.moe.enabled && cfg.moe.overlap;
         ri.io_two_wave = cfg.moe.enabled && cfg.moe.io_two_wave;
         ri.prefetch_layers = cfg.moe.enabled ? cfg.moe.prefetch_layers : 0;

--- a/core/src/io/file_reader.cpp
+++ b/core/src/io/file_reader.cpp
@@ -91,7 +91,7 @@ bool FileReader::open(const std::string & path, int lanes, bool direct, size_t a
     return true;
 }
 
-long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) {
+long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes, bool allow_in_place) {
     if (nbytes == 0) return 0;
     const pio::fd_t fd = fds_[lane];
 
@@ -124,19 +124,22 @@ long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) 
     const uint64_t shift = off - a0; // where the payload sits inside the aligned window
 
     // Zero-copy: the bounce exists only to undo `shift`, so when the caller's buffer already
-    // carries the same sub-alignment remainder as the file offset, there is nothing to undo —
-    // the aligned window maps onto the destination at the same relative position and can be read
-    // in place. The streamer places its per-layer buffers that way deliberately (see
-    // MoeStreamConfig::odirect_zero_copy); every other caller simply fails this test and keeps
-    // the copy, so the fast path needs no flag of its own and cannot be entered by accident.
+    // carries the same sub-alignment remainder as the file offset, there is nothing to undo — the
+    // aligned window maps onto the destination at the same relative position and can be read in
+    // place. The streamer places its per-layer buffers that way deliberately (see
+    // MoeStreamConfig::odirect_zero_copy).
     //
-    // The window overhangs the payload on both sides, so this writes up to `shift` bytes before
-    // the destination and the rest of a page after it. Those bytes belong to the neighbouring
-    // slices, and they receive their own correct file contents — buffer and file differ by a
-    // constant offset here, which is exactly what the remainder match establishes. The caller is
-    // responsible for the overhung pages being writable; for the expert cache they are, because
-    // its page commit covers precisely this window.
-    const bool in_place = ((uintptr_t) dst & (uintptr_t) (align_ - 1)) == (uintptr_t) shift;
+    // The remainder match is necessary but NOT sufficient, which is why `allow_in_place` exists.
+    // The window overhangs the payload at both ends — up to `shift` bytes before it and the rest
+    // of a page after — so the destination must have room for bytes beyond the slice it asked for.
+    // The expert cache does: one contiguous reservation per layer, whose page commit covers
+    // precisely this window, and where the overhung bytes belong to neighbouring experts and
+    // receive their own correct file contents (buffer and file differ by a constant offset there).
+    // A caller with a separately sized buffer does not, and the most ordinary case of all — a
+    // page-aligned tensor offset read into a page-aligned buffer — passes the remainder test with
+    // shift 0 while the window is still a page longer than the tensor. Inferring the fast path
+    // from addresses alone therefore overran the dense loader's buffers; it is a promise now.
+    const bool in_place = allow_in_place && ((uintptr_t) dst & (uintptr_t) (align_ - 1)) == (uintptr_t) shift;
 
     char * b;
     if (in_place) {

--- a/core/src/io/file_reader.cpp
+++ b/core/src/io/file_reader.cpp
@@ -121,21 +121,43 @@ long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) 
     const uint64_t a0 = off & ~(uint64_t) (align_ - 1);
     const uint64_t a1 = (off + nbytes + align_ - 1) & ~(uint64_t) (align_ - 1);
     const size_t len = (size_t) (a1 - a0);
-    if (bounce_sz_[lane] < len) {
-        // Clear the size BEFORE the allocation: on failure the lane must look empty, not keep
-        // advertising the freed buffer's capacity — a later smaller read would skip the realloc and
-        // pread into a null pointer, turning one transient OOM into a permanently dead lane.
-        if (bounces_[lane]) pio::aligned_free(bounces_[lane]);
-        bounces_[lane] = nullptr;
-        bounce_sz_[lane] = 0;
-        bounces_[lane] = pio::alloc_aligned(align_, len);
-        if (!bounces_[lane]) {
-            std::fprintf(stderr, "bmoe: bounce realloc %zu failed\n", len);
-            return -1;
+    const uint64_t shift = off - a0; // where the payload sits inside the aligned window
+
+    // Zero-copy: the bounce exists only to undo `shift`, so when the caller's buffer already
+    // carries the same sub-alignment remainder as the file offset, there is nothing to undo —
+    // the aligned window maps onto the destination at the same relative position and can be read
+    // in place. The streamer places its per-layer buffers that way deliberately (see
+    // MoeStreamConfig::odirect_zero_copy); every other caller simply fails this test and keeps
+    // the copy, so the fast path needs no flag of its own and cannot be entered by accident.
+    //
+    // The window overhangs the payload on both sides, so this writes up to `shift` bytes before
+    // the destination and the rest of a page after it. Those bytes belong to the neighbouring
+    // slices, and they receive their own correct file contents — buffer and file differ by a
+    // constant offset here, which is exactly what the remainder match establishes. The caller is
+    // responsible for the overhung pages being writable; for the expert cache they are, because
+    // its page commit covers precisely this window.
+    const bool in_place = ((uintptr_t) dst & (uintptr_t) (align_ - 1)) == (uintptr_t) shift;
+
+    char * b;
+    if (in_place) {
+        b = (char *) dst - shift;
+    } else {
+        if (bounce_sz_[lane] < len) {
+            // Clear the size BEFORE the allocation: on failure the lane must look empty, not keep
+            // advertising the freed buffer's capacity — a later smaller read would skip the realloc
+            // and pread into a null pointer, turning one transient OOM into a permanently dead lane.
+            if (bounces_[lane]) pio::aligned_free(bounces_[lane]);
+            bounces_[lane] = nullptr;
+            bounce_sz_[lane] = 0;
+            bounces_[lane] = pio::alloc_aligned(align_, len);
+            if (!bounces_[lane]) {
+                std::fprintf(stderr, "bmoe: bounce realloc %zu failed\n", len);
+                return -1;
+            }
+            bounce_sz_[lane] = len;
         }
-        bounce_sz_[lane] = len;
+        b = (char *) bounces_[lane];
     }
-    char * b = (char *) bounces_[lane];
     const pio::fd_t fd_buf = fds_buf_[lane];
     const uint64_t read_end = (fsize_ && a1 > fsize_) ? fsize_ : a1;
     const uint64_t bulk_end = read_end & ~(uint64_t) (align_ - 1);
@@ -165,7 +187,7 @@ long long FileReader::read(int lane, void * dst, uint64_t off, uint64_t nbytes) 
     }
     const auto t1 = clock_t_::now();
     syscall_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-    std::memcpy(dst, b + (off - a0), (size_t) nbytes);
+    if (!in_place) std::memcpy(dst, b + shift, (size_t) nbytes);
     const long long window = (long long) (read_end - a0);
     read_bytes_.fetch_add(window);
     return window; // the aligned window pulled — what the effective bandwidth is judged against

--- a/core/src/io/file_reader.h
+++ b/core/src/io/file_reader.h
@@ -46,7 +46,15 @@ public:
     // the drive — the aligned window (>= nbytes) when direct, exactly the requested bytes when
     // buffered — which is what the bandwidth must be judged against; or -1 on I/O error. A
     // zero-length read is a no-op returning 0. The lane's bounce grows if a direct read needs more.
-    long long read(int lane, void * dst, uint64_t off, uint64_t nbytes);
+    //
+    // `allow_in_place` is a PROMISE from the caller, never an inference: that the pages either side
+    // of [dst, dst+nbytes) — up to the enclosing alignment boundaries — are writable and are the
+    // caller's to clobber. Given it, and given `dst` carrying the same sub-alignment remainder as
+    // `off`, the aligned window is read straight into place and the bounce copy disappears. Only
+    // the expert cache can promise that (it reserves one contiguous range per layer and places it
+    // to match the file); the dense loader, whose tensors are separately sized buffers, must not —
+    // for it the window is simply longer than the tensor and would run off the end.
+    long long read(int lane, void * dst, uint64_t off, uint64_t nbytes, bool allow_in_place = false);
 
     // Aggregate accounting since open, summed across lanes.
     long long read_bytes() const { return read_bytes_.load(std::memory_order_relaxed); }

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -36,13 +36,14 @@ public:
                      r.n_ubatch, r.chatml);
         std::fprintf(f_,
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_floor_mb=%d cache_ceil_mb=%d "
-                     "force_cache=%d load_all=%d io_threads=%d o_direct=%d overlap=%d io_two_wave=%d prefetch=%d "
+                     "force_cache=%d load_all=%d io_threads=%d o_direct=%d odirect_zero_copy=%d overlap=%d "
+                     "io_two_wave=%d prefetch=%d "
                      "predict_prefetch=%d predict_log=%d predict_spec_max=%d prefetch_sync=%d "
                      "dense_weights=%s drop_cold_frac=%.4g drop_renorm=%d drop_prefill=%d\n",
                      r.moe_stream, r.cache_mb, r.cache_auto, r.cache_floor_mb, r.cache_ceil_mb, r.force_cache,
-                     r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave, r.prefetch_layers,
-                     r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync, r.dense_weights.c_str(),
-                     (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
+                     r.load_all, r.io_threads, r.o_direct, r.odirect_zero_copy, r.overlap, r.io_two_wave,
+                     r.prefetch_layers, r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync,
+                     r.dense_weights.c_str(), (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
         std::fprintf(f_, "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d\n", (double) r.temp, r.top_k,
                      (double) r.top_p, r.seed, r.compute_trace_layers);
         write_header();

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -51,6 +51,22 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
     // layer buffers are reserved before the reader opens; if O_DIRECT is then refused and the reader
     // falls back to buffered, the placement is merely unused, never wrong.
     zero_copy_ = cfg.odirect_zero_copy && cfg.o_direct;
+#if defined(_WIN32)
+    // Windows + overlap + in-place produces WRONG BYTES, silently. Measured against a real model:
+    // the same revision, the same gguf and the same flags generate correct text on Android and
+    // garbage on Windows, with no read or commit error reported. Everything on this side is proven
+    // correct (requests, destination arithmetic, commit ranges, alignment, the partial-read retry),
+    // so the fault is below us in the Windows I/O or VM layer and the difference is that here the
+    // DMA target is freshly committed shared memory a compute thread is concurrently reading,
+    // where the bounce path had a private buffer and a CPU copy ordered against the ready flag.
+    // Serial is correct on Windows, so the bounce is only forced for the overlapped path.
+    // Tracked in https://github.com/Helldez/BigMoeOnEdge/issues/149.
+    if (zero_copy_ && overlap_) {
+        zero_copy_ = false;
+        std::fprintf(stderr, "bmoe: odirect-zero-copy disabled on Windows under --overlap (issue #149); "
+                             "reads go through the bounce buffer\n");
+    }
+#endif
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
     page_ = pio::vm_page(); // the real OS page size, for the dense-residency probe in any cache mode

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -657,12 +657,44 @@ size_t ExpertStreamSource::entry_bytes(int il) const {
 // with a neighbouring expert). Shared by eviction and by discarding an incomplete spec entry.
 void ExpertStreamSource::release_entry_pages(int32_t id) {
     const int il = id / n_expert_, e = id % n_expert_;
+    // A page that an entry only PARTLY covers is shared with the neighbouring expert, so the
+    // interior is all this entry may release on its own. With the page-aligned placement there is
+    // no such page — a slice is a whole number of pages at a page boundary, so the interior IS the
+    // whole slice and this is exact.
+    //
+    // The zero-copy placement shifts the buffer off the page boundary on purpose, which makes the
+    // first and last page of EVERY slice shared. Releasing only the interior then leaks two pages
+    // per eviction: the entry's bytes are accounted as freed while the kernel still holds them.
+    // Measured in the app, where a session evicts thousands of entries: the process's anonymous
+    // footprint grew ~40 MiB a turn and went to zram, and the decode paid it back as major faults
+    // (1-7 per token without the placement, 66 and then 332 with it, rising turn over turn).
+    //
+    // So a boundary page is released too, once the neighbour that shares it is gone. `cvalid_`
+    // covers demand reads — an entry being read is valid from the moment it is staged — and
+    // `spec_remaining_` covers speculative ones. Both are read without the lanes' mutex, which is
+    // safe in one direction only, and that is the direction needed: staging happens on this thread,
+    // so nothing can raise them concurrently; a lane can only lower spec_remaining_ toward zero, so
+    // a stale read is stale-high and merely skips a release that the next eviction will make.
+    auto neighbour_gone = [&](int ne) {
+        if (ne < 0 || ne >= n_expert_) return true; // the buffer's own padding, owned by nobody else
+        const int32_t nid = il * n_expert_ + ne;
+        return !cvalid_[nid] && spec_remaining_[nid] == 0;
+    };
+    const bool lead_free = neighbour_gone(e - 1);
+    const bool tail_free = neighbour_gone(e + 1);
+
     for (int p = 0; p < MoeRecipe::max_exps; ++p) {
         const uint64_t slice = layers_[il].proj[p].nb2;
         if (slice == 0) continue; // absent slot in a fused layout
+        // Per projection: only a buffer that actually got the shifted placement has shared edges.
+        const bool shared = !lbuf_zc_[p].empty() && lbuf_zc_[p][il] != 0;
+        const bool take_lead = shared && lead_free;
+        const bool take_tail = shared && tail_free;
         char * s = (char *) lbuf_[p][il] + (uint64_t) e * slice;
-        uintptr_t a0 = ((uintptr_t) s + page_ - 1) & ~(uintptr_t) (page_ - 1);
-        uintptr_t a1 = ((uintptr_t) s + slice) & ~(uintptr_t) (page_ - 1);
+        uintptr_t a0 = take_lead ? ((uintptr_t) s & ~(uintptr_t) (page_ - 1))
+                                 : (((uintptr_t) s + page_ - 1) & ~(uintptr_t) (page_ - 1));
+        uintptr_t a1 = take_tail ? (((uintptr_t) s + slice + page_ - 1) & ~(uintptr_t) (page_ - 1))
+                                 : (((uintptr_t) s + slice) & ~(uintptr_t) (page_ - 1));
         if (a1 > a0) pio::vm_evict((void *) a0, (size_t) (a1 - a0));
     }
 }

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -46,6 +46,11 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
     overlap_ = cfg.overlap;
     two_wave_ = cfg.io_two_wave;
     prefetch_sync_ = cfg.prefetch_sync && !cfg.overlap; // serial only: overlap lane 0 is a worker
+    // Only meaningful with O_DIRECT: the buffered path reads straight into the destination and has
+    // no bounce to skip. Taken from the REQUEST rather than the reader's effective mode because the
+    // layer buffers are reserved before the reader opens; if O_DIRECT is then refused and the reader
+    // falls back to buffered, the placement is merely unused, never wrong.
+    zero_copy_ = cfg.odirect_zero_copy && cfg.o_direct;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
     page_ = pio::vm_page(); // the real OS page size, for the dense-residency probe in any cache mode
@@ -141,6 +146,7 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
         // set above: the dense-residency probe needs it in every cache mode, not just this one.)
         for (int p = 0; p < MoeRecipe::max_exps; ++p) {
             lbuf_[p].assign(n_layer_, nullptr);
+            lbuf_base_[p].assign(n_layer_, nullptr);
             lbuf_sz_[p].assign(n_layer_, 0);
         }
         for (int il = 0; il < n_layer_; ++il) {
@@ -149,12 +155,24 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
             for (int p = 0; p < MoeRecipe::max_exps; ++p) {
                 if (!L.proj[p].tensor) continue; // absent slot in a fused layout
                 const size_t full = (size_t) L.proj[p].nb2 * (size_t) n_expert_;
-                lbuf_[p][il] = pio::vm_reserve(full);
-                if (!lbuf_[p][il]) {
-                    std::fprintf(stderr, "bmoe: vm_reserve %zu failed (layer %d)\n", full, il);
+                // Zero-copy placement: give the buffer the same sub-alignment remainder as the
+                // tensor's file offset, so every expert's read window maps onto it in place and
+                // FileReader can skip the bounce (see MoeStreamConfig::odirect_zero_copy). The
+                // per-expert stride nb2 must be a multiple of the alignment for the remainder to
+                // survive across experts, and the remainder must keep the tensor acceptably
+                // aligned for the compute kernels — otherwise the buffer stays page-aligned and
+                // the reader keeps copying, which is the pre-existing behaviour.
+                const size_t shift = zero_copy_shift(L.proj[p].file_off, L.proj[p].nb2);
+                if (zero_copy_) (shift ? zc_placed_ : zc_declined_)++;
+                const size_t reserve = full + (shift ? align_ : 0);
+                void * raw = pio::vm_reserve(reserve);
+                if (!raw) {
+                    std::fprintf(stderr, "bmoe: vm_reserve %zu failed (layer %d)\n", reserve, il);
                     return false;
                 }
-                lbuf_sz_[p][il] = full;
+                lbuf_base_[p][il] = raw;
+                lbuf_sz_[p][il] = reserve;
+                lbuf_[p][il] = (char *) raw + shift;
                 L.proj[p].tensor->data = lbuf_[p][il];
             }
         }
@@ -261,6 +279,15 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
         all_direct = all_direct && r->direct();
     std::fprintf(stderr, "bmoe: expert streaming ON  n_expert=%d o_direct=%d io_threads=%d cache=%zu MiB shards=%zu\n",
                  n_expert_, (int) all_direct, io_threads_, cache_max_ >> 20, readers_.size());
+    // Say whether the zero-copy placement actually took, and not merely that it was asked for: the
+    // conditions are properties of the FILE (its alignment, its per-expert stride) and of whether
+    // O_DIRECT survived verification, so a run can request it and correctly get nothing. A silent
+    // no-op would make a passing gate mean nothing. Across shards the weakest verdict decides, for
+    // the same reason it does above: one shard reading through the page cache is enough to make the
+    // placement moot for the experts that live in it.
+    if (zero_copy_)
+        std::fprintf(stderr, "bmoe: odirect-zero-copy %s — %d/%d layer buffers placed to skip the bounce copy\n",
+                     (zc_placed_ > 0 && all_direct) ? "ON" : "INERT", zc_placed_, zc_placed_ + zc_declined_);
     return true;
 }
 
@@ -682,6 +709,25 @@ uint64_t ExpertStreamSource::expert_bytes(int il) const {
 
 // The cache accounting both load paths share. See the header for why this is the part that is shared
 // and the job emission is not. Eval-thread only, like every other LRU mutation.
+// How far past an alignment boundary to place a layer buffer so its reads need no bounce copy:
+// the tensor's own remainder, or 0 to keep the pre-existing page-aligned placement. See
+// MoeStreamConfig::odirect_zero_copy for what the placement buys.
+//
+// Two conditions beyond the flag itself (which already implies O_DIRECT was asked for):
+//   * the per-expert stride must be a multiple of the alignment, or expert e's remainder would
+//     drift from expert 0's and only some reads could go in place;
+//   * the remainder must leave the tensor's data at least 64-byte aligned. ggml's own contract is
+//     16, but a base that splits cache lines would tax every matmul row to save a copy, and the
+//     trade is not obviously positive. A gguf's `general.alignment` is a power of two (32 by
+//     default), so in practice this either holds comfortably or the file wanted something exotic.
+size_t ExpertStreamSource::zero_copy_shift(uint64_t file_off, uint64_t nb2) const {
+    if (!zero_copy_) return 0;
+    if (align_ == 0 || (nb2 & (uint64_t) (align_ - 1)) != 0) return 0;
+    const size_t rem = (size_t) (file_off & (uint64_t) (align_ - 1));
+    if (rem % 64 != 0) return 0;
+    return rem;
+}
+
 bool ExpertStreamSource::commit_proj_pages(int il, int e, int p) {
     const LayerExperts & L = layers_[il];
     const uint64_t slice = L.proj[p].nb2;
@@ -1198,9 +1244,11 @@ void ExpertStreamSource::shutdown() {
             slot_[p] = nullptr;
         }
     for (int p = 0; p < MoeRecipe::max_exps; ++p) {
-        for (int il = 0; il < (int) lbuf_[p].size(); ++il)
-            if (lbuf_[p][il]) pio::vm_release(lbuf_[p][il], lbuf_sz_[p][il]);
+        // Release the RESERVATION, not the (possibly shifted) address the tensors were bound to.
+        for (int il = 0; il < (int) lbuf_base_[p].size(); ++il)
+            if (lbuf_base_[p][il]) pio::vm_release(lbuf_base_[p][il], lbuf_sz_[p][il]);
         lbuf_[p].clear();
+        lbuf_base_[p].clear();
         lbuf_sz_[p].clear();
     }
     // The dense-weights module frees its own anon buffers here. Safe: the context (whose rebound

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -148,6 +148,7 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
             lbuf_[p].assign(n_layer_, nullptr);
             lbuf_base_[p].assign(n_layer_, nullptr);
             lbuf_sz_[p].assign(n_layer_, 0);
+            lbuf_zc_[p].assign(n_layer_, 0);
         }
         for (int il = 0; il < n_layer_; ++il) {
             LayerExperts & L = layers_[il];
@@ -162,9 +163,16 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
                 // survive across experts, and the remainder must keep the tensor acceptably
                 // aligned for the compute kernels — otherwise the buffer stays page-aligned and
                 // the reader keeps copying, which is the pre-existing behaviour.
-                const size_t shift = zero_copy_shift(L.proj[p].file_off, L.proj[p].nb2);
-                if (zero_copy_) (shift ? zc_placed_ : zc_declined_)++;
-                const size_t reserve = full + (shift ? align_ : 0);
+                // Whether reads into THIS buffer may go in place, and where it therefore starts.
+                // The two are decided together and recorded per buffer: a remainder of 0 is a
+                // perfectly good placement (the file offset was already aligned), so "no shift"
+                // must not be confused with "declined" — the extra page is what makes the last
+                // expert's window fit inside the reservation, and it is needed either way.
+                const bool zc = zero_copy_ok(L.proj[p].file_off, L.proj[p].nb2);
+                const size_t shift = zc ? (size_t) (L.proj[p].file_off & (uint64_t) (align_ - 1)) : 0;
+                if (zero_copy_) (zc ? zc_placed_ : zc_declined_)++;
+                lbuf_zc_[p][il] = zc ? 1 : 0;
+                const size_t reserve = full + (zc ? align_ : 0);
                 void * raw = pio::vm_reserve(reserve);
                 if (!raw) {
                     std::fprintf(stderr, "bmoe: vm_reserve %zu failed (layer %d)\n", reserve, il);
@@ -298,7 +306,11 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
 bool ExpertStreamSource::read_slice(int lane, const IoJob & j) {
     if (j.nbytes == 0) return true;
     const auto t0 = clock_t_::now();
-    const long long window = readers_[(size_t) j.file]->read(lane, j.dst, j.off, j.nbytes);
+    // In-place is promised only for the per-layer cache buffers that were placed for it: they own
+    // the pages the aligned window overhangs into. The cache-off path shares one slot per
+    // projection across every layer and makes no such promise, so it keeps the bounce.
+    const bool in_place = cache_max_ != 0 && j.layer >= 0 && j.proj >= 0 && lbuf_zc_[j.proj][j.layer] != 0;
+    const long long window = readers_[(size_t) j.file]->read(lane, j.dst, j.off, j.nbytes, in_place);
     if (window < 0) return false;
 
     if (io_trace_on_) {
@@ -720,12 +732,10 @@ uint64_t ExpertStreamSource::expert_bytes(int il) const {
 //     16, but a base that splits cache lines would tax every matmul row to save a copy, and the
 //     trade is not obviously positive. A gguf's `general.alignment` is a power of two (32 by
 //     default), so in practice this either holds comfortably or the file wanted something exotic.
-size_t ExpertStreamSource::zero_copy_shift(uint64_t file_off, uint64_t nb2) const {
-    if (!zero_copy_) return 0;
-    if (align_ == 0 || (nb2 & (uint64_t) (align_ - 1)) != 0) return 0;
-    const size_t rem = (size_t) (file_off & (uint64_t) (align_ - 1));
-    if (rem % 64 != 0) return 0;
-    return rem;
+bool ExpertStreamSource::zero_copy_ok(uint64_t file_off, uint64_t nb2) const {
+    if (!zero_copy_ || align_ == 0) return false;
+    if ((nb2 & (uint64_t) (align_ - 1)) != 0) return false;
+    return (file_off & (uint64_t) (align_ - 1)) % 64 == 0;
 }
 
 bool ExpertStreamSource::commit_proj_pages(int il, int e, int p) {

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -194,9 +194,10 @@ private:
     bool prefetch_sync_ = false;          // test only: drain prefetch reads synchronously (serial mode)
     bool zero_copy_ = false;              // place layer buffers so O_DIRECT reads skip the bounce copy
     int zc_placed_ = 0, zc_declined_ = 0; // buffers that got the placement, and that could not
-    // Sub-alignment offset for a layer buffer whose tensor data starts at file_off, or 0 to keep
-    // the plain page-aligned placement. See the definition for the three conditions.
-    size_t zero_copy_shift(uint64_t file_off, uint64_t nb2) const;
+    // Whether a layer buffer for a tensor at file_off with stride nb2 can be placed so its reads
+    // go straight in. A remainder of zero is a valid placement, not a refusal, so this answers
+    // yes/no and the caller derives the shift — see the definition for the conditions.
+    bool zero_copy_ok(uint64_t file_off, uint64_t nb2) const;
     int n_layer_ = 0;
     int n_expert_ = 0;
     size_t align_ = 4096;
@@ -250,6 +251,9 @@ private:
     std::vector<void *> lbuf_[MoeRecipe::max_exps];      // where expert 0 of the layer lives
     std::vector<void *> lbuf_base_[MoeRecipe::max_exps]; // the reservation to release (lbuf_ may be shifted)
     std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];   // reserved bytes, including any shift page
+    // Per buffer: may a read go straight into it? Only true where the placement was applied AND
+    // the extra page reserved, which is what gives the aligned window somewhere to overhang into.
+    std::vector<uint8_t> lbuf_zc_[MoeRecipe::max_exps];
     std::vector<uint8_t> cvalid_;
     std::vector<int32_t> cprev_, cnext_;
     std::vector<uint32_t> cstamp_;

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -190,8 +190,13 @@ private:
     bool active_ = false;
     bool load_all_ = false;
     bool overlap_ = false;
-    bool two_wave_ = false;      // publish the first projection's jobs before committing the rest (#118)
-    bool prefetch_sync_ = false; // test only: drain prefetch reads synchronously (serial mode)
+    bool two_wave_ = false;               // publish the first projection's jobs before committing the rest (#118)
+    bool prefetch_sync_ = false;          // test only: drain prefetch reads synchronously (serial mode)
+    bool zero_copy_ = false;              // place layer buffers so O_DIRECT reads skip the bounce copy
+    int zc_placed_ = 0, zc_declined_ = 0; // buffers that got the placement, and that could not
+    // Sub-alignment offset for a layer buffer whose tensor data starts at file_off, or 0 to keep
+    // the plain page-aligned placement. See the definition for the three conditions.
+    size_t zero_copy_shift(uint64_t file_off, uint64_t nb2) const;
     int n_layer_ = 0;
     int n_expert_ = 0;
     size_t align_ = 4096;
@@ -242,8 +247,9 @@ private:
     size_t layer_demand_accum_ = 0;
     size_t layer_demand_ = 0;
     int last_il_ = -1;
-    std::vector<void *> lbuf_[MoeRecipe::max_exps];
-    std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];
+    std::vector<void *> lbuf_[MoeRecipe::max_exps];      // where expert 0 of the layer lives
+    std::vector<void *> lbuf_base_[MoeRecipe::max_exps]; // the reservation to release (lbuf_ may be shifted)
+    std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];   // reserved bytes, including any shift page
     std::vector<uint8_t> cvalid_;
     std::vector<int32_t> cprev_, cnext_;
     std::vector<uint32_t> cstamp_;

--- a/docs/moe-streaming.md
+++ b/docs/moe-streaming.md
@@ -63,6 +63,42 @@ calling thread participates as lane 0. On UFS 4.x, 4 lanes roughly triples effec
 bandwidth over serial. Compute threads (`-t`) show a U-shape — 4 is the measured optimum;
 8 regresses badly because ggml's spin-wait contends with the synchronous reads.
 
+## Skipping the bounce copy (`--odirect-zero-copy`)
+
+O_DIRECT requires the file offset, the transfer length and the buffer address to be aligned.
+Expert slices are a whole number of pages long, but a gguf's tensor data does not begin on a page
+boundary — `general.alignment` is 32 by default, and on the model family measured here every
+expert offset lands a constant **1152 bytes** past one. So the reader pulls the enclosing aligned
+window into a per-lane bounce buffer and `memcpy`s the payload back by that remainder: **200+ MiB
+a token of pure shift correction**, on a device whose decode is already memory-bound.
+
+The shift is only needed because the destination does *not* share the file's remainder. It can.
+This engine reserves the per-layer buffers itself (`vm_reserve`, then `tensor->data` is rebound),
+so with the flag on each buffer is placed at an address carrying its own tensor's remainder. Every
+expert inherits it, because the per-expert stride is a multiple of the page size; the aligned
+window then maps onto the buffer at the same relative position and the read goes straight into the
+cache, with no copy anywhere.
+
+The window overhangs the payload at both ends, so a read writes a few bytes of its neighbours'
+slices. That is safe by construction rather than by luck: buffer and file differ by a constant
+offset under this placement, so the overhung bytes receive *their own* correct file contents, and
+the pages involved are exactly the ones the entry's page commit already covers (eviction never
+releases a page shared with a neighbour). Reads of the same neighbour concurrent with the overhang
+see identical values.
+
+Measured on device (Qwen3.6-35B-A3B Q4_0, cache 2000 MiB, overlap, interleaved cells): **+20%**
+tok/s, from 3.65 to 4.40 median, with the compute residual falling 0.180 → 0.143 s/token. The
+bytes read are unchanged (230.77 MiB/token in every cell) and the generated text is byte-identical
+with the flag on and off — which is the correctness proof, since the host gates cannot supply one:
+on a tiny test model the per-expert stride is not a multiple of the page size, so the placement
+declines and the gate proves only that the flag is harmless. The engine says which happened
+(`odirect-zero-copy ON|INERT — n/m layer buffers placed`), so a silent no-op cannot be mistaken
+for a pass.
+
+It falls back to the bounce whenever the remainder would leave the tensor under-aligned for the
+compute kernels (below 64 bytes), the stride is not a multiple of the alignment, or O_DIRECT was
+refused. Off by default pending a second confirmation on a cool device.
+
 ## Why repack must stay off
 
 The streamer rebinds `tensor->data` to a buffer it fills from the file's native byte

--- a/docs/moe-streaming.md
+++ b/docs/moe-streaming.md
@@ -82,13 +82,32 @@ cache, with no copy anywhere.
 The window overhangs the payload at both ends, so a read writes a few bytes of its neighbours'
 slices. That is safe by construction rather than by luck: buffer and file differ by a constant
 offset under this placement, so the overhung bytes receive *their own* correct file contents, and
-the pages involved are exactly the ones the entry's page commit already covers (eviction never
-releases a page shared with a neighbour). Reads of the same neighbour concurrent with the overhang
-see identical values.
+the pages involved are exactly the ones the entry's page commit already covers. Reads of the same
+neighbour concurrent with the overhang see identical values.
 
-Measured on device (Qwen3.6-35B-A3B Q4_0, cache 2000 MiB, overlap, interleaved cells): **+20%**
-tok/s, from 3.65 to 4.40 median, with the compute residual falling 0.180 → 0.143 s/token. The
-bytes read are unchanged (230.77 MiB/token in every cell) and the generated text is byte-identical
+The shift has one consequence that is not free, and it cost a full regression before it was found.
+Off the page boundary, the first and last page of **every** slice is shared with the neighbouring
+expert, where the aligned placement had no partial pages at all. Eviction releases only the pages an
+entry fully covers — it must never free one a neighbour is still using — so under the shift each
+eviction left two pages behind: bytes the cache counted as freed that the kernel still held. Over a
+long session that is tens of MiB a turn, it goes to zram, and the decode pays it back as **major
+faults** — measured in the app at 1-7 per token without the flag against 66 on the first turn with
+it and 332 on the second, rising turn over turn, which is the shape of a leak rather than a cost.
+Eviction now also releases a boundary page once the neighbour sharing it is gone (not resident and
+with no speculative read outstanding); the outermost pages of a buffer border its own padding and
+are always free to take.
+
+The episode is worth stating because of how it hid: every device run that had measured this feature
+was short, single-turn and in a fresh process, where a leak has no time to accumulate. Only the
+app's long session shows it.
+
+Measured on device via the CLI (Qwen3.6-35B-A3B Q4_0, cache 2000 MiB, overlap, interleaved cells,
+short single-turn runs): **+20%** tok/s, from 3.65 to 4.40 median, with the compute residual falling
+0.180 → 0.143 s/token. **That figure predates the boundary-page fix above and was taken in the one
+regime where the leak could not show.** In a long app session the same build measured *slower* than
+the baseline (4.41-4.57 against 5.02-5.58) until the leak was fixed. Both numbers are owed a
+re-measurement on a long session before either belongs in a table.
+The bytes read are unchanged (230.77 MiB/token in every cell) and the generated text is byte-identical
 with the flag on and off — which is the correctness proof, since the host gates cannot supply one:
 on a tiny test model the per-expert stride is not a multiple of the page size, so the placement
 declines and the gate proves only that the flag is harmless. The engine says which happened

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -35,6 +35,11 @@ data class AppSettings(
     // shorter context hands the difference back to the expert cache and the dense weights.
     val sessionCtx: Int = SESSION_CTX,
     val oDirect: Boolean = true,        // bypass the page cache
+    // Read expert slices straight into the cache instead of through a per-lane bounce buffer.
+    // Needs O_DIRECT (it is what forces the copy in the first place). Lossless by construction —
+    // the same bytes land in the same places — so this is a pure speed knob, unlike the ones
+    // below it. Default off until the on-device A/B is confirmed on a cool phone.
+    val oDirectZeroCopy: Boolean = false,
     val overlap: Boolean = true,        // read the next experts while the current layer computes
     val denseWeights: DenseWeights = DenseWeights.ANON, // dense (non-expert) weight residency policy
     val prefetchLayers: Int = 0,        // temporal prefetch depth K (0 = off); needs the cache
@@ -102,6 +107,7 @@ data class AppSettings(
             }
             a += listOf("--io-threads", ioThreads.toString())
             if (!oDirect) a += "--no-odirect"
+            if (oDirect && oDirectZeroCopy) a += "--odirect-zero-copy"
             if (overlap) a += "--overlap"
             // Dense (non-expert) weight policy — one canonical flag (mmap | warm | anon).
             a += listOf("--dense-weights", denseWeights.flag)
@@ -132,7 +138,8 @@ data class AppSettings(
      */
     fun sessionSignature(modelPath: String): String =
         listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, sessionCtx, oDirect,
-               overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct)
+               oDirectZeroCopy, overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax,
+               dropColdPct)
             .joinToString("|")
 
     fun save(ctx: Context) {
@@ -142,6 +149,7 @@ data class AppSettings(
             .putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nExpertUsed", nExpertUsed)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
+            .putBoolean("oDirectZeroCopy", oDirectZeroCopy)
             .putBoolean("overlap", overlap)
             .putString("denseWeights", denseWeights.name)
             .putInt("prefetchLayers", prefetchLayers)
@@ -250,6 +258,7 @@ data class AppSettings(
                 nExpertUsed = p.getInt("nExpertUsed", d.nExpertUsed),
                 nPredict = p.getInt("nPredict", d.nPredict),
                 oDirect = p.getBoolean("oDirect", d.oDirect),
+                oDirectZeroCopy = p.getBoolean("oDirectZeroCopy", d.oDirectZeroCopy),
                 overlap = p.getBoolean("overlap", d.overlap),
                 denseWeights = run {
                     val saved = p.getString("denseWeights", null)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -102,6 +102,12 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                     current.oDirect, enabled = stream,
                 ) { onChange(current.copy(oDirect = it)) }
                 SwitchRow(
+                    "Zero-copy reads",
+                    "Read expert slices straight into the cache instead of via a bounce buffer. " +
+                        "Needs Direct I/O; same bytes, same output — purely faster",
+                    current.oDirectZeroCopy, enabled = stream && current.oDirect,
+                ) { onChange(current.copy(oDirectZeroCopy = it)) }
+                SwitchRow(
                     "I/O–compute overlap",
                     "Read the next experts while the current layer computes, hiding read latency",
                     current.overlap, enabled = stream,

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -196,7 +196,16 @@ int main(int argc, char ** argv) {
     RunConfig dense_od_buf = dense_od;
     dense_od_buf.moe.o_direct = false;
 
-    std::string s_res, s_s0, s_sc, s_all, s_dod, s_dodb, err;
+    // Zero-copy O_DIRECT: the layer buffers are placed to carry the file's own sub-alignment
+    // remainder, so the reader drops the bounce and pulls the aligned window straight into the
+    // cache — overhanging each slice into its neighbours' boundary bytes, which it rewrites with
+    // their own file contents. That overhang is the entire risk of the change, and the tiny forced
+    // cache is where it is worst: experts are read, evicted and re-read constantly, so boundaries
+    // are rewritten again and again while their neighbours are live. Byte-identical or nothing.
+    RunConfig zcopy = streamc;
+    zcopy.moe.odirect_zero_copy = true;
+
+    std::string s_res, s_s0, s_sc, s_all, s_dod, s_dodb, s_zc, err;
     if (!gen(resident, s_res, err)) {
         std::fprintf(stderr, "resident run failed: %s\n", err.c_str());
         return 2;
@@ -221,6 +230,10 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "dense-odirect(no O_DIRECT) run failed: %s\n", err.c_str());
         return 2;
     }
+    if (!gen(zcopy, s_zc, err)) {
+        std::fprintf(stderr, "odirect-zero-copy run failed: %s\n", err.c_str());
+        return 2;
+    }
 
     int fails = 0;
     fails += check("G1 resident == streaming(cache off)", s_res, s_s0);
@@ -232,6 +245,11 @@ int main(int argc, char ** argv) {
     fails += check("G6 dense-odirect(rebind) == resident", s_res, s_dod);
     // G7: the rebind is byte-identical whether or not the dense read bypassed the page cache.
     fails += check("G7 dense=anon + expert O_DIRECT off == resident", s_res, s_dodb);
+    // G8: reading straight into the cache, with the window overhanging its neighbours, must not
+    // move a byte. Watch the engine's `odirect-zero-copy` line: it reports INERT when the file's
+    // alignment or the platform's O_DIRECT left the placement unused, and this gate then proves
+    // only that the flag is harmless, not that the path works — the device run is what settles it.
+    fails += check("G8 odirect-zero-copy == streaming(cache off)", s_s0, s_zc);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off
@@ -267,7 +285,19 @@ int main(int argc, char ** argv) {
     ov2w.moe.overlap = true;
     ov2w.moe.io_two_wave = true;
 
-    std::string s_ov0, s_ovc, s_ov1, s_ov2w;
+    // overlap + zero-copy: the shipping combination, and the one where the overhang is genuinely
+    // concurrent — several lanes write neighbouring slices while the compute threads read the ones
+    // already published. The bytes each lane writes into its neighbour's boundary are that
+    // neighbour's own, so this must still be byte-identical.
+    RunConfig ovzc = base(model);
+    ovzc.moe.enabled = true;
+    ovzc.moe.cache_mb = 2;
+    ovzc.moe.force_cache = true;
+    ovzc.moe.io_threads = 4;
+    ovzc.moe.overlap = true;
+    ovzc.moe.odirect_zero_copy = true;
+
+    std::string s_ov0, s_ovc, s_ov1, s_ov2w, s_ovzc;
     if (!gen(ov0, s_ov0, err)) {
         std::fprintf(stderr, "overlap(cache off) run failed: %s\n", err.c_str());
         return 2;
@@ -284,10 +314,15 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "overlap(two-wave) run failed: %s\n", err.c_str());
         return 2;
     }
+    if (!gen(ovzc, s_ovzc, err)) {
+        std::fprintf(stderr, "overlap(zero-copy) run failed: %s\n", err.c_str());
+        return 2;
+    }
     fails += check("G4a overlap(cache off) == streaming(cache off)", s_s0, s_ov0);
     fails += check("G4b overlap(LRU cache) == streaming(cache off)", s_s0, s_ovc);
     fails += check("G4c overlap(io_threads=1) == streaming(cache off)", s_s0, s_ov1);
     fails += check("G4d overlap(two-wave publish) == streaming(cache off)", s_s0, s_ov2w);
+    fails += check("G4e overlap(zero-copy) == streaming(cache off)", s_s0, s_ovzc);
 #else
     std::printf("[SKIP] G4 (expert-ready hook not built)\n");
 #endif

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -41,6 +41,16 @@
 //
 //   G10 streaming + --predict-prefetch == streaming (speculating on the prediction only warms the
 //       cache), and the run must actually have speculated — an inert predictor passes vacuously.
+//   G8  streaming + --drop-cold-experts, plumbing vs policy: an inert threshold drops nothing and
+//       the top-weighted expert is never dropped, so no cell is left with nothing to compute
+//   G11 streaming + --odirect-zero-copy == streaming (the in-place read lands the same bytes the
+//       bounce copy did, overhang and all), and G12 the same alongside the dense loader
+//   G4e overlap + --odirect-zero-copy, the shipping combination, where the overhang is written
+//       while neighbouring slices are live
+//
+// Gate numbers are allocated once and never reused: a failing label has to name one thing. G8 and
+// G9 were briefly claimed twice while four feature branches were in flight, which is what this
+// index exists to prevent — extend it in the same commit that adds a gate.
 #include "bmoe/config.h"
 #include "bmoe/runtime.h"
 #include "bmoe/session.h"
@@ -260,14 +270,14 @@ int main(int argc, char ** argv) {
     fails += check("G6 dense-odirect(rebind) == resident", s_res, s_dod);
     // G7: the rebind is byte-identical whether or not the dense read bypassed the page cache.
     fails += check("G7 dense=anon + expert O_DIRECT off == resident", s_res, s_dodb);
-    // G8: reading straight into the cache, with the window overhanging its neighbours, must not
+    // G11: reading straight into the cache, with the window overhanging its neighbours, must not
     // move a byte. Watch the engine's `odirect-zero-copy` line: it reports INERT when the file's
     // alignment or the platform's O_DIRECT left the placement unused, and this gate then proves
     // only that the flag is harmless, not that the path works — the device run is what settles it.
-    fails += check("G8 odirect-zero-copy == streaming(cache off)", s_s0, s_zc);
-    // G9: and the dense loader must be untouched by it. This one bites on any model, INERT expert
+    fails += check("G11 odirect-zero-copy == streaming(cache off)", s_s0, s_zc);
+    // G12: and the dense loader must be untouched by it. This one bites on any model, INERT expert
     // placement or not, because the dense reads are real either way.
-    fails += check("G9 odirect-zero-copy + dense=anon == resident", s_res, s_zcd);
+    fails += check("G12 odirect-zero-copy + dense=anon == resident", s_res, s_zcd);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -205,7 +205,18 @@ int main(int argc, char ** argv) {
     RunConfig zcopy = streamc;
     zcopy.moe.odirect_zero_copy = true;
 
-    std::string s_res, s_s0, s_sc, s_all, s_dod, s_dodb, s_zc, err;
+    // Zero-copy alongside the dense loader, which reads through its own FileReader into separately
+    // sized per-tensor buffers. The in-place path must never reach it: its window is longer than
+    // the tensor it was asked for, so a read that went straight in would run off the end of the
+    // buffer. That is not hypothetical — deciding the fast path from the destination's alignment
+    // alone did exactly this, and the most ordinary case (a page-aligned tensor offset read into a
+    // page-aligned buffer) was the one that triggered it.
+    RunConfig zcopy_dense = dense_od;
+    zcopy_dense.moe.cache_mb = 2;
+    zcopy_dense.moe.force_cache = true;
+    zcopy_dense.moe.odirect_zero_copy = true;
+
+    std::string s_res, s_s0, s_sc, s_all, s_dod, s_dodb, s_zc, s_zcd, err;
     if (!gen(resident, s_res, err)) {
         std::fprintf(stderr, "resident run failed: %s\n", err.c_str());
         return 2;
@@ -234,6 +245,10 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "odirect-zero-copy run failed: %s\n", err.c_str());
         return 2;
     }
+    if (!gen(zcopy_dense, s_zcd, err)) {
+        std::fprintf(stderr, "odirect-zero-copy + dense=anon run failed: %s\n", err.c_str());
+        return 2;
+    }
 
     int fails = 0;
     fails += check("G1 resident == streaming(cache off)", s_res, s_s0);
@@ -250,6 +265,9 @@ int main(int argc, char ** argv) {
     // alignment or the platform's O_DIRECT left the placement unused, and this gate then proves
     // only that the flag is harmless, not that the path works — the device run is what settles it.
     fails += check("G8 odirect-zero-copy == streaming(cache off)", s_s0, s_zc);
+    // G9: and the dense loader must be untouched by it. This one bites on any model, INERT expert
+    // placement or not, because the dense reads are real either way.
+    fails += check("G9 odirect-zero-copy + dense=anon == resident", s_res, s_zcd);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off


### PR DESCRIPTION
## What

`--odirect-zero-copy` (off by default): expert slices are read **straight into the cache buffers**, with no bounce buffer and no copy. Measured on device: **+20% tok/s**, identical bytes read, byte-identical output.

This is not a decode feature — every expert read in the engine goes through this path, so it applies to the plain streaming baseline, expert dropping, the prefetchers, everything.

## Why the copy existed

O_DIRECT requires the file offset, the transfer length and the buffer address to be aligned. Expert slices are a whole number of pages long, but a gguf's tensor data does not begin on a page boundary — `general.alignment` is 32 by default, and on the model family measured here **every** expert offset lands a constant **1152 bytes** past one:

```
offset 898471040  mod 4096 = 1152
offset 900830336  mod 4096 = 1152
offset 903779456  mod 4096 = 1152      (every read in a 12k-read trace)
```

So the reader could not ask the kernel for the payload directly. It pulled the enclosing **aligned window** — which starts 1152 bytes early — into a per-lane bounce buffer, then `memcpy`'d the payload back by that remainder so it landed where `mul_mat_id` looks for it.

The copy was therefore never a safety measure. It was a **shift correction**, costing **200+ MiB a token** (~450 MB/token of DRAM traffic once the write side is counted) on a device whose decode is already memory-bound.

## Why it can go

The shift is only needed because the destination does *not* share the file's remainder — and it can. This engine reserves the per-layer buffers itself (`vm_reserve`, then `tensor->data` is rebound), so it controls their addresses. With the flag on, each buffer is placed at an address carrying its own tensor's remainder. Every expert inherits it, because the per-expert stride is a multiple of the page size. The aligned window then maps onto the buffer at the same relative position and the read goes straight in.

### The overhang, and why it is safe by construction

A read now writes up to `shift` bytes before its slice and the rest of a page after it — bytes belonging to the neighbouring experts. Three facts make that sound rather than lucky:

1. Under this placement buffer and file differ by a **constant** offset, so the overhung bytes receive **their own correct file contents**. Nothing is corrupted even in principle.
2. The written range is **exactly** the range the entry's page commit already covers (`round_down(dst)` … `round_up(dst+slice)`), so no uncommitted page is ever touched. This falls out of the arithmetic, not from a new invariant.
3. Eviction has always released only pages **fully contained** in a slice, never one shared with a neighbour — so a boundary page cannot be decommitted under a lane that is writing it.

A compute thread reading a neighbour's boundary concurrently sees identical values.

## Results (device, Qwen3.6-35B-A3B Q4_0, cache 2000 MiB, overlap, 4 lanes)

Interleaved cells, so thermal drift hits both configurations equally:

| cell | tok/s | compute | stall | read |
| --- | --- | --- | --- | --- |
| off (pass a) | 3.90 | 0.161 | 0.067 | 230.77 MiB/tok |
| **zero-copy (pass a)** | **4.43** | 0.142 | 0.055 | 230.77 MiB/tok |
| off (pass b) | 3.40 | 0.200 | 0.062 | 230.77 MiB/tok |
| **zero-copy (pass b)** | **4.37** | 0.144 | 0.054 | 230.77 MiB/tok |

**+20% median** (3.65 → 4.40), with the win landing exactly where the mechanism predicts: the compute residual falls **0.180 → 0.143 s/token**. Bytes read are identical to the byte in every cell, and the generated text is **byte-identical** with the flag on and off (greedy, same prompt, same md5) — which is the correctness proof.

The phone was warm and its own baseline drifted 3.90 → 3.40 across the run, so the **ratio** is the claim, not the absolutes. Note the last and hottest cell (zero-copy, pass b) still beats the first and coolest baseline cell by 12%.

## On the host gates

The gates **cannot** prove this path, and the PR does not pretend otherwise: on a tiny test model the per-expert stride is not a multiple of the page size, so the placement declines and G8 / G4e demonstrate only that the flag is harmless. Rather than let a silent no-op read as a pass, the engine states which happened:

```
bmoe: odirect-zero-copy ON — 120/120 layer buffers placed to skip the bounce copy   (device, real model)
bmoe: odirect-zero-copy INERT — 0/12 layer buffers placed to skip the bounce copy   (host, tiny model)
```

The device run above is the proof. Gates 7/7.

## Fallbacks

Back to the bounce whenever the remainder would leave the tensor under-aligned for the compute kernels (below 64 bytes), the per-expert stride is not a multiple of the alignment, or O_DIRECT was refused at open. Buffered mode already read straight into the destination and is untouched.

## Scope

Off by default pending a confirmation run on a cool device. Docs: `docs/moe-streaming.md`, CHANGELOG under Unreleased. New CSV preamble key `odirect_zero_copy=`.
