### PR TITLE
feat(moe): Ling 3.0 (bailingmoe3) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.20.0] - 2026-08-17
+
+### Added
+- **Ling 3.0 (`bailingmoe3`) recipe.** Ling-3.0-flash (127B total, ~5B active) routes over 512
+  experts with a per-expert bias (the `lfm2moe` pattern) plus one always-on shared expert that
+  stays resident; the experts name the standard split suffixes, so streaming is one registry row.
+  The leading dense blocks never bind, and the trailing NextN/MTP block names expert tensors but
+  is not even loaded (llama.cpp defaults `load_mtp=false`), so it never streams. The hybrid
+  KDA/MLA attention stack is dense-side llama.cpp code, invisible to the streaming seam.
+
+### Changed
+- **llama.cpp submodule bumped** to upstream `3733366` (BailingMoE3 support) with the expert-ready
+  hook rebased on top, still a single-commit delta over stock upstream. Byte-identity gates pass
+  on the new base. App version 0.20.0 (versionCode 35).
+
+### Fixed
+- **`--mtp` kept working across the bump.** Upstream now skips the nextn/MTP tensors at load
+  unless `load_mtp` is set, and the flag defaults to off, so the second context `--mtp` builds
+  over that block would have found its tensors missing. Worse as a failure mode: `n_layer_nextn`
+  is read from the gguf metadata and stays non-zero regardless, so the "this model has no trained
+  MTP head" check would have passed and the trouble surfaced later. The block is now requested
+  exactly when speculation asks for it. Verified on Qwen3.6-35B-A3B: 17/19 drafts accepted,
+  3.43 tokens per verify decode.
+
 ## [0.19.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Defaults are the measured winning recipe for a model near RAM.
 | `gpt-oss` | OpenAI gpt-oss-20b / 120b | Purely routed; MXFP4 weights stream unchanged |
 | `lfm2moe` | Liquid AI LFM2 / LFM2.5 MoE (e.g. 8B-A1B) | Hybrid conv/attention stack with leading dense blocks; those stay resident |
 | `deepseek4` | DeepSeek V4 Flash (284B-A13B), validated on the 0731 release | V3.2-style routing (256 experts + shared); compressed attention is dense-side; ships multi-shard |
+| `bailingmoe3` | Ling 3.0 (e.g. Ling-3.0-flash, 127B-A5B) | 512 routed experts + shared, biased top-k; hybrid KDA/MLA attention is dense-side |
 
 Adding an architecture is one row in the registry; expert counts and layouts are discovered from
 the model file at runtime, so nothing about a specific model is hardcoded in the streaming path.

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -404,9 +404,14 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
     // Load with the layout the streamer requires: file-backed mmap, no repack (a repacked
     // q4_K buffer would break the rebind), experts on CPU.
     llama_model_params mparams = llama_model_default_params();
-    mparams.use_mmap = true;
+    mparams.load_mode = LLAMA_LOAD_MODE_MMAP;
     mparams.use_extra_bufts = false;
     mparams.n_gpu_layers = 0;
+    // The nextn/MTP block is skipped at load unless asked for: llama.cpp marks its tensors
+    // TENSOR_SKIP by default, and only --mtp builds a graph over them. n_layer_nextn comes from
+    // the gguf metadata either way, so the "this model has no trained head" check below is
+    // unaffected by this flag.
+    mparams.load_mtp = cfg.spec.is_mtp();
 
     // Optional active-expert override: reduce the model's top-k routing (e.g. 8 -> 6) to cut
     // per-token compute and — under streaming — flash I/O, at a quality cost. Applied purely

--- a/core/src/engine/thinking_control.cpp
+++ b/core/src/engine/thinking_control.cpp
@@ -77,13 +77,31 @@ ThinkControl probe_think_control(const common_chat_templates * tmpls) {
         const bool owns_span =
             !off_p.thinking_start_tag.empty() && src.find(off_p.thinking_start_tag) != std::string::npos;
 
-        // It does, and the flag is inert: the request cannot be honoured. Closing the span in the
-        // prompt is only a suggestion to a model that opens its own — LFM2.5 reasons straight past a
-        // pre-closed empty one and emits the reasoning untagged into the answer (issue #82), worse
-        // than leaving it alone. Say so instead of making it worse.
-        if (owns_span) return ThinkControl::None;
-
         const std::string prefilled = apply_probe(tmpls, /*enable_thinking=*/false, /*prefill=*/true).prompt;
+
+        // It does, and the flag is inert. Whether the request can still be honoured depends on WHO
+        // closes the span. If the prefilled render moves past the closed span into further structure
+        // of the format itself — harmony ends the analysis channel and then opens the final one —
+        // the model is placed in its answer section and cannot decline. If the render just ends at
+        // the closing tag, closing it was only a suggestion to a model that opens its own — LFM2.5
+        // reasons straight past a pre-closed empty span and emits the reasoning untagged into the
+        // answer (issue #82), worse than leaving it alone. Say so instead of making it worse.
+        if (owns_span) {
+            if (prefilled != off) {
+                size_t close_end = std::string::npos;
+                for (const std::string & tag : off_p.thinking_end_tags) {
+                    const size_t at = tag.empty() ? std::string::npos : prefilled.rfind(tag);
+                    if (at != std::string::npos && (close_end == std::string::npos || at + tag.size() > close_end)) {
+                        close_end = at + tag.size();
+                    }
+                }
+                if (close_end != std::string::npos &&
+                    prefilled.find_first_not_of(" \t\r\n", close_end) != std::string::npos) {
+                    return ThinkControl::Prefill;
+                }
+            }
+            return ThinkControl::None;
+        }
 
         // No span of its own, and the prefill lands: reasoning is structural — a channel the format
         // itself separates — so starting the turn past that section is not something the model can

--- a/core/src/moe/arch_registry.cpp
+++ b/core/src/moe/arch_registry.cpp
@@ -49,6 +49,14 @@ static const MoeRecipe k_recipes[] = {
     // inside llama.cpp and invisible to the streaming seam. Models this size ship as multi-shard
     // ggufs; the streamer resolves each expert tensor to its (shard, offset) — see gguf_offsets.
     {"deepseek4", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
+    // bailingmoe3 (Ling 3.0, e.g. Ling-3.0-flash 127B-A5B) combines every pattern above and adds
+    // nothing new to the seam: 512 routed experts with the standard split suffixes (one row),
+    // top-k with a per-expert bias (exp_probs_b, the lfm2moe pattern), an always-on shared expert
+    // (ffn_*_shexp) that stays mmap-resident, leading dense blocks that never bind, and a trailing
+    // NextN/MTP block that names expert tensors but is not even loaded (llama.cpp defaults
+    // load_mtp=false), so its layer simply never streams. The hybrid KDA/MLA attention stack is
+    // dense-side machinery inside llama.cpp and invisible to the seam.
+    {"bailingmoe3", {"ffn_gate_exps", "ffn_up_exps", "ffn_down_exps"}},
 };
 
 static const int k_n_recipes = (int) (sizeof(k_recipes) / sizeof(k_recipes[0]));

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -51,8 +51,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 34
-        versionName '0.19.0'
+        versionCode 35
+        versionName '0.20.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/tests/think_control_test.cpp
+++ b/tests/think_control_test.cpp
@@ -132,10 +132,11 @@ int main() {
             expect_span_closed("lfm2.5: the prefill would close the span correctly", t.get(), "</think>");
         }
 
-        // gpt-oss / harmony. Its template ignores the flag too, and it declares NO thinking tags:
-        // reasoning is a channel the format separates structurally, so priming past it is not
-        // something the model can decline. This is the case the engine used to carry as two
-        // hardcoded harmony marker strings in the decode path.
+        // gpt-oss / harmony. Its template ignores the flag too, and it declares thinking tags —
+        // but reasoning is a channel the format separates structurally: the prefilled render closes
+        // the analysis channel and opens the final one, so priming past it is not something the
+        // model can decline. This is the case the engine used to carry as two hardcoded harmony
+        // marker strings in the decode path.
         {
             auto t = load(BMOE_TMPL_GPTOSS);
             expect("gpt-oss: probed as prefill",


### PR DESCRIPTION
## What

Ling 3.0 support (`bailingmoe3`), e.g. Ling-3.0-flash: 127B total, ~5B active, 512 routed experts. Upstream merged BailingMoE3 today (ggml-org/llama.cpp#26608); this PR bumps the submodule to that base and adds the one registry row the streamer needs.

## How

- **Submodule bump** to fork branch `bmoe/expert-ready-hook-ling3`: the same single expert-ready-hook commit, cherry-picked clean onto upstream `3733366`. The previous fork branch stays untouched so the old pin remains reachable. The jump crosses 496 upstream commits.
- **Recipe row.** `bailingmoe3` combines patterns the registry already carries: split expert suffixes, biased top-k (the `lfm2moe` pattern), a resident shared expert, leading dense blocks, and a NextN/MTP block llama.cpp does not load by default.
- Three adaptations the new base forces, all on our side of the seam:
  - `llama_model_params.use_mmap` became the `load_mode` enum. The streamer's required layout is now pinned with `LLAMA_LOAD_MODE_MMAP`.
  - **The nextn/MTP tensors are now skipped at load unless `load_mtp` is set, and it defaults to off**, so `--mtp` would have built its second context over a block whose tensors were never loaded. It fails badly rather than loudly: `n_layer_nextn` comes from the gguf metadata and stays non-zero either way, so the "no trained MTP head" guard would have passed and the trouble surfaced further in. The block is now requested exactly when speculation asks for it.
  - gpt-oss/harmony now declares its thinking tags, so the think-control probe decides by mechanism instead: a prefill that moves past the closed span into further structure of the format itself is binding, while one that just ends at the closing tag is only a suggestion (LFM2.5 stays reported as uncontrollable).

## Evidence

Byte-identity gates pass on the new base (`qwen3moe`, `gemma4`, 4-shard split): streamed == resident.

PC smoke on Qwen3.6-35B-A3B, every cell of the recipe that still applies, against the recorded baseline:

| cell | tok/s | read/token | hit | signal |
|---|---:|---:|---:|---|
| plain | 2.14 | 270.5 MiB | 39.6% | coherent text (baseline 2.11 / 272 / 36%) |
| `--ngram --draft 3` | 2.14 | 270.5 MiB | 39.6% | drafted on 0 of 24 steps, identical to plain, which is the designed property |
| `--route-ahead 2` | 2.68 | 264.3 MiB | 69.0% | 2984/2984 speculated experts useful, stall 0.30 down to 0.04 |
| `--mtp --draft 3` | 2.25 (2.09 effective) | 313.4 MiB | 23.9% | 17/19 drafts accepted, 3.43 tokens per verify |

(`--odirect-zero-copy` is not in `main`, it lives on the PR #143 branch, so that cell does not apply here.)

`think_control` covers the new probe logic: harmony as prefill, LFM2.5 as none, non-reasoning LFM variants as template.

## Not covered

No device run yet, and no load of `gpt-oss`, `lfm2moe` or `deepseek4` on the new base. Given the size of the upstream jump, a device validation is owed before this is released.

App version 0.20.0 (versionCode 35). A catalog entry for Ling follows once a reputable quantized upload exists; the URL field and file picker already take any `bailingmoe3` gguf.
