### PR TITLE
feat(moe): warn when the expert cache budget sits below one token's cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Semantic Versioning.
 
 ## [0.21.0] - 2026-08-25
 
+### Added
+- **The expert cache says when it cannot hit.** One token's worst-case routed bytes are priced at
+  load from the model's shape alone — every bound layer's expert-entry bytes times
+  `min(top_k, n_expert)`, at the top-k the run actually applies — and the engine prints one stderr
+  line when the resolved budget falls under it. Below that cycle global LRU evicts precisely what
+  it is about to read, so the hit rate is 0 % while the run still pays the management and the RAM.
+  It warns rather than refuses: the budget is legal and the output byte-identical, so the engine
+  states the fact and leaves the choice alone. The number is not the fixed `cache_min_mb` floor,
+  which is what made this invisible: a budget can clear the floor and still sit under *this* model's
+  cycle, and `--n-expert-used` widens the cycle without touching the budget. Validated on device on
+  Gemma 4 26B (cycle 902 MiB: 800 MiB measures a 0.0 % hit against 26.8 % at 950 MiB, decode
+  1.42 → 2.01 tok/s across that gap) and Qwen3.6-35B (cycle 582 MiB: 500 MiB measures 0.0 % against
+  36.0 % at 650 MiB). By @gjjkbssg (#165, #167).
+- **`cache_cycle_mb` in the metrics preamble.** The same number, recorded next to the budget it
+  should be judged against, so a committed CSV says on its own whether its cache could ever have
+  hit — no second run of the same model and top-k to compare with. See
+  [docs/telemetry.md](docs/telemetry.md) and [docs/cache-sizing.md](docs/cache-sizing.md).
+
 ### Changed
 - **Finer expert-cache rungs below 2000 MiB in the app.** The ladder went 500 → 1000 → 2000, and
   that x2 is where the choice is sharp: on an 8 GB phone 1000 MiB runs and 2000 MiB gets the app

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -263,6 +263,12 @@ struct RunInfo {
     bool cache_auto = false;
     int cache_floor_mb = 0; // the RAM auto-sizing was told to leave free — the input behind cache_mb
     int cache_ceil_mb = 0;
+    // One token's WORST-CASE routed bytes, priced at load from the model's shape and the effective
+    // top-k. A cache_mb under this cannot hold a token cycle, so the run's hit rate is near zero by
+    // construction — and that is invisible in a committed CSV unless the cycle is recorded next to
+    // the budget, because the cliff is a property of the MODEL, not of the number that was typed.
+    // 0 when streaming is off.
+    int cache_cycle_mb = 0;
     bool force_cache = false;
     bool load_all = false; // whole-expert-set baseline: reads everything, so its bytes mean something else
     int io_threads = 0;

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -803,6 +803,11 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                 if (ri.n_expert_used <= 0) ri.n_expert_used = mi.n_expert_used;
             }
         }
+        // Last, because it needs both numbers above: the budget the streamer settled on and the
+        // width that was actually applied. Rounded UP — a cycle reported as smaller than it is
+        // would put a budget on the wrong side of the cliff in exactly the borderline case.
+        ri.cache_cycle_mb =
+            (int) ((im.source.worst_cycle_bytes(ri.n_expert_used) + 1024ull * 1024ull - 1) / (1024ull * 1024ull));
     }
 
     // The effective routing width, resolved once: an override IS the applied width, otherwise the
@@ -829,6 +834,23 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                          "routing here, against 12.5%% at the top-k 8 this was measured on. Expect it to discard "
                          "much more, and check output quality on your own task.\n",
                          (double) cfg.moe.drop_cold_frac, k, 100.0 * cfg.moe.drop_cold_frac / k);
+    }
+
+    // A cache budget below one token's worst-case cycle: say so once, at load.
+    //
+    // The number is computable from the model's shape alone, so this costs nothing and is available
+    // at the only moment it can still be acted on. It is a warning, not a rejection: the budget is
+    // legal, the run is byte-correct, and cache_min_mb already rejects the band it was drawn for.
+    // What this catches is the case that number cannot see — a budget comfortably above the fixed
+    // floor and still under THIS model's cycle, which --n-expert-used widens without touching the
+    // budget. Below the cycle no entry survives to the next token, so the run pays management and
+    // RAM for a cache that cannot hit. The engine states the fact; what to do about it is
+    // docs/cache-sizing.md's business, not a knob the engine should editorialize about.
+    if (im.info.cache_mb > 0 && im.info.cache_cycle_mb > 0 && im.info.cache_mb < im.info.cache_cycle_mb) {
+        std::fprintf(stderr,
+                     "bmoe: WARNING expert cache %d MiB is below this model's worst-case token cycle of %d MiB "
+                     "at top-k %d — no entry can survive to the next token, so expect a hit rate near zero.\n",
+                     im.info.cache_mb, im.info.cache_cycle_mb, im.info.n_expert_used);
     }
 
     im.load_seconds = secs(t_load0, clock_t_::now());

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -36,13 +36,14 @@ public:
                      r.n_ubatch, r.chatml);
         std::fprintf(f_,
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_floor_mb=%d cache_ceil_mb=%d "
-                     "force_cache=%d load_all=%d io_threads=%d o_direct=%d overlap=%d io_two_wave=%d prefetch=%d "
+                     "cache_cycle_mb=%d force_cache=%d load_all=%d io_threads=%d o_direct=%d "
+                     "overlap=%d io_two_wave=%d prefetch=%d "
                      "route_ahead=%d predict_prefetch=%d predict_log=%d predict_spec_max=%d prefetch_sync=%d "
                      "dense_weights=%s drop_cold_frac=%.4g drop_renorm=%d drop_prefill=%d\n",
-                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_floor_mb, r.cache_ceil_mb, r.force_cache,
-                     r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave, r.prefetch_layers, r.route_ahead,
-                     r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync, r.dense_weights.c_str(),
-                     (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
+                     r.moe_stream, r.cache_mb, r.cache_auto, r.cache_floor_mb, r.cache_ceil_mb, r.cache_cycle_mb,
+                     r.force_cache, r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave, r.prefetch_layers,
+                     r.route_ahead, r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync,
+                     r.dense_weights.c_str(), (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
         std::fprintf(f_,
                      "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d spec=%s "
                      "spec_draft_max=%d mtp_p_min=%.4g ngram_min_match=%d\n",

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -672,6 +672,17 @@ void ExpertStreamSource::set_cache_budget(size_t bytes) {
         evict_tail();
 }
 
+size_t ExpertStreamSource::worst_cycle_bytes(int top_k) const {
+    // entry_bytes prices a layer's experts uniformly (one entry = every projection of one expert
+    // of that layer), so the worst token demands top_k entries from every bound layer. Clamped
+    // at n_expert_: a top_k wider than the bank asks for entries that do not exist.
+    if (top_k <= 0) return 0;
+    size_t cycle = 0;
+    for (int il = 0; il < (int) layers_.size(); ++il)
+        if (layers_[il].bound) cycle += entry_bytes(il) * (size_t) std::min(top_k, n_expert_);
+    return cycle;
+}
+
 // ── LRU plumbing ────────────────────────────────────────────────────────────────────
 void ExpertStreamSource::lru_unlink(int32_t id) {
     int32_t pv = cprev_[id], nx = cnext_[id];

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -99,6 +99,14 @@ public:
     // and exercised by the shrink gate. This is the only thing that moves the budget after init.
     void set_cache_budget(size_t bytes);
 
+    // The cliff from cache-sizing.md, computed at init from model shape alone: the bytes one
+    // token's pass over the layer stack demands in the worst case, i.e. every bound layer's top_k
+    // most expensive experts. A global-LRU budget below this thrashes to exactly 0% hits — it
+    // reads as much as no cache while still paying management and RAM — so the runtime warns
+    // when it sees one. Worst case, not the measured demand: the router picks at runtime, and
+    // the measured token_demand_ needs a decode before it exists.
+    size_t worst_cycle_bytes(int top_k) const;
+
     // ── I/O trace (diagnostics; see bmoe/decode_trace.h) ────────────────────────────
     // When on, every read_slice records one row. Rows are appended under a dedicated leaf mutex
     // (reads happen on N lanes at once), so this costs a lock per read and is off by default.

--- a/docs/cache-sizing.md
+++ b/docs/cache-sizing.md
@@ -39,7 +39,22 @@ strictly better than a cache: same reads, none of the RAM, none of the managemen
 Fixing this by changing the eviction policy was tried and rejected — a per-layer partition is
 immune to the cliff by construction but costs ~30 % throughput
 ([bench-data/2026-07-20-cache-replay/layer-lfu-verdict.md](bench-data/2026-07-20-cache-replay/layer-lfu-verdict.md)).
-The cheap fix is a guard: the worst-case cycle is computable at init from model shape alone.
+The cheap fix was a guard, and it is in: the worst-case cycle is priced at init from the model's
+shape alone — every bound layer's expert-entry bytes times `min(top_k, n_expert)`, at the top-k the
+run actually applies. The engine records it in every metrics preamble as `cache_cycle_mb` next to
+the budget it is being compared against, and prints one line to stderr at load when the budget is
+under it:
+
+```
+bmoe: WARNING expert cache 1500 MiB is below this model's worst-case token cycle of 1815 MiB
+at top-k 4 — no entry can survive to the next token, so expect a hit rate near zero.
+```
+
+It states the fact and stops there; the advice above — that `--cache-mb 0` is strictly better below
+the cliff — stays here rather than in the engine's output. Note this is the *worst case* (a disjoint
+routed set at every layer), so it is an upper bound on the measured `token_demand_MiB`, and a budget
+above it is safe for any routing. Recording it matters as much as the warning: a committed CSV whose
+budget sat under the cycle now says so, without needing a run of the same model to compare against.
 
 ## What it does
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,11 +116,13 @@ than merged — a measured regression does not belong in the engine.
 The transferable lesson: a hit-rate curve is not a throughput argument. Any future policy has to
 be measured on device, however good its simulation.
 
-What is still worth doing here is **not** a policy but a guard. Global LRU's recency order is
-anti-correlated with the deterministic layer cycle, so below one token cycle it evicts precisely
-what it is about to read and the hit rate goes to **exactly 0 %** — reproduced on device at a
-budget the CLI accepts today. The worst-case cycle is computable at init from model shape alone,
-so refusing or warning on a budget under it costs almost nothing.
+What was still worth doing here was **not** a policy but a guard, and it has shipped. Global LRU's
+recency order is anti-correlated with the deterministic layer cycle, so below one token cycle it
+evicts precisely what it is about to read and the hit rate goes to **exactly 0 %** — reproduced on
+device at a budget the CLI accepts today. Since the worst-case cycle is computable at init from
+model shape alone, the engine now prices it there, records it as `cache_cycle_mb`, and warns when
+the resolved budget falls under it. It warns rather than refuses: the budget is legal and the run is
+byte-correct, it just cannot hit. See [cache-sizing.md](cache-sizing.md).
 
 ## More architectures
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -217,7 +217,8 @@ prints just the summary lines.
 # model=<file> arch=<arch> n_layer=<n> n_expert=<n> n_expert_used=<k> threads=<n>
   n_ctx=<n> n_ubatch=<n> chatml=<0|1>
 # moe_stream=<0|1> cache_mb=<n> cache_auto=<0|1> cache_floor_mb=<n> cache_ceil_mb=<n>
-  force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1> overlap=<0|1> io_two_wave=<0|1> prefetch=<n>
+  cache_cycle_mb=<n> force_cache=<0|1> load_all=<0|1> io_threads=<n> o_direct=<0|1>
+  overlap=<0|1> io_two_wave=<0|1> prefetch=<n>
   route_ahead=<n> predict_prefetch=<0|1> predict_log=<0|1> predict_spec_max=<n> prefetch_sync=<0|1>
   dense_weights=<mmap|warm|anon|ahwb> drop_cold_frac=<f> drop_renorm=<0|1> drop_prefill=<0|1>
 # temp=<f> top_k=<n> top_p=<f> seed=<u> compute_trace_layers=<n> spec=<off|mtp|ngram>
@@ -240,6 +241,11 @@ effective top-k after any override. Fields to read carefully:
   reader finds a run's name.
 - `n_ubatch` sets the compute-buffer reservation, so it moves the very memory columns below;
   `0` means it follows `n_batch`.
+- `cache_cycle_mb` is one token's **worst-case** routed bytes for this model at this `n_expert_used`,
+  priced at load from tensor shapes. It is here so a budget can be judged without a second run: a
+  `cache_mb` under it cannot hold a token cycle, so the hit rate is near zero however legal the
+  number looks against `cache_min_mb`. The engine warns once at load when that is the case. See
+  [cache-sizing.md](cache-sizing.md).
 - `predict_log=1`, `prefetch_sync=1` or `compute_trace_layers>0` mean **the run was instrumented**.
   A probed or traced run is not a benchmark run — see the warning under [Decode
   traces](#decode-traces).


### PR DESCRIPTION
Closes #165. Related: #166 (which deliberately left this out so the guard lands as its own change).

Below one token's worst-case routed bytes, global LRU evicts precisely what it is about to read: the hit rate is 0% while the run still pays the cache's management time and its RAM. The only protection so far was `cache_min_mb`, a fixed floor that happens to sit above the cycle for the shipped models at their default top-k — and stops holding the moment `--n-expert-used` widens the routing without touching the budget.

**What this adds**

- `ExpertStreamSource::worst_cycle_bytes(top_k)` — the cycle priced at init from the model's shape alone: every bound layer's `entry_bytes` × `min(top_k, n_expert)`, at the top-k the run actually applies. Worst case, not the measured `token_demand_` (which needs a decode to exist).
- One stderr line at load when the resolved budget falls under it. It warns rather than refuses — the budget is legal and the output byte-identical — and states the fact without advice: the argument that `--cache-mb 0` is strictly better below the cliff stays in `docs/cache-sizing.md`, per your note on the original #166 draft.
- `cache_cycle_mb` in the metrics preamble, next to the budget it should be judged against (rounded up, from the resolved budget and the effective top-k) — so a committed CSV answers on its own whether its cache could ever have hit, without a second run of the same model and top-k. Documented in `docs/telemetry.md`.
- `docs/cache-sizing.md` and `docs/roadmap.md` updated in the same commit (the guard moves from "still worth doing" to shipped); CHANGELOG deliberately untouched since 0.21.0 is already cut — happy to fold the entry into your next dated section wherever you want it.

**Verification** (macOS arm64 host build)

The five cells from #165 reproduce identically:

| cell | result |
|---|---|
| `--cache-mb 1 --force-cache` | warns, cycle 2 MiB at top-k 2 |
| `--cache-mb 2 --force-cache` (== cycle) | silent |
| `--cache-mb 4 --force-cache` | silent |
| `--cache-mb 0` | silent |
| `--cache-mb 2 --force-cache --n-expert-used 4` | warns, cycle 3 MiB at top-k 4 — the k-override widens the cycle, exactly the trap cache-sizing.md describes |

The k=4 cycle is 3 MiB and not 4 because `entry_bytes` is per-layer from the real tensor shapes — the guard prices from the model, never from a constant. The preamble writes `... cache_ceil_mb=0 cache_cycle_mb=2 ...` next to the budget; 10/10 ctest host gates green.

Not yet validated on device — no engine hot path is touched (init-time arithmetic plus one `fprintf`), but a phone run before the next tag would close that. Also: formatted with clang-format 21 locally; if CI's pinned 18 disagrees anywhere I will follow up immediately.
