### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,9 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Set up NDK
-        uses: nttld/setup-ndk@v1
+        # Third-party action, pinned by commit SHA: a mutable tag here would run whatever the
+        # upstream repo points it at, inside a job that holds a contents:write token.
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         id: ndk
         with:
           # r27c == 27.2.12479018, the NDK release-apk.yml builds published APKs with. These two
@@ -168,6 +170,8 @@ jobs:
           if-no-files-found: error
       - name: Attach APK to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        # Pinned by commit SHA for the same reason. This step only runs on a tag push, so a
+        # wrong pin would not surface until a release: resolve the SHA, do not hand-edit it.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: examples/android/app/build/outputs/apk/dev/debug/app-dev-debug.apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,14 @@ Semantic Versioning.
   NDK r27c, the same release that produces published APKs, so CI stops validating a build nobody
   installs; and it passes `-DGGML_OPENCL=OFF`, the flag whose absence once shipped a stray backend
   into two releases. `actions/checkout` moves to v5 (v4 pins a deprecated Node runtime).
+- **Third-party actions are pinned by commit SHA.** `nttld/setup-ndk` and `softprops/action-gh-release`
+  ran from mutable major tags inside the APK job, which holds a `contents: write` token: whoever
+  controls those tags upstream could have pointed them at unreviewed code with permission to rewrite
+  this repo's release assets. Both now resolve to a fixed commit, with the human-readable version in a
+  trailing comment. GitHub-owned actions stay on major tags, since pinning them would mean an SHA bump
+  on every upstream release for a materially smaller risk. The signing keystore was never exposed to
+  this: it lives only in `release-apk.yml`, which runs no third-party action and triggers only on
+  events that already require write access.
 - **`--help` lists every flag the CLI accepts.** `--io-trace` in particular was a fully documented,
   guarded diagnostic that the usage text never mentioned; `--version`, `-h`, `--prefetch-sync` and
   the two deprecated `--dense-weights` aliases are named now too. A flag that works but is not


### PR DESCRIPTION
`nttld/setup-ndk@v1` and `softprops/action-gh-release@v2` ran from mutable major tags inside the
`android-apk` job, which holds a `contents: write` token. Whoever controls those tags upstream could
have pointed them at unreviewed code with permission to rewrite this repository's release assets.

Both are now pinned to a commit SHA, with the human-readable version in a trailing comment:

| Action | SHA | Version |
| --- | --- | --- |
| `nttld/setup-ndk` | `ed92fe6` | v1.6.0 |
| `softprops/action-gh-release` | `3bb1273` | v2.6.2 |

Each SHA was resolved through the API and checked against the tag it belongs to, rather than copied
by hand. `action-gh-release` is pinned at the v2 line it was already on; moving to v3 is a separate
decision, not something to slip into a hardening change.

GitHub-owned actions (`checkout`, `setup-java`, `upload-artifact`) stay on major tags. Pinning them
too would be needed to turn on the repository's SHA-pinning enforcement, at the cost of an SHA bump
on every upstream release, for a materially smaller risk.

The release signing keystore was never reachable through this path. It lives only in
`release-apk.yml`, which runs no third-party action and triggers only on `release: published` and
`workflow_dispatch`, both of which already require write access.

CI exercises the `setup-ndk` pin on this PR. The `action-gh-release` pin only runs on a tag push, so
it stays unproven until the next release: that is why the SHA was resolved rather than typed.

Alongside this change, and not visible in the diff, the repository now has secret scanning with push
protection enabled, a ruleset blocking deletion and force-push on release tags `v*`, and the same on
`main`.
