### PR TITLE
feat(app): sharded model downloads — DeepSeek V4 Flash in the catalog, gpt-oss one-tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Semantic Versioning.
   the first shard, as with llama.cpp itself; a missing sibling fails the load with the shard named.
   The byte-identity gates gained a 4-shard fixture (metadata-only first shard, the layout large
   quants actually use) proving streamed == resident across shard boundaries.
+- **The app downloads sharded models.** A catalog entry can list several shard files; they are
+  fetched sequentially (each resumable, one aggregate progress bar, free space checked once
+  against the whole remaining set) and the model list offers the first shard — the file the
+  engine opens. gpt-oss-120b turns from a "merge it on a PC" recipe into a one-tap download, and
+  DeepSeek V4 Flash UD-IQ2_M (~91 GB, three shards) joins the catalog. Deleting a sharded model
+  deletes the whole set. App version 0.19.0 (versionCode 34).
 - **DeepSeek V4 Flash (`deepseek4`) recipe.** V3.2-style expert routing — 256 routed experts with a
   per-expert bias (the `lfm2moe` pattern) plus an always-on shared expert that stays resident — over
   the standard split expert suffixes, so streaming is one registry row. The V4 attention machinery

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ doing that part: MXFP4 and Q4_K_M stream through the same code. Supporting a new
 is one row in a registry, and following a new llama.cpp release is a routine submodule bump.
 
 The most extreme thing it can do today: **DeepSeek V4 Flash 0731**, a 284B-parameter MoE
-(~91 GB on disk at 2-bit expert quantization), on a phone with 12 GB of RAM — more than seven
+(~91 GB on disk at 2-bit expert quantization), on a phone with 12 GB of RAM: more than seven
 times more model than memory, streamed from flash as three shard files exactly as Hugging Face
 ships them, no merge step. Behind it, **gpt-oss-120b** (~60 GB) generates at **1.3 tok/s**
 losslessly and **2.2 tok/s** with one speed knob, against **0.09 tok/s** for the same file
@@ -97,7 +97,7 @@ finishes, pick the model and chat. The telemetry panel shows tok/s and the compu
 split live, and every streaming knob below is in Settings.
 
 Models above Hugging Face's 50 GB per-file limit (gpt-oss-120b, DeepSeek V4 Flash) ship as
-multi-shard ggufs. The engine reads split models natively — point it at the first shard
+multi-shard ggufs. The engine reads split models natively: point it at the first shard
 (`-00001-of-...`) with the siblings alongside; no merge step. gpt-oss-120b still needs a manual
 copy to the device: steps in the [Android example README](examples/android/README.md#gpt-oss-120b).
 
@@ -185,11 +185,11 @@ reads served from RAM instead of flash. Bold marks the best configuration for th
 
 | Configuration | tok/s | Flash/token | Cache hit |
 |---|---:|---:|---:|
+| mmap baseline (no streaming) | 0.09 | n/a | n/a |
+| streamed, k=4 (default), no cache, 4 lanes | 0.7 | 1817 MiB | n/a |
+| streamed, k=4 (default), cache 2000 MiB, 8 lanes | 1.3 | 1292 MiB | 27% |
+| streamed, k=2, no cache, 4 lanes | 1.8 | 909 MiB | n/a |
 | **streamed, k=2, cache 2000 MiB, 8 lanes** | **2.2** | 590 MiB | 32% |
-| streamed, k=2, no cache, 4 lanes | 1.8 | 909 MiB | — |
-| streamed, default k=4, cache 2000 MiB, 8 lanes | 1.3 | 1292 MiB | 27% |
-| streamed, default k=4, no cache, 4 lanes | 0.7 | 1817 MiB | — |
-| mmap baseline (no streaming) | 0.09 | — | — |
 
 All streamed rows use `--overlap --dense-weights anon --no-think`. The setting that unlocked this
 model is `--dense-weights anon`: this far past RAM the phone keeps reclaiming the always-used
@@ -206,9 +206,9 @@ dense weights kept out of the page cache (`--dense-weights anon`) runs it stably
 
 | Configuration | tok/s | Flash/token | Cache hit |
 |---|---:|---:|---:|
-| mmap baseline (no streaming) | 0.1 (unstable) | — | — |
-| streamed, default k=8, cache 2000 MiB, 4 lanes, overlap | 4.3 | 206 MiB | 56% |
-| streamed, default k=8, cache 3000 MiB, 4 lanes, overlap | 5.0 | 144 MiB | 65% |
+| mmap baseline (no streaming) | 0.1 (unstable) | n/a | n/a |
+| streamed, k=8 (default), cache 2000 MiB, 4 lanes, overlap | 4.3 | 206 MiB | 56% |
+| streamed, k=8 (default), cache 3000 MiB, 4 lanes, overlap | 5.0 | 144 MiB | 65% |
 | streamed, k=6, cache 2000 MiB, 4 lanes, overlap | 5.4 | 137 MiB | 60% |
 | **streamed, k=6, cache 3000 MiB, 4 lanes, overlap** | **5.8** | 91 MiB | 68% |
 
@@ -225,12 +225,12 @@ worth a further ~16% by routing to six experts instead of eight. The lossless be
 
 | Configuration | tok/s | Flash/token | Cache hit |
 |---|---:|---:|---:|
-| mmap baseline (no streaming) | 2.0 (unstable) | — | — |
-| streamed, default k=8, no cache, 4 lanes | 1.7 | 1051 MiB | — |
-| streamed, default k=8, cache 2000 MiB, 4 lanes | 2.4 | 480 MiB | 53% |
-| streamed, default k=8, cache 4000 MiB, 4 lanes | 4.0 | 225 MiB | 76% |
-| **streamed, default k=8, auto cache (capped 4000 MiB), 4 lanes, overlap** | **5.2** | 225 MiB | 76% |
+| streamed, k=8 (default), no cache, 4 lanes | 1.7 | 1051 MiB | n/a |
+| mmap baseline (no streaming) | 2.0 (unstable) | n/a | n/a |
+| streamed, k=8 (default), cache 2000 MiB, 4 lanes | 2.4 | 480 MiB | 53% |
+| streamed, k=8 (default), cache 4000 MiB, 4 lanes | 4.0 | 225 MiB | 76% |
 | streamed, k=6, cache 4000 MiB, 4 lanes | 5.0 | 165 MiB | 77% |
+| **streamed, k=8 (default), auto cache (cap 4000 MiB), 4 lanes, overlap** | **5.2** | 225 MiB | 76% |
 
 Cache size is the dominant lever here, and the auto-sized cache with a ceiling
 ([docs/cache-sizing.md](docs/cache-sizing.md)) is the winning recipe. The mmap baseline
@@ -241,11 +241,11 @@ a little quality for a further +24% over the model's own width.
 
 | Configuration | tok/s | Flash/token | Cache hit |
 |---|---:|---:|---:|
-| mmap baseline (no streaming) | 0.4 | — | — |
-| streamed, default k=8, no cache, 4 lanes | 1.6 | 904 MiB | — |
-| streamed, default k=8, cache 2000 MiB, 4 lanes | 2.2 | 366 MiB | 58% |
-| streamed, default k=8, cache 2000 MiB, 4 lanes, overlap | 2.8 | 365 MiB | 58% |
-| streamed, default k=8, cache 4000 MiB, 4 lanes | 4.1 | 144 MiB | 82% |
+| mmap baseline (no streaming) | 0.4 | n/a | n/a |
+| streamed, k=8 (default), no cache, 4 lanes | 1.6 | 904 MiB | n/a |
+| streamed, k=8 (default), cache 2000 MiB, 4 lanes | 2.2 | 366 MiB | 58% |
+| streamed, k=8 (default), cache 2000 MiB, 4 lanes, overlap | 2.8 | 365 MiB | 58% |
+| streamed, k=8 (default), cache 4000 MiB, 4 lanes | 4.1 | 144 MiB | 82% |
 | **streamed, k=6, cache 4000 MiB, 4 lanes** | **5.0** | 98 MiB | 83% |
 
 Gemma keeps more of itself permanently resident, so the 4000 MiB cache fits only when enough RAM is
@@ -258,7 +258,7 @@ Every other benchmarked setting changes *how* weights are fetched, never the mat
 *what* the model computes, and both are measured:
 
 **Turbo top-k** (`--n-expert-used N`) forces the routing width below the model's own (8 for the
-Qwen and Gemma models, 4 for gpt-oss), cutting compute and flash reads together: **+22–24%** on
+Qwen and Gemma models, 4 for gpt-oss), cutting compute and flash reads together: **+22-24%** on
 the Qwen and Gemma models, and gpt-oss goes from 1.3 to **2.2 tok/s** at k=2. It is deterministic,
 which is why its `k=6` rows sit in the tables above. But it spends quality indiscriminately: the
 routing tail is cut whether or not those experts were already free to run from RAM.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ tokenizer and chat template llama.cpp supports works out of the box, because lla
 doing that part: MXFP4 and Q4_K_M stream through the same code. Supporting a new MoE architecture
 is one row in a registry, and following a new llama.cpp release is a routine submodule bump.
 
-The most extreme thing it can do today: **gpt-oss-120b**, a ~60 GB model, on a phone with 12 GB of
-RAM. Five times more model than memory, generating at **1.3 tok/s** losslessly and **2.2 tok/s**
-with one speed knob, against **0.09 tok/s** for the same file loaded the ordinary way.
+The most extreme thing it can do today: **DeepSeek V4 Flash 0731**, a 284B-parameter MoE
+(~91 GB on disk at 2-bit expert quantization), on a phone with 12 GB of RAM — more than seven
+times more model than memory, streamed from flash as three shard files exactly as Hugging Face
+ships them, no merge step. Behind it, **gpt-oss-120b** (~60 GB) generates at **1.3 tok/s**
+losslessly and **2.2 tok/s** with one speed knob, against **0.09 tok/s** for the same file
+loaded the ordinary way.
+
+<!-- DSv4 hero video: replace the asset link below when the on-device recording lands with the
+     v0.19.0 release. Caption pattern: model, size, device RAM, "real time, not sped up". -->
 
 <p align="center"><img src="docs/assets/hero.gif" width="380" alt="gpt-oss-120b (~60 GB) generating on a 12 GB phone, with live tok/s and telemetry"></p>
 <p align="center"><em>gpt-oss-120b (~60 GB) on a 12 GB phone. Real time, not sped up. Full three-model demo below.</em></p>

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -77,16 +77,23 @@ check). Nothing below needs a storage permission except the last option.
    adb shell mv /data/local/tmp/shardllm /data/local/tmp/bmoe
    ```
 
-### gpt-oss-120b
+### Sharded models (gpt-oss-120b, DeepSeek V4 Flash)
 
-Listed in the catalog but not downloadable in-app: Hugging Face ships the Q4_K_M quant as two
-shards (the 50 GB per-file limit), and expert streaming reads tensors by byte offset from a
-single file. Merge the shards on a PC, then transfer the result:
+Models above Hugging Face's 50 GB per-file limit ship as several shard files
+(`-00001-of-0000N.gguf`). The engine streams a split set natively, so these download in-app
+like any other catalog entry: the shards are fetched one at a time (each resumable), the row
+shows one progress bar over the whole set, and the model list offers the FIRST shard — that is
+the file the engine opens; it finds the siblings next to it. A merged single-file gpt-oss from
+an earlier release keeps working and still shows as on-device.
+
+For adb-pushed models the same rule applies — push all shards to the same directory and pass
+the first one:
 
 ```bash
-llama-gguf-split --merge gpt-oss-120b-Q4_K_M-00001-of-00002.gguf gpt-oss-120b-Q4_K_M.gguf
-adb push gpt-oss-120b-Q4_K_M.gguf /data/local/tmp/bmoe/   # or import it with the file picker
+adb push DeepSeek-V4-Flash-0731-UD-IQ2_M-0000*-of-00003.gguf /data/local/tmp/bmoe/
 ```
+
+Mind the space: DeepSeek V4 Flash UD-IQ2_M is ~91 GB on disk.
 
 ## Expected numbers
 

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -82,11 +82,11 @@ check). Nothing below needs a storage permission except the last option.
 Models above Hugging Face's 50 GB per-file limit ship as several shard files
 (`-00001-of-0000N.gguf`). The engine streams a split set natively, so these download in-app
 like any other catalog entry: the shards are fetched one at a time (each resumable), the row
-shows one progress bar over the whole set, and the model list offers the FIRST shard — that is
+shows one progress bar over the whole set, and the model list offers the FIRST shard, which is
 the file the engine opens; it finds the siblings next to it. A merged single-file gpt-oss from
 an earlier release keeps working and still shows as on-device.
 
-For adb-pushed models the same rule applies — push all shards to the same directory and pass
+For adb-pushed models the same rule applies: push all shards to the same directory and pass
 the first one:
 
 ```bash

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -51,8 +51,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 33
-        versionName '0.18.1'
+        versionCode 34
+        versionName '0.19.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -71,6 +71,7 @@ data class AppSettings(
             "-m", modelPath,
             "-t", threads.toString(),
             "-c", SESSION_CTX.toString(),
+            "--ubatch", SESSION_UBATCH.toString(),
             // Render the model's OWN chat template, whichever family it belongs to; the flag name
             // is historical (ChatML is only llama.cpp's fallback when a gguf ships no template).
             // Nothing here selects a format, so it is correct for every model in the catalog.
@@ -152,6 +153,16 @@ data class AppSettings(
         // long prompt plus the largest practical generation. A request that would overflow it is
         // rejected recoverably by the CLI, leaving the session usable.
         const val SESSION_CTX = 4096
+
+        // Widest graph computed at once. Compute buffers are RESERVED for it, so leaving it at the
+        // context width (the engine's default) hands the whole reservation to a model that only
+        // ever decodes one token at a time. That reservation is memory the expert cache and the
+        // dense weights do not get: measured +18% decode on a model near RAM, and on a >RAM model
+        // with a large dense set it is the difference between decoding and swapping (DeepSeek V4
+        // spent 13.9 s/token of "compute" that was really page faults, against 1.5 s at this
+        // width). Prefill pays instead, and barely: chunking it costs ~7.7x the flash reads but
+        // only ~6% of prefill wall time, because prefill is compute-bound.
+        const val SESSION_UBATCH = 512
 
         // Tokens to generate per turn, when nothing says otherwise. The service falls back to this
         // for a request that arrives without one, so the default lives here rather than in two

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -30,6 +30,10 @@ data class AppSettings(
     val threads: Int = 4,               // compute threads (-t)
     val nExpertUsed: Int = 0,           // top-k override (0 = model default); lower = faster, changes output
     val nPredict: Int = DEFAULT_N_PREDICT,
+    // Context the session is opened with: prompt plus reply for the whole conversation. It is also
+    // memory — the KV cache is sized for it once at open — so on a model that already fills RAM a
+    // shorter context hands the difference back to the expert cache and the dense weights.
+    val sessionCtx: Int = SESSION_CTX,
     val oDirect: Boolean = true,        // bypass the page cache
     val overlap: Boolean = true,        // read the next experts while the current layer computes
     val denseWeights: DenseWeights = DenseWeights.ANON, // dense (non-expert) weight residency policy
@@ -70,8 +74,9 @@ data class AppSettings(
             cliPath,
             "-m", modelPath,
             "-t", threads.toString(),
-            "-c", SESSION_CTX.toString(),
-            "--ubatch", SESSION_UBATCH.toString(),
+            "-c", sessionCtx.toString(),
+            // Never reserve a graph wider than the context itself.
+            "--ubatch", minOf(SESSION_UBATCH, sessionCtx).toString(),
             // Render the model's OWN chat template, whichever family it belongs to; the flag name
             // is historical (ChatML is only llama.cpp's fallback when a gguf ships no template).
             // Nothing here selects a format, so it is correct for every model in the catalog.
@@ -126,7 +131,7 @@ data class AppSettings(
      * excluded — they vary per request without touching the loaded model.
      */
     fun sessionSignature(modelPath: String): String =
-        listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, oDirect,
+        listOf(modelPath, mmap, cacheMb, cacheCeilMb, ioThreads, threads, nExpertUsed, sessionCtx, oDirect,
                overlap, denseWeights, prefetchLayers, predictPrefetch, predictSpecMax, dropColdPct)
             .joinToString("|")
 
@@ -143,6 +148,7 @@ data class AppSettings(
             .putBoolean("predictPrefetch", predictPrefetch)
             .putInt("predictSpecMax", predictSpecMax)
             .putInt("dropColdPct", dropColdPct)
+            .putInt("sessionCtx", sessionCtx)
             .putBoolean("thinking", thinking)
             .putBoolean("metricsCsv", metricsCsv)
             .apply()
@@ -163,6 +169,10 @@ data class AppSettings(
         // width). Prefill pays instead, and barely: chunking it costs ~7.7x the flash reads but
         // only ~6% of prefill wall time, because prefill is compute-bound.
         const val SESSION_UBATCH = 512
+
+        // Context rungs. 4096 is the default a chat wants; the shorter ones exist for a model that
+        // already fills RAM, where the KV cache competes with the weights themselves.
+        val CTX_CHOICES = intArrayOf(512, 1024, 2048, 4096, 8192)
 
         // Tokens to generate per turn, when nothing says otherwise. The service falls back to this
         // for a request that arrives without one, so the default lives here rather than in two
@@ -256,6 +266,7 @@ data class AppSettings(
                 predictPrefetch = p.getBoolean("predictPrefetch", d.predictPrefetch),
                 predictSpecMax = p.getInt("predictSpecMax", d.predictSpecMax),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
+                sessionCtx = p.getInt("sessionCtx", d.sessionCtx),
                 thinking = p.getBoolean("thinking", d.thinking),
                 metricsCsv = p.getBoolean("metricsCsv", d.metricsCsv),
             )

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/GgufHeader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/GgufHeader.kt
@@ -12,13 +12,19 @@ import java.io.InputStream
  * the KV section is (a big tokenizer can push the tensor names well past any fixed window).
  *
  * gguf layout: "GGUF" magic, u32 version, then counts and a key/value metadata block, then one
- * info record per tensor (name, dims, type, offset). We only need the tensor names: a MoE model
- * names its down projection `blk.<il>.ffn_down_exps`, absent from dense models.
+ * info record per tensor (name, dims, type, offset).
+ *
+ * Two signals say "MoE", and both are needed. The metadata key `<arch>.expert_count` is the
+ * definitive one and is the only one a SPLIT model's first shard carries: that shard holds the
+ * metadata and (with the layout Hugging Face quants use) barely any tensors, so looking for an
+ * expert tensor there finds nothing and would hide the model from the picker. The tensor name
+ * `blk.<il>.ffn_down_exps` stays as the second check, for a file whose metadata omits the count.
  *
  * Spec: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md
  */
 object GgufHeader {
     private const val MOE_MARKER = "ffn_down_exps"
+    private const val MOE_KV_SUFFIX = ".expert_count"
 
     // gguf value types (for skipping KV entries we don't read).
     private const val T_UINT8 = 0
@@ -69,10 +75,16 @@ object GgufHeader {
             throw IllegalArgumentException("implausible header counts")
         }
 
-        // Skip the KV metadata block to reach the tensor-info records.
+        // Walk the KV metadata block. The expert count settles it on its own — and is the only
+        // signal present in a split model's first shard, which carries no expert tensors.
         for (i in 0 until kvCount) {
-            skipString(s)                 // key
-            skipValue(s, s.u32())         // value
+            val key = readString(s)
+            val type = s.u32()
+            if (key.endsWith(MOE_KV_SUFFIX) && isIntScalar(type)) {
+                if (readIntScalar(s, type) > 0) return true
+            } else {
+                skipValue(s, type)
+            }
             if (s.pos > MAX_HEADER_BYTES) throw IllegalArgumentException("header too large")
         }
 
@@ -88,6 +100,24 @@ object GgufHeader {
             if (s.pos > MAX_HEADER_BYTES) throw IllegalArgumentException("header too large")
         }
         return false
+    }
+
+    private fun isIntScalar(type: Int): Boolean = when (type) {
+        T_UINT8, T_INT8, T_UINT16, T_INT16, T_UINT32, T_INT32, T_UINT64, T_INT64 -> true
+        else -> false
+    }
+
+    /** Read an integer KV value of any width. Callers check [isIntScalar] first. */
+    private fun readIntScalar(s: Counting, type: Int): Long = when (type) {
+        T_UINT8, T_INT8 -> {
+            val b = ByteArray(1); s.readFully(b); b[0].toLong() and 0xff
+        }
+        T_UINT16, T_INT16 -> {
+            val b = ByteArray(2); s.readFully(b)
+            (b[0].toLong() and 0xff) or ((b[1].toLong() and 0xff) shl 8)
+        }
+        T_UINT32, T_INT32 -> s.u32().toLong() and 0xffffffffL
+        else -> s.u64()
     }
 
     private fun skipValue(s: Counting, type: Int) {
@@ -149,7 +179,10 @@ object GgufHeader {
                 off += n
             }
         }
-        String(buf, Charsets.US_ASCII).contains(MOE_MARKER)
+        val text = String(buf, Charsets.US_ASCII)
+        // The KV key is enough here too: a dense model names neither. (`expert_used_count` does
+        // not contain `expert_count` as a substring, so this cannot fire on the wrong key.)
+        text.contains(MOE_MARKER) || text.contains("expert_count")
     }.getOrDefault(false)
 
     /** InputStream wrapper: little-endian primitive reads, exact skipping, and a byte counter. */

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -565,7 +565,15 @@ private fun AddModelSection(
 
     // The raw on-disk view, shards included: `models` is the SELECTABLE list (non-first shards
     // hidden), but a sharded catalog entry is on-device only when every shard file is.
-    val present = remember(models) { models.map { it.name }.toSet() + ModelManager.allGgufNames(context) }
+    //
+    // Keyed on the in-flight NAMES as well as `models`, because `models` alone cannot see a shard
+    // land: shards 2..N are hidden from the selectable list by design, so finishing a 41 GB shard
+    // leaves it byte-identical and a `remember(models)` would serve a stale set forever — the entry
+    // would offer "Download" for a model already fully on the device. The key set changes exactly
+    // when a shard starts or finishes, not on every progress tick, so the directory scan stays rare.
+    val present = remember(models, progress.keys) {
+        models.map { it.name }.toSet() + ModelManager.allGgufNames(context)
+    }
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
@@ -642,7 +650,7 @@ private fun AddModelSection(
                 // On-device models the catalog does not list — imported via the URL field or the
                 // file picker below. They have no catalog row of their own, only a picker entry, so
                 // this is the one place to remove them.
-                val extraModels = models.filter { m -> ModelCatalog.entries.none { it.fileName == m.name } }
+                val extraModels = models.filter { m -> !ModelCatalog.isCatalogFile(m.name) }
                 if (extraModels.isNotEmpty()) {
                     HorizontalDivider()
                     Text("Imported models", fontSize = 14.sp, fontWeight = FontWeight.Medium)
@@ -699,8 +707,11 @@ private fun AddModelSection(
                         modifier = Modifier.weight(1f),
                     ) { Text("Pick file") }
                 }
-                // A pasted URL has no catalog row to show its progress in.
-                progress.filterKeys { k -> ModelCatalog.entries.none { it.fileName == k } }
+                // A pasted URL has no catalog row to show its progress in. Shard names belong to
+                // their entry's row: listing them here would duplicate the download AND offer a
+                // Cancel that cancels nothing (the chain is registered under the entry name) while
+                // still deleting the .part the worker is writing.
+                progress.filterKeys { k -> !ModelCatalog.isCatalogFile(k) }
                     .forEach { (name, p) ->
                         DownloadProgress(p, onCancel = { ModelDownloader.cancel(context, name) })
                     }
@@ -720,11 +731,13 @@ private fun AddModelSection(
     }
 
     deleteTarget?.let { fname ->
-        // A sharded catalog entry deletes as a unit: every shard's copies, not just the first's —
-        // orphaned 40 GB tails are the failure mode this forbids.
+        // A catalog entry deletes as a unit: every file it owns, not just the one whose button was
+        // tapped. Orphaned 40 GB tails are the failure mode this forbids. The entry's own name stays
+        // in the set alongside the shards, so a gpt-oss merged by an earlier release is still
+        // deletable; copiesOf drops the names that are not on disk.
         val targetNames = remember(fname) {
-            ModelCatalog.entries.firstOrNull { it.fileName == fname && it.shards.isNotEmpty() }
-                ?.shards?.map { it.fileName } ?: listOf(fname)
+            ModelCatalog.entries.firstOrNull { fname in ModelCatalog.fileNamesOf(it) }
+                ?.let { ModelCatalog.fileNamesOf(it).toList() } ?: listOf(fname)
         }
         val copies = remember(fname, models) { targetNames.flatMap { ModelManager.copiesOf(context, it) } }
         // The loaded session pins its gguf via mmap; deleting it out from under a live engine is the

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MainActivity.kt
@@ -563,7 +563,9 @@ private fun AddModelSection(
     // at the bottom of the card it would surface under a different heading entirely.
     var rowError by remember { mutableStateOf<Pair<String, String>?>(null) }
 
-    val present = remember(models) { models.map { it.name }.toSet() }
+    // The raw on-disk view, shards included: `models` is the SELECTABLE list (non-first shards
+    // hidden), but a sharded catalog entry is on-device only when every shard file is.
+    val present = remember(models) { models.map { it.name }.toSet() + ModelManager.allGgufNames(context) }
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
@@ -616,19 +618,23 @@ private fun AddModelSection(
                     CatalogRow(
                         entry = e,
                         status = ModelCatalog.statusOf(e, present, progress.keys),
-                        progress = progress[e.fileName],
+                        progress = ModelDownloader.entryProgress(context, e, progress),
                         installShown = showInstall == e.fileName,
                         error = rowError?.takeIf { it.first == e.fileName }?.second,
                         onToggleInstall = { showInstall = if (showInstall == e.fileName) null else e.fileName },
                         onDownload = {
                             error = null
                             rowError = null
-                            ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
-                                .onFailure {
-                                    rowError = e.fileName to (it.message ?: "download failed to start")
-                                }
+                            val res = if (e.shards.isNotEmpty()) {
+                                ModelDownloader.enqueueShards(context, e)
+                            } else {
+                                ModelDownloader.enqueue(context, e.url ?: "", e.fileName, e.approxBytes)
+                            }
+                            res.onFailure {
+                                rowError = e.fileName to (it.message ?: "download failed to start")
+                            }
                         },
-                        onCancel = { ModelDownloader.cancel(context, e.fileName) },
+                        onCancel = { ModelDownloader.cancelEntry(context, e) },
                         onDelete = { deleteTarget = e.fileName },
                     )
                 }
@@ -714,7 +720,13 @@ private fun AddModelSection(
     }
 
     deleteTarget?.let { fname ->
-        val copies = remember(fname, models) { ModelManager.copiesOf(context, fname) }
+        // A sharded catalog entry deletes as a unit: every shard's copies, not just the first's —
+        // orphaned 40 GB tails are the failure mode this forbids.
+        val targetNames = remember(fname) {
+            ModelCatalog.entries.firstOrNull { it.fileName == fname && it.shards.isNotEmpty() }
+                ?.shards?.map { it.fileName } ?: listOf(fname)
+        }
+        val copies = remember(fname, models) { targetNames.flatMap { ModelManager.copiesOf(context, it) } }
         // The loaded session pins its gguf via mmap; deleting it out from under a live engine is the
         // failure mode to forbid. sessionSignature starts with the model's path, so match on that.
         val isLoaded = copies.any { loadedSig != null && loadedSig.startsWith(it.absolutePath + "|") }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -41,6 +41,21 @@ object ModelCatalog {
     /** One file of a sharded entry. [bytes] is exact (from the repository), not approximate. */
     data class Shard(val fileName: String, val url: String, val bytes: Long)
 
+    /**
+     * Every on-disk name this entry can own: its own file plus any shards. The entry's [Entry.fileName]
+     * is usually the first shard, but not always — gpt-oss keeps the legacy merged name so a file
+     * merged by an earlier release still counts. Anything that asks "does this filename belong to a
+     * catalog entry?" must ask THIS, not [Entry.fileName]: a shard answered no, and then showed up as
+     * an imported model with a Delete that orphaned the rest of the set.
+     */
+    fun fileNamesOf(e: Entry): Set<String> = buildSet {
+        add(e.fileName)
+        e.shards.forEach { add(it.fileName) }
+    }
+
+    /** True if [name] is a file some catalog entry owns. */
+    fun isCatalogFile(name: String): Boolean = entries.any { name in fileNamesOf(it) }
+
     enum class Status {
         /** Already on the device — nothing to do. */
         ON_DEVICE,

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -26,9 +26,20 @@ object ModelCatalog {
         val url: String?,
         /** Why you would pick this one. Kept short enough to sit on one line. */
         val blurb: String,
-        /** Manual install steps, shown on demand. Non-null exactly when [url] is null. */
+        /** Manual install steps, shown on demand. Non-null exactly when the entry is [Status.MANUAL_ONLY]. */
         val install: String? = null,
+        /**
+         * A model above Hugging Face's 50 GB per-file limit ships as several shard files; the engine
+         * opens the FIRST shard and streams the whole set. For such an entry this lists every shard
+         * in order, [fileName] is the first shard (the file handed to the engine, and the name the
+         * whole set is keyed by in downloads and deletes), [approxBytes] is the total, and [url]
+         * stays null — the shard URLs are here.
+         */
+        val shards: List<Shard> = emptyList(),
     )
+
+    /** One file of a sharded entry. [bytes] is exact (from the repository), not approximate. */
+    data class Shard(val fileName: String, val url: String, val bytes: Long)
 
     enum class Status {
         /** Already on the device — nothing to do. */
@@ -77,27 +88,55 @@ object ModelCatalog {
         Entry(
             title = "gpt-oss-120b",
             quant = "Q4_K_M",
+            // The legacy name: earlier releases required merging the two shards on a PC, so a
+            // merged file by this name on the device still counts as ON_DEVICE. New downloads
+            // fetch the two shards as-is — the engine streams a split set natively.
             fileName = "gpt-oss-120b-Q4_K_M.gguf",
             approxBytes = 62_768_723_552L,
-            // Not downloadable in-app: Hugging Face ships this quant as two shards (the 50 GB
-            // per-file limit), and expert streaming reads tensors by byte offset from one file.
-            // Merging on the phone would need ~120 GB of free space, so it is a PC step.
             url = null,
-            blurb = "5B active of 117B. The >RAM case — merge it on a PC.",
-            install = "Hugging Face ships this quant as two shards, and expert streaming needs a\n" +
-                "single file. Merging on the phone would need ~120 GB free, so merge on a PC:\n" +
-                "\n" +
-                "1. Download both shards from\n" +
-                "   huggingface.co/unsloth/gpt-oss-120b-GGUF (folder Q4_K_M/)\n" +
-                "2. llama-gguf-split --merge \\\n" +
-                "     gpt-oss-120b-Q4_K_M-00001-of-00002.gguf \\\n" +
-                "     gpt-oss-120b-Q4_K_M.gguf\n" +
-                "3. Move the merged file to the phone" +
-                if (BuildConfig.SHARED_STORAGE) {
-                    ":\n   adb push gpt-oss-120b-Q4_K_M.gguf /data/local/tmp/bmoe/"
-                } else {
-                    ", then pick it with\n   \"Other model\" below."
-                },
+            blurb = "5B active of 117B. The >RAM case — two shards, downloaded as-is.",
+            shards = listOf(
+                Shard(
+                    "gpt-oss-120b-Q4_K_M-00001-of-00002.gguf",
+                    "https://huggingface.co/unsloth/gpt-oss-120b-GGUF/resolve/main/Q4_K_M/" +
+                        "gpt-oss-120b-Q4_K_M-00001-of-00002.gguf?download=true",
+                    49_630_904_192L,
+                ),
+                Shard(
+                    "gpt-oss-120b-Q4_K_M-00002-of-00002.gguf",
+                    "https://huggingface.co/unsloth/gpt-oss-120b-GGUF/resolve/main/Q4_K_M/" +
+                        "gpt-oss-120b-Q4_K_M-00002-of-00002.gguf?download=true",
+                    13_137_819_360L,
+                ),
+            ),
+        ),
+        Entry(
+            title = "DeepSeek V4 Flash",
+            quant = "UD-IQ2_M",
+            fileName = "DeepSeek-V4-Flash-0731-UD-IQ2_M-00001-of-00003.gguf",
+            approxBytes = 90_926_928_288L,
+            url = null,
+            blurb = "13B active of 284B. The biggest thing this app offers — needs ~95 GB free.",
+            shards = listOf(
+                Shard(
+                    "DeepSeek-V4-Flash-0731-UD-IQ2_M-00001-of-00003.gguf",
+                    "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF/resolve/main/UD-IQ2_M/" +
+                        "DeepSeek-V4-Flash-0731-UD-IQ2_M-00001-of-00003.gguf?download=true",
+                    5_257_664L,
+                ),
+                Shard(
+                    "DeepSeek-V4-Flash-0731-UD-IQ2_M-00002-of-00003.gguf",
+                    "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF/resolve/main/UD-IQ2_M/" +
+                        "DeepSeek-V4-Flash-0731-UD-IQ2_M-00002-of-00003.gguf?download=true",
+                    49_956_780_160L,
+                ),
+                Shard(
+                    "DeepSeek-V4-Flash-0731-UD-IQ2_M-00003-of-00003.gguf",
+                    "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF/resolve/main/UD-IQ2_M/" +
+                        "DeepSeek-V4-Flash-0731-UD-IQ2_M-00003-of-00003.gguf?download=true",
+                    40_964_890_464L,
+                ),
+            ),
         ),
     )
 
@@ -117,6 +156,15 @@ object ModelCatalog {
      * in-flight downloads.
      */
     fun statusOf(e: Entry, present: Set<String>, downloading: Set<String>): Status = when {
+        // A sharded entry is on-device when EVERY shard landed — or when a legacy pre-split file
+        // by the entry name is present (gpt-oss merged on a PC by an earlier release). Any shard
+        // still in flight makes the whole entry DOWNLOADING: the set is downloaded sequentially,
+        // so exactly one transfers at a time but the entry is one unit of progress to the user.
+        e.shards.isNotEmpty() -> when {
+            e.fileName in present || e.shards.all { it.fileName in present } -> Status.ON_DEVICE
+            e.shards.any { it.fileName in downloading } -> Status.DOWNLOADING
+            else -> Status.AVAILABLE
+        }
         e.fileName in present -> Status.ON_DEVICE
         e.fileName in downloading -> Status.DOWNLOADING
         e.url == null -> Status.MANUAL_ONLY

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -157,16 +157,21 @@ object ModelDownloader {
      */
     fun entryProgress(ctx: Context, e: ModelCatalog.Entry, live: Map<String, Progress>): Progress? {
         if (e.shards.isEmpty()) return live[e.fileName]
-        val active = e.shards.firstNotNullOfOrNull { live[it.fileName] } ?: return null
+        val active = e.shards.firstNotNullOfOrNull { s -> live[s.fileName]?.let { s to it } } ?: return null
         val dir = ModelManager.internalModelsDir(ctx)
         val landed = e.shards.sumOf { s -> if (File(dir, s.fileName).isFile) s.bytes else 0L }
+        // A shard that is queued rather than running reports 0 bytes (events() has no progress row
+        // for it yet), which on a resumed 50 GB transfer would read as lost ground. Fall back to
+        // what is already in its .part.
+        val inFlight = if (active.second.downloadedBytes > 0) active.second.downloadedBytes
+        else File(dir, active.first.fileName + DownloadWorker.PART_SUFFIX).length()
         return Progress(
             id = e.fileName,
             name = e.fileName,
-            downloadedBytes = landed + active.downloadedBytes.coerceAtLeast(0),
+            downloadedBytes = landed + inFlight,
             totalBytes = e.approxBytes,
-            state = active.state,
-            reason = active.reason,
+            state = active.second.state,
+            reason = active.second.reason,
         )
     }
 

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelDownloader.kt
@@ -102,6 +102,86 @@ object ModelDownloader {
     }
 
     /**
+     * Start a sharded (multi-file) catalog download: one [DownloadWorker] per missing shard,
+     * CHAINED so they transfer sequentially — the phone's line is the bottleneck, and one file at a
+     * time keeps the resume story per-file. The chain's unique-work name is the ENTRY's fileName
+     * (the first shard), so enqueuing twice is a no-op and cancel kills the whole set; each link
+     * still tags its own shard name, so [events] reports per-shard progress under that name.
+     *
+     * Free space is checked ONCE against the whole remaining set (missing shards minus their
+     * partial bytes), not per file — three separate late failures for one decision is the thing
+     * this avoids. Shards already fully on disk are skipped, so a torn set resumes cleanly.
+     */
+    fun enqueueShards(ctx: Context, entry: ModelCatalog.Entry): Result<String> = runCatching {
+        require(entry.shards.isNotEmpty()) { "not a sharded entry" }
+        val dir = ModelManager.internalModelsDir(ctx)
+        val missing = entry.shards.filter { !File(dir, it.fileName).isFile }
+        if (missing.isEmpty()) return@runCatching entry.fileName // all landed — caller re-scans
+        val needed = missing.sumOf { s ->
+            (s.bytes - File(dir, s.fileName + DownloadWorker.PART_SUFFIX).length()).coerceAtLeast(0)
+        }
+        if (needed > dir.usableSpace) {
+            error(
+                "needs ${ModelCatalog.gbLabel(needed)}, " +
+                    "only ${ModelCatalog.gbLabel(dir.usableSpace)} free"
+            )
+        }
+
+        val requests = missing.map { s ->
+            OneTimeWorkRequestBuilder<DownloadWorker>()
+                .setInputData(
+                    workDataOf(
+                        DownloadWorker.KEY_URL to s.url,
+                        DownloadWorker.KEY_NAME to s.fileName,
+                        DownloadWorker.KEY_EXPECTED to s.bytes,
+                    )
+                )
+                .addTag(DownloadWorker.TAG)
+                .addTag(NAME_TAG_PREFIX + s.fileName)
+                .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+        }
+        var chain = WorkManager.getInstance(ctx).beginUniqueWork(entry.fileName, ExistingWorkPolicy.KEEP, requests.first())
+        for (req in requests.drop(1)) chain = chain.then(req)
+        // Block until the chain is persisted, same reason as enqueue above.
+        chain.enqueue().result.get()
+        entry.fileName
+    }
+
+    /**
+     * A catalog entry's aggregate progress, or null when nothing of it is in flight. Single-file
+     * entries pass through; for a sharded entry the fraction is over the WHOLE set — shards already
+     * on disk count as done, the in-flight shard contributes its partial bytes — because the row
+     * shows one model, not three files.
+     */
+    fun entryProgress(ctx: Context, e: ModelCatalog.Entry, live: Map<String, Progress>): Progress? {
+        if (e.shards.isEmpty()) return live[e.fileName]
+        val active = e.shards.firstNotNullOfOrNull { live[it.fileName] } ?: return null
+        val dir = ModelManager.internalModelsDir(ctx)
+        val landed = e.shards.sumOf { s -> if (File(dir, s.fileName).isFile) s.bytes else 0L }
+        return Progress(
+            id = e.fileName,
+            name = e.fileName,
+            downloadedBytes = landed + active.downloadedBytes.coerceAtLeast(0),
+            totalBytes = e.approxBytes,
+            state = active.state,
+            reason = active.reason,
+        )
+    }
+
+    /**
+     * Cancel a catalog entry's download — the whole chain for a sharded entry — and delete the
+     * leftover .part files. Shards that fully landed stay: a later retry skips them.
+     */
+    fun cancelEntry(ctx: Context, e: ModelCatalog.Entry) {
+        WorkManager.getInstance(ctx).cancelUniqueWork(e.fileName).result.get()
+        val dir = ModelManager.internalModelsDir(ctx)
+        val names = if (e.shards.isEmpty()) listOf(e.fileName) else e.shards.map { it.fileName }
+        names.forEach { File(dir, it + DownloadWorker.PART_SUFFIX).delete() }
+    }
+
+    /**
      * Every download's progress and outcome, as a stream. WorkManager's own flow drives it, so the
      * UI observes instead of polling, and a transfer started before the app was killed reappears on
      * the first emission rather than running unseen.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelManager.kt
@@ -65,8 +65,25 @@ object ModelManager {
             .distinctBy { it.name }
             .sortedBy { it.name }
 
-    /** List MoE models only. Blocking header reads — call off the main thread. */
-    fun listMoeModels(ctx: Context): List<File> = allGguf(ctx).filter { GgufHeader.isMoe(it) }
+    // Shards 2..N of a split gguf (`-00002-of-00003.gguf`) carry tensor data but no model
+    // metadata — llama.cpp and the engine read everything from the FIRST shard, which is the only
+    // selectable file of the set. Their header also fails GgufHeader.isMoe, but that would be
+    // filtering by accident; this is the designed rule.
+    private val SHARD_SUFFIX = Regex("-(\\d{5})-of-\\d{5}\\.gguf$")
+
+    private fun isNonFirstShard(name: String): Boolean =
+        SHARD_SUFFIX.find(name)?.let { it.groupValues[1] != "00001" } == true
+
+    /** List MoE models only (first shard represents a split set). Blocking header reads — call off the main thread. */
+    fun listMoeModels(ctx: Context): List<File> =
+        allGguf(ctx).filter { !isNonFirstShard(it.name) && GgufHeader.isMoe(it) }
+
+    /**
+     * Names of every gguf on the device, non-first shards included. The catalog's presence check
+     * needs this raw view: a sharded entry is ON_DEVICE only when every shard is, and shards 2..N
+     * are exactly what [listMoeModels] hides.
+     */
+    fun allGgufNames(ctx: Context): Set<String> = allGguf(ctx).map { it.name }.toSet()
 
     /**
      * Every on-disk copy of [fileName] across the scanned dirs. listMoeModels dedups by name and

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/RunService.kt
@@ -83,6 +83,9 @@ class RunService : Service() {
 
     // ── session lifecycle ──
 
+    /** Context of the running session, parsed from its argv at start (see startSession). */
+    private var sessionCtx = AppSettings.SESSION_CTX
+
     private fun startSession(intent: Intent?) {
         val model = intent?.getStringExtra(EXTRA_MODEL) ?: run { fail("no model"); return }
         val argv = intent.getStringArrayListExtra(EXTRA_ARGV) ?: run { fail("no argv"); return }
@@ -108,6 +111,13 @@ class RunService : Service() {
         main.removeCallbacks(forceKill)
 
         val streaming = argv.contains("--moe-stream")
+        // The context this session was actually opened with, for the "ctx used/total" readout.
+        // Taken from the argv rather than re-read from settings, so the number always describes
+        // the running process even if the setting changed after it started.
+        sessionCtx = argv.indexOf("-c").let { i ->
+            if (i >= 0 && i + 1 < argv.size) argv[i + 1].toIntOrNull() ?: AppSettings.SESSION_CTX
+            else AppSettings.SESSION_CTX
+        }
         startForeground(NOTIF_ID, buildNotification("Loading model…"))
         RunBus.update {
             // ioMode is re-sniffed from the new session's stderr, so clear it: it describes the
@@ -270,7 +280,7 @@ class RunService : Service() {
                     append(String.format(loc, " · prefill %.1fs", prefill))
                     if (nPrompt >= 0) append(String.format(loc, " (%d tok)", nPrompt))
                 }
-                if (nPast >= 0) append(String.format(loc, " · ctx %d/%d", nPast, AppSettings.SESSION_CTX))
+                if (nPast >= 0) append(String.format(loc, " · ctx %d/%d", nPast, sessionCtx))
                 if (hit >= 0) append(String.format(loc, " · cache %.0f%%", hit))
                 if (cancelled) append(" · cancelled")
             }

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -224,6 +224,17 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 IntSetting("Tokens to generate", AppSettings.NPREDICT_CHOICES, current.nPredict) {
                     onChange(current.copy(nPredict = it))
                 }
+                IntSetting("Context (tokens)", AppSettings.CTX_CHOICES, current.sessionCtx) {
+                    onChange(current.copy(sessionCtx = it))
+                }
+                Text(
+                    "How much of the conversation the session can hold, prompt and reply together. " +
+                        "It is also memory: the KV cache is sized for it once when the model opens, " +
+                        "and on a model that already fills RAM that memory comes out of the expert " +
+                        "cache and the weights. Shorten it on the largest models, raise it when you " +
+                        "want long conversations and have the room. Changing it reopens the session.",
+                    fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
             Section("Prompt") {


### PR DESCRIPTION
Stacked on #144 (multi-shard engine support) — merge that first; this diff is the app commit only.

## What

The demo app learns sharded models:

- **Catalog entries can list shard files.** They download sequentially through one WorkManager
  chain: per-file HTTP Range resume, one aggregate progress bar over the whole set, and the
  free-space check runs once against the remaining bytes (missing shards minus their partials) —
  not three separate late failures.
- **The model picker offers only the first shard** — the file the engine opens (it finds the
  siblings next to it). Hiding shards 2..N is now a designed rule in ModelManager, not an
  accident of the MoE header filter.
- **Deleting a sharded entry deletes the whole set**, every copy of every shard.
- **DeepSeek V4 Flash UD-IQ2_M (~91 GB, three shards) joins the catalog**, and **gpt-oss-120b
  goes from a "merge it on a PC" manual recipe to a one-tap download** (two shards as-is). A
  merged single-file gpt-oss from an earlier release still counts as on-device.

App version 0.19.0 (versionCode 34). CHANGELOG and the Android README updated in the same PR.

## Validation

- Kotlin compiles; dev APK builds from this branch.
- On-device flow test pending (blocked on the ~91 GB download finishing); will land before the
  release is tagged, per the project's release rules.
