### PR TITLE
fix(build): report the project version the release actually cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.21.0] - 2026-08-25
+
+### Changed
+- **Finer expert-cache rungs below 2000 MiB in the app.** The ladder went 500 → 1000 → 2000, and
+  that x2 is where the choice is sharp: on an 8 GB phone 1000 MiB runs and 2000 MiB gets the app
+  killed by the OS, so the step handed the user a cliff instead of a setting. 1250, 1500 and 1750
+  fill it; above 2000 the existing 1000 MiB step is a small fraction of the budget and is unchanged.
+  Reported by @eiffel31 (#146).
+
+### Fixed
+- **The build reports its own version again.** `project(VERSION)` in the top-level `CMakeLists.txt`
+  still said `0.19.0` after 0.20.0 was cut, and since that is the single source of `BMOE_VERSION`,
+  every 0.20.0 build self-reports as 0.19.0 — in `bmoe-cli --version` and in the `engine=` line of
+  every metrics CSV it wrote. Any CSV committed between 2026-08-17 and this release names the wrong
+  engine; nothing else was affected. Reported by @gjjkbssg (#163).
+
 ## [0.20.0] - 2026-08-17
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.21)
 # The version is declared here and nowhere else in the build: the engine reports it (bmoe-cli
 # --version, and the run-parameter preamble of every metrics CSV), so a committed benchmark file
 # says which engine produced it. Keep it in step with CHANGELOG.md and the app's versionName.
-project(bigmoeonedge VERSION 0.19.0 LANGUAGES CXX)
+project(bigmoeonedge VERSION 0.21.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -51,8 +51,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 35
-        versionName '0.20.0'
+        versionCode 36
+        versionName '0.21.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -283,9 +283,15 @@ data class AppSettings(
         // per token and returns an 8-13% hit rate from a 2000-3000 MiB budget, so its cache may
         // already be below the floor's intent while sitting well above its number. These rungs are
         // here to measure where the cache stops earning the memory pressure it creates.
+        //
+        // The rungs are dense below 2000 and coarse above it, because that is where the choice is
+        // sharp: on an 8 GB phone 1000 MiB runs and 2000 MiB gets the app killed by the OS, so a
+        // x2 step there hands the user a cliff instead of a setting. Above 2000 a 1000 MiB step is
+        // a small fraction of the budget and needs no refining.
         // See docs/android-memory.md.
         const val CACHE_AUTO = -1
-        val CACHE_CHOICES = intArrayOf(CACHE_AUTO, 0, 500, 1000, 2000, 3000, 4000, 5000, 6000)
+        val CACHE_CHOICES =
+            intArrayOf(CACHE_AUTO, 0, 500, 1000, 1250, 1500, 1750, 2000, 3000, 4000, 5000, 6000)
 
         /** True for a fixed budget the engine would reject without --force-cache. */
         fun cacheNeedsForce(mb: Int) = mb in 1 until CACHE_MIN_MB


### PR DESCRIPTION
Closes #146. Closes the version half of #163; the exec-bit half is @gjjkbssg's #164.

## The build reports its own version again

`project(VERSION)` in the top-level `CMakeLists.txt` still said `0.19.0` after 0.20.0 was tagged. The comment directly above that line explains why it is the single source of `BMOE_VERSION`: so that a committed benchmark file says which engine produced it. That is exactly what stopped being true. Every 0.20.0 build self-reports as 0.19.0, in `bmoe-cli --version` and in the `engine=` line of every metrics CSV it writes.

Any CSV committed since 2026-08-17 therefore names the wrong engine. Nothing else was affected, but this is the kind of error that quietly poisons a benchmark read months later, so it gets a changelog line rather than a silent fix.

Bumped to `0.21.0`, the version being developed, with the app's `versionCode` and `versionName` moved in step.

## Finer expert-cache rungs below 2000 MiB in the app

The ladder went 500, 1000, 2000, and that x2 is where the choice is sharp: on an 8 GB phone 1000 MiB runs and 2000 MiB gets the app killed by the OS, so the step handed the user a cliff instead of a setting. 1250, 1500 and 1750 fill it. Above 2000 the existing 1000 MiB step is already a small fraction of the budget and is unchanged.

Worth noting where the new rungs fall relative to `CACHE_MIN_MB` (1500): 1250 still takes `--force-cache`, 1500 and 1750 do not. The ladder now has usable rungs on both sides of the engine's floor instead of jumping over it.

## Verification

- 10/10 ctest host gates green
- `bmoe-cli --version` reports `0.21.0`
- No engine code touched. The Kotlin change is one `intArrayOf` behind the existing generic stepper, so it needs no new UI.

## Related, deliberately not in this PR

- **#164** (exec bit on the doc-invoked scripts) is @gjjkbssg's and should land as his commit. He offered in #163 to extend it to all five `scripts/*.sh` rather than only the two the docs invoke directly, which is worth taking up: leaving the set inconsistent only hides the next instance.
- **#165** (warn when the expert cache budget is below one token's worst-case cycle) is his as well. He has it implemented and asked for the shape before opening a PR, so the answer belongs in that issue rather than in a competing commit here.
