### PR TITLE
fix(app): name cache_cycle_mb in the metrics view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Semantic Versioning.
   36.0 % at 650 MiB). By @gjjkbssg (#165, #167).
 - **`cache_cycle_mb` in the metrics preamble.** The same number, recorded next to the budget it
   should be judged against, so a committed CSV says on its own whether its cache could ever have
-  hit — no second run of the same model and top-k to compare with. See
+  hit — no second run of the same model and top-k to compare with. Named and explained in the app's
+  metrics view like every other cache field, rather than falling through as a raw key. See
   [docs/telemetry.md](docs/telemetry.md) and [docs/cache-sizing.md](docs/cache-sizing.md).
 
 ### Changed

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricFields.kt
@@ -87,6 +87,7 @@ object ConfigFields {
         ConfigField("cache_auto", "the budget was sized from free RAM once at load, then held for the run"),
         ConfigField("cache_floor_mb", "RAM auto-sizing leaves free for the rest of the system. Applies only with cache_auto"),
         ConfigField("cache_ceil_mb", "upper bound on the auto budget; 0 caps only at the full expert-set size"),
+        ConfigField("cache_cycle_mb", "one token's worst-case routed bytes for this model at the applied top-k, priced at load. A cache_mb under it cannot hold a token cycle, so the hit rate is near zero however legal the budget looks against the engine's floor"),
         ConfigField("force_cache", "a budget below the engine's floor was permitted. Such a cache thrashes by design and is slower than no cache — reserved for probing where the floor lies"),
         ConfigField("io_threads", "parallel flash read lanes, including the calling thread. 1 is the serial baseline"),
         ConfigField("o_direct", "expert reads bypassed the page cache"),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/MetricsScreen.kt
@@ -403,6 +403,7 @@ private val CONFIG_ORDER = listOf(
     "cache_auto" to "Cache auto-size",
     "cache_floor_mb" to "Cache floor (MiB)",
     "cache_ceil_mb" to "Cache ceiling (MiB)",
+    "cache_cycle_mb" to "Token cycle (MiB)",
     "force_cache" to "Force cache",
     "io_threads" to "I/O lanes",
     "o_direct" to "Direct I/O",


### PR DESCRIPTION
Completes #167, which added `cache_cycle_mb` to the metrics preamble without teaching the app the key.

`MetricsScreen` renders unknown config keys through a fallback: raw key as the label, sorted, appended after the known ones. So the number this release is about showed up as `cache_cycle_mb` at the bottom of the list, detached from the cache block, while every sibling (`cache_mb`, `cache_floor_mb`, `cache_ceil_mb`) reads as prose with an explanation behind it.

Two rows, in the two places every other config field is declared:

- `MetricsScreen.CONFIG_ORDER`: `"cache_cycle_mb" to "Token cycle (MiB)"`, right after `cache_ceil_mb`, so it lands with the rest of the cache group instead of after it.
- `MetricFields`: the description, in the same terms the docs use.

Also makes the existing CHANGELOG line true. It said the number was recorded; it is now also readable where people look at it.

No engine change, no behaviour change. The app builds and the field renders in the cache block.
