### PR TITLE
feat(moe): minor-fault telemetry, and a slot bank the device measured as negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- **The expert cache's page cost is now measurable, and optionally removable.** Two changes that
+  belong together.
+
+  `minflt` / `minflt_mib` join the per-token CSV and the run summary. Minor faults were the one
+  large cost in the streaming path that no metric could see. Evicting an entry releases its pages,
+  so the next miss reads into an address the kernel must hand back and zero before the read lands,
+  and none of that is billed to `mgmt_ms`: on POSIX `vm_commit` is a no-op, so the page arrives
+  later, inside the reader, and surfaces as I/O or compute. Read against `read_bytes`, the ratio is
+  the finding. On Qwen3.6-35B at a 2000 MiB budget it is 1.00, meaning every streamed byte lands in
+  a page zeroed for it first. Measured on the Windows host too, where the cache decommits and
+  recommits explicitly.
+
+  `--cache-slot-bank N` is the lever that answers it. Each layer gets N slots whose pages are
+  claimed once at load and never released, so eviction is a reassignment and a miss overwrites
+  bytes already ours. It works by rewriting the router's selected-expert ids to slot indices, which
+  is legal because `mul_mat_id` addresses `src0` as `data + id*nb2` and never asks what the id
+  means. The rewrite happens at the single node where no other consumer is left to mislead: the
+  terminal of the layer's weight chain, after the routing weights have been gathered and before the
+  first expert matmul. Decode only, since one `mul_mat_id` serves a whole batch. N is capped at the
+  model's expert count. Architectures whose experts carry a per-expert bias or scale read the same
+  ids after the matmul, so the engine detects them from the graph's node names and disarms itself.
+  Off by default, and off in the app.
+
+  Host result on Qwen3.6-35B, three A/B pairs: 2.805 to 3.035 tok/s (+8.2 %), minor faults 61 323
+  to 0 per token, `mgmt_ms` 31.1 to 0.9 ms, generated text byte-identical. The attribution is not
+  the one the mechanism suggests, and is documented as such: ms per MiB read did not move, so the
+  zeroing was already hidden behind that machine's SSD wait. What paid was the eviction syscalls
+  disappearing, plus a hit-rate rise (54.9 to 57.5 %) that falls out of the bank's per-layer LRU
+  giving every layer a floor. A phone inverts both halves of that balance, which is why nothing is
+  turned on until it has been measured there. See `docs/cache-sizing.md` and `docs/telemetry.md`.
+
 ## [0.21.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,24 +19,31 @@ Semantic Versioning.
   a page zeroed for it first. Measured on the Windows host too, where the cache decommits and
   recommits explicitly.
 
-  `--cache-slot-bank N` is the lever that answers it. Each layer gets N slots whose pages are
-  claimed once at load and never released, so eviction is a reassignment and a miss overwrites
-  bytes already ours. It works by rewriting the router's selected-expert ids to slot indices, which
-  is legal because `mul_mat_id` addresses `src0` as `data + id*nb2` and never asks what the id
-  means. The rewrite happens at the single node where no other consumer is left to mislead: the
-  terminal of the layer's weight chain, after the routing weights have been gathered and before the
-  first expert matmul. Decode only, since one `mul_mat_id` serves a whole batch. N is capped at the
-  model's expert count. Architectures whose experts carry a per-expert bias or scale read the same
-  ids after the matmul, so the engine detects them from the graph's node names and disarms itself.
-  Off by default, and off in the app.
+  `--cache-slot-bank` is the lever that answers it, and it ships **off, as a measured negative on
+  Android**. Each layer gets a set of slots whose pages are claimed once at load and never
+  released, so eviction is a reassignment and a miss overwrites bytes already ours. It works by
+  rewriting the router's selected-expert ids to slot indices, which is legal because `mul_mat_id`
+  addresses `src0` as `data + id*nb2` and never asks what the id means. The rewrite happens at the
+  single node where no other consumer is left to mislead: the terminal of the layer's weight chain,
+  after the routing weights have been gathered and before the first expert matmul. Decode only,
+  since one `mul_mat_id` serves a whole batch. How many slots is derived from the budget, not asked
+  of the caller. Architectures whose experts carry a per-expert bias or scale read the same ids
+  after the matmul, so the engine detects them from the graph's node names and disarms itself.
 
-  Host result on Qwen3.6-35B, three A/B pairs: 2.805 to 3.035 tok/s (+8.2 %), minor faults 61 323
-  to 0 per token, `mgmt_ms` 31.1 to 0.9 ms, generated text byte-identical. The attribution is not
-  the one the mechanism suggests, and is documented as such: ms per MiB read did not move, so the
-  zeroing was already hidden behind that machine's SSD wait. What paid was the eviction syscalls
-  disappearing, plus a hit-rate rise (54.9 to 57.5 %) that falls out of the bank's per-layer LRU
-  giving every layer a floor. A phone inverts both halves of that balance, which is why nothing is
-  turned on until it has been measured there. See `docs/cache-sizing.md` and `docs/telemetry.md`.
+  The mechanism works, on both platforms: minor faults per 4 KiB of streamed data go from 1.04 to
+  0.04 on device, and `mgmt_ms` from 6.4 to 0.9. It does not pay, for a reason specific to Android
+  and worth recording. The bank is permanently dirty anonymous memory, and at any moment most of
+  its slots are untouched, which is exactly the profile `swappiness 160` compresses into zram. So
+  **major** faults went from 4-116 per token to 1 676-5 484, and swap from ~100 MiB to 155-393 MiB,
+  with throughput tracking the swap (8.06 tok/s at 155 MiB, 4.35 at 393). The decommit the bank
+  removes was not waste: it is how the cache tells the kernel it genuinely does not need those
+  pages, which is what keeps it out of reclaim. Net on Qwen3.6-35B: +2.2 % on a good run, with a
+  tail that loses 44 %. Generated text stays byte-identical throughout.
+
+  Kept because the telemetry above is only half readable without something to compare against, and
+  because the ids-to-slots seam is now demonstrated rather than assumed. See `docs/cache-sizing.md`
+  for the numbers and the two design faults still in it (uniform slots per layer cost 3.4 points of
+  hit rate; the disarm check is broader than the danger it guards).
 
 ## [0.21.0] - 2026-08-25
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -432,11 +432,11 @@ static void print_usage(const char * argv0) {
         "                          `--dense-weights anon`, --no-warm-dense means `--dense-weights mmap`\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
-        "      --cache-slot-bank N EXPERIMENT: decode-only slot-bank cache, N slots per layer\n"
-        "                          (0=off). The bank's pages are committed once and overwritten\n"
-        "                          instead of released, so a miss stops re-faulting a page the\n"
-        "                          kernel had to zero first. Rewrites the router ids to slot\n"
-        "                          indices; N must be <= n_expert. Prefill is unaffected.\n"
+        "      --cache-slot-bank   EXPERIMENT: decode-only slot-bank cache. Claims its pages once\n"
+        "                          and overwrites slots instead of releasing them, so evicting\n"
+        "                          costs no syscall and a miss stops re-faulting a page the kernel\n"
+        "                          had to zero first. Sized from the budget: prefill keeps one\n"
+        "                          token cycle of LRU, the rest becomes slots. Decode only.\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
         "      --io-two-wave       publish a layer's first-projection reads before committing the\n"
         "                          rest, so the lanes start sooner (needs --overlap and the cache;\n"
@@ -623,7 +623,7 @@ int main(int argc, char ** argv) {
             else
                 cfg.moe.cache_mb = std::atoi(v.c_str());
         } else if (a == "--cache-slot-bank")
-            cfg.moe.cache_slot_bank = std::atoi(next("--cache-slot-bank"));
+            cfg.moe.cache_slot_bank = true;
         else if (a == "--cache-floor-mb")
             cfg.moe.cache_floor_mb = std::atoi(next("--cache-floor-mb"));
         else if (a == "--cache-ceil-mb")

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -432,6 +432,11 @@ static void print_usage(const char * argv0) {
         "                          `--dense-weights anon`, --no-warm-dense means `--dense-weights mmap`\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
+        "      --cache-slot-bank N EXPERIMENT: decode-only slot-bank cache, N slots per layer\n"
+        "                          (0=off). The bank's pages are committed once and overwritten\n"
+        "                          instead of released, so a miss stops re-faulting a page the\n"
+        "                          kernel had to zero first. Rewrites the router ids to slot\n"
+        "                          indices; N must be <= n_expert. Prefill is unaffected.\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
         "      --io-two-wave       publish a layer's first-projection reads before committing the\n"
         "                          rest, so the lanes start sooner (needs --overlap and the cache;\n"
@@ -617,7 +622,9 @@ int main(int argc, char ** argv) {
                 cfg.moe.cache_auto = true;
             else
                 cfg.moe.cache_mb = std::atoi(v.c_str());
-        } else if (a == "--cache-floor-mb")
+        } else if (a == "--cache-slot-bank")
+            cfg.moe.cache_slot_bank = std::atoi(next("--cache-slot-bank"));
+        else if (a == "--cache-floor-mb")
             cfg.moe.cache_floor_mb = std::atoi(next("--cache-floor-mb"));
         else if (a == "--cache-ceil-mb")
             cfg.moe.cache_ceil_mb = std::atoi(next("--cache-ceil-mb"));

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -57,6 +57,30 @@ struct MoeStreamConfig {
                                // expert-set size); useful to keep the cache from taking all the
                                // headroom when the marginal hit-rate gain no longer justifies the RAM
 
+    // EXPERIMENT — decode-only slot-bank cache, N slots per layer (0 = off, the shipping path).
+    //
+    // What it removes: with the normal cache, an expert lives at its canonical offset e*nb2 and
+    // eviction physically releases those pages, so the next miss reads into an address the kernel
+    // must first hand back and ZERO. Measured on the host at cache_mb=2000: 63128 minor faults and
+    // 246.6 MiB of kernel zeroing per token, against 246.8 MiB actually read — a ratio of 1.00, i.e.
+    // every streamed byte lands in a freshly zeroed page. None of it is billed to mgmt_ms, because
+    // vm_commit is a no-op on POSIX and the page arrives later, inside the reader.
+    //
+    // How it removes it: the bank's pages are committed once and never released; a miss overwrites
+    // the slot it is given. That needs the expert's ADDRESS to be free to change, which means
+    // rewriting the router's ids from expert index to slot index before mul_mat_id reads them —
+    // legal because the kernel addresses src0 as `data + id*nb2` and never checks the id's identity.
+    //
+    // Why decode only: every token of a batch goes through ONE mul_mat_id, so at prefill the whole
+    // batch's expert set would have to be resident at once. Prefill therefore keeps the canonical
+    // buffers and the normal cache untouched; the bank is used when n_tokens == 1. The two hold
+    // separate residency, so the bank starts cold on the first generated token.
+    //
+    // Hard ceiling: a slot index is fed to mul_mat_id in place of an expert index, and the kernel
+    // sizes its per-expert scratch by ne02, so N must stay <= n_expert. Archs whose experts carry a
+    // per-expert bias or scale (those read the ids AFTER the matmul) are rejected at init.
+    int cache_slot_bank = 0;
+
     // Parallel expert-slice read lanes (incl. the calling thread). 1 = serial baseline.
     // Clamped to [1, io_threads_max]. 4 is the measured sweet spot on UFS4 phones.
     int io_threads = 4;

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -57,7 +57,7 @@ struct MoeStreamConfig {
                                // expert-set size); useful to keep the cache from taking all the
                                // headroom when the marginal hit-rate gain no longer justifies the RAM
 
-    // EXPERIMENT — decode-only slot-bank cache, N slots per layer (0 = off, the shipping path).
+    // EXPERIMENT — decode-only slot-bank cache (off = the shipping path).
     //
     // What it removes: with the normal cache, an expert lives at its canonical offset e*nb2 and
     // eviction physically releases those pages, so the next miss reads into an address the kernel
@@ -76,10 +76,25 @@ struct MoeStreamConfig {
     // buffers and the normal cache untouched; the bank is used when n_tokens == 1. The two hold
     // separate residency, so the bank starts cold on the first generated token.
     //
-    // Hard ceiling: a slot index is fed to mul_mat_id in place of an expert index, and the kernel
-    // sizes its per-expert scratch by ne02, so N must stay <= n_expert. Archs whose experts carry a
-    // per-expert bias or scale (those read the ids AFTER the matmul) are rejected at init.
-    int cache_slot_bank = 0;
+    // MEASURED NEGATIVE ON ANDROID — kept for the seam it demonstrates, not as a lever. The bank is
+    // permanently dirty anonymous memory whose slots are mostly untouched at any instant, which is
+    // what swappiness 160 compresses into zram: major faults per token went from 4-116 to
+    // 1676-5484 and swap from ~100 to 155-393 MiB, with throughput tracking the swap. The decommit
+    // this removes turns out to be the cache's way of telling the kernel it truly does not need
+    // those pages, which is what kept it out of reclaim. See docs/cache-sizing.md.
+    //
+    // How many slots per layer is not a question for the caller: the engine knows the budget, the
+    // per-expert bytes and the routing width, which is everything the answer depends on. It gives
+    // the LRU one worst-case token cycle (the floor below which a cache measurably cannot hit at
+    // all, see docs/cache-sizing.md) and turns the rest into slots, so the bank comes OUT of
+    // cache_mb rather than sitting on top of it. A budget that cannot cover the cycle plus one slot
+    // per layer leaves the bank off, and says so.
+    //
+    // Hard ceiling on the derived count: a slot index is fed to mul_mat_id in place of an expert
+    // index, and the kernel sizes its per-expert scratch by ne02, so it stays <= n_expert. Archs
+    // whose experts carry a per-expert bias or scale (they read the ids AFTER the matmul) disarm
+    // the bank at run time, detected from the graph's own node names.
+    bool cache_slot_bank = false;
 
     // Parallel expert-slice read lanes (incl. the calling thread). 1 = serial baseline.
     // Clamped to [1, io_threads_max]. 4 is the measured sweet spot on UFS4 phones.

--- a/core/include/bmoe/expert_source.h
+++ b/core/include/bmoe/expert_source.h
@@ -64,6 +64,26 @@ public:
     // Flash bytes one expert of layer `il` occupies across its projections — what a miss costs.
     virtual uint64_t expert_bytes(int /*il*/) const { return 0; }
 
+    // ── decode-only slot bank (optional; see MoeStreamConfig::cache_slot_bank) ──
+    // A source may keep expert bytes somewhere other than the expert's canonical offset, so that
+    // eviction can overwrite a slot instead of releasing pages the kernel would have to re-zero.
+    // That only works if the caller rewrites the router's ids to slot indices and repoints the
+    // weight tensor at the bank, which is why the seam is here and not private to the source: the
+    // hook owns the ids, the source owns the bytes, and neither can do it alone.
+    //
+    // Default: no bank. slot_bank_on() false means every other method here is never consulted.
+    virtual bool slot_bank_on() const { return false; }
+
+    // Tell the source whether the graph now being evaluated is a single-token decode. Only then may
+    // it target the bank; a multi-token batch would need its whole expert set resident at once.
+    // Called once per graph, before the first load_layer of that graph.
+    virtual void set_decode_graph(bool /*single_token*/) {}
+
+    // Slot holding expert `e` of layer `il`, valid only after load_layer(il, ...) has returned and
+    // only while slot_bank_on() and the current graph is a decode. -1 if the expert is not banked,
+    // which the caller must treat as "do not rewrite this id".
+    virtual int slot_of_expert(int /*il*/, int /*e*/) const { return -1; }
+
     // Cumulative streaming statistics, for telemetry and the end-of-run summary.
     struct Stats {
         uint64_t read_bytes = 0;           // bytes pulled from flash (aligned windows)

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -45,6 +45,14 @@ struct TokenMetrics {
     // from flash inside the decode; cpu_ms vs wall_ms×threads = how CPU-bound the decode really was
     // (low occupancy ⇒ throttled/preempted, not heavy math). See docs/telemetry.md.
     uint64_t majflt = 0; // major page faults during this decode (backing-store reads)
+    // Minor faults: served without backing store, and on a streaming run these are overwhelmingly
+    // the expert cache paying for its own eviction. Evict decommits the entry, the next miss reads
+    // into that same address, and the kernel must hand back a page and zero it before the read can
+    // land — zeroing the reader then overwrites whole. `mgmt_ms` cannot see this: on POSIX vm_commit
+    // is a no-op, so the page arrives on first touch inside the reader and bills io/stall/compute
+    // instead. Read minflt_mib against read_bytes: if they track, every streamed byte is landing in
+    // a freshly zeroed page and the zeroing is pure waste. See docs/telemetry.md.
+    uint64_t minflt = 0; // minor page faults during this decode (no backing-store read)
     double cpu_ms = 0.0; // CPU time summed across all threads during this decode
     // Fraction of the DENSE (non-expert) weights the kernel still had in RAM at the last sample, or -1
     // when unmeasured (throttled, streaming off, or the platform can't report). Under the anon policy
@@ -57,6 +65,10 @@ struct TokenMetrics {
     // token is immediately comparable to `read_bytes` — the reads we chose against the reads the
     // kernel forced on us. 0 when faults are unmeasured.
     double majflt_mib = 0.0;
+    // The same conversion for minor faults, and the one that makes the comparison legible: this is
+    // the memory the kernel zeroed for us this token. Next to `read_bytes` it answers whether the
+    // cache is re-paying for every byte it streams.
+    double minflt_mib = 0.0;
 
     // ── where memory is, per token (0 when the platform cannot report) ──
     // The split is the point: the expert cache is anonymous, the model's weights are file-backed,
@@ -127,6 +139,9 @@ struct RunSummary {
     // stall hiding in "compute"; cpu_util = cpu_s/token ÷ (s/token × threads) near 1 is compute-bound,
     // well below 1 is a throttled/preempted core. 0 when the platform can't measure them.
     double majflt_per_token = 0.0;
+    // Minor faults per token. On a streaming run, compare against moe_read_mib × 1 MiB ÷ page size:
+    // a ratio near 1 means the expert cache refaults essentially everything it reads.
+    double minflt_per_token = 0.0;
     double cpu_s_per_token = 0.0;
     // Everything between the decodes, per token: the region gen_seconds (and so tok/s) excludes.
     // Includes the tail after the last token, which no row can carry. Read next to s_per_token: the

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -278,6 +278,12 @@ struct RunInfo {
     bool cache_auto = false;
     int cache_floor_mb = 0; // the RAM auto-sizing was told to leave free — the input behind cache_mb
     int cache_ceil_mb = 0;
+    // Slots per layer the decode-only bank was given, or 0 when it is off (including when it asked
+    // to be on and the engine refused: the budget was too small, or the graph reads the routing ids
+    // after the matmul). Recording the RESOLVED count rather than the request is the point — the
+    // flag is a switch and the number is derived, so the request says nothing a reader can compare.
+    // Two CSVs that differ only in this column are the A/B; without it they are indistinguishable.
+    int cache_slot_bank = 0;
     // One token's WORST-CASE routed bytes, priced at load from the model's shape and the effective
     // top-k. A cache_mb under this cannot hold a token cycle, so the run's hit rate is near zero by
     // construction — and that is invisible in a committed CSV unless the cycle is recorded next to

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -114,6 +114,7 @@ struct GenTally {
     double prev_drain_s = 0.0;
     double prev_adopt_s = 0.0;
     uint64_t majflt = 0;
+    uint64_t minflt = 0;
     double cpu_seconds = 0.0;
 
     // Fill in everything a generated token is measured by — its wall/fault/CPU decomposition, the
@@ -121,18 +122,27 @@ struct GenTally {
     // above — then advance those cursors and the run totals. The token's TEXT stays with the
     // caller: what a token says depends on chat state, what it cost does not.
     //
-    // `wall` is the decode's wall time in seconds and `faults`/`cpu_s` the deltas measured around
-    // that same decode; `st` is the expert source's stats, or null when streaming is off.
-    void
-    record(TokenMetrics & m, double wall, uint64_t faults, double cpu_s, int turn, const IExpertSource::Stats * st) {
+    // `wall` is the decode's wall time in seconds and `faults`/`soft_faults`/`cpu_s` the deltas
+    // measured around that same decode; `st` is the expert source's stats, or null when streaming
+    // is off.
+    void record(TokenMetrics & m,
+                double wall,
+                uint64_t faults,
+                uint64_t soft_faults,
+                double cpu_s,
+                int turn,
+                const IExpertSource::Stats * st) {
         m.wall_ms = wall * 1000.0;
         // Fault/CPU decomposition is independent of streaming — dense-weight faults show up in the
         // mmap baseline too — so record it for every token before the moe/no-moe split below.
         m.majflt = faults;
+        m.minflt = soft_faults;
         m.cpu_ms = cpu_s * 1000.0;
         m.majflt_mib = (double) m.majflt * (double) pio::fault_bytes() / (1024.0 * 1024.0);
+        m.minflt_mib = (double) m.minflt * (double) pio::fault_bytes() / (1024.0 * 1024.0);
         m.turn = turn;
         majflt += m.majflt;
+        minflt += m.minflt;
         cpu_seconds += cpu_s;
 
         // Read the memory picture AFTER the decode, outside the caller's timing bracket: two /proc
@@ -1271,6 +1281,7 @@ RunResult Session::generate(const GenerateRequest & req,
         // Bracket ONLY the decode: major faults and CPU-time deltas here decompose this token's
         // compute residual into flash-fault stalls vs. genuine (or throttled) computation.
         const uint64_t f0 = pio::major_faults();
+        const uint64_t sf0 = pio::minor_faults();
         const double c0 = pio::process_cpu_seconds();
         auto s0 = clock_t_::now();
         const double overhead = secs(loop_mark, s0); // everything since the previous decode returned
@@ -1280,6 +1291,7 @@ RunResult Session::generate(const GenerateRequest & req,
         auto s1 = clock_t_::now();
         loop_mark = s1; // the next token's overhead is measured from here
         const uint64_t f1 = pio::major_faults();
+        const uint64_t sf1 = pio::minor_faults();
         const double c1 = pio::process_cpu_seconds();
         if (dec != 0) {
             if (im.cancel_requested.load(std::memory_order_relaxed)) {
@@ -1402,9 +1414,9 @@ RunResult Session::generate(const GenerateRequest & req,
                 m.reasoning = std::move(sv.reasoning);
             }
             if (e == 0)
-                tally.record(m, wall, f1 - f0, c1 - c0, im.turn, moe.enabled ? &st : nullptr);
+                tally.record(m, wall, f1 - f0, sf1 - sf0, c1 - c0, im.turn, moe.enabled ? &st : nullptr);
             else
-                tally.record(m, 0.0, 0, 0.0, im.turn, moe.enabled ? &st : nullptr);
+                tally.record(m, 0.0, 0, 0, 0.0, im.turn, moe.enabled ? &st : nullptr);
             if (on_token) on_token(m);
             if (sink) sink->on_token(m);
         }
@@ -1454,6 +1466,7 @@ RunResult Session::generate(const GenerateRequest & req,
     s.load_seconds = im.load_seconds;
     s.prefill_seconds = prefill_seconds;
     s.majflt_per_token = n_gen ? (double) tally.majflt / n_gen : 0.0;
+    s.minflt_per_token = n_gen ? (double) tally.minflt / n_gen : 0.0;
     s.cpu_s_per_token = n_gen ? tally.cpu_seconds / n_gen : 0.0;
     if (moe.enabled) {
         IExpertSource::Stats st = im.source.stats();

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -685,7 +685,11 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
             im.source.set_dense_tensors(std::move(dense));
         }
 
-        if (!im.source.init(offs.shard_paths, n_expert, std::move(layers), cfg.moe))
+        // The effective top-k: an override IS the applied width, otherwise the model's own. The
+        // slot bank needs it to price a token cycle while sizing itself; 0 (not MoE metadata)
+        // simply leaves the bank off.
+        const int top_k = cfg.n_expert_used > 0 ? cfg.n_expert_used : (gguf().ok ? gguf().n_expert_used : 0);
+        if (!im.source.init(offs.shard_paths, n_expert, top_k, std::move(layers), cfg.moe))
             return fail("expert stream source init failed");
         im.hook->set_source(&im.source);
 
@@ -818,6 +822,10 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // would put a budget on the wrong side of the cliff in exactly the borderline case.
         ri.cache_cycle_mb =
             (int) ((im.source.worst_cycle_bytes(ri.n_expert_used) + 1024ull * 1024ull - 1) / (1024ull * 1024ull));
+        // The RESOLVED slot count, not the request: the flag is a switch, the engine derives the
+        // number, and it can refuse outright. A CSV that recorded the request would have said
+        // "bank on" for runs where the bank never armed.
+        ri.cache_slot_bank = im.source.slot_bank_slots();
     }
 
     // The effective routing width, resolved once: an override IS the applied width, otherwise the

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -5,6 +5,7 @@
 // ::abs is not visible (GCC hard-errors; MSVC happened to tolerate it).
 #if defined(_WIN32)
 #include <windows.h>
+#include <psapi.h> // PROCESS_MEMORY_COUNTERS; the K32* entry points live in kernel32, so no extra link
 #include <malloc.h>
 #include <cstring>
 #else
@@ -133,6 +134,19 @@ uint64_t mem_available_bytes() {
 uint64_t major_faults() {
     return 0;
 }
+
+// Measured here, unlike the rest: the host cache really does MEM_DECOMMIT on evict and MEM_COMMIT on
+// the next miss, so the refault-and-zero cost this counter exists to size is present on the host too.
+// PageFaultCount is soft+hard together — coarser than ru_minflt, but the delta across a decode is
+// dominated by the cache's own recommits, which is the quantity being sized.
+uint64_t minor_faults() {
+    PROCESS_MEMORY_COUNTERS pmc;
+    std::memset(&pmc, 0, sizeof(pmc));
+    pmc.cb = sizeof(pmc);
+    // K32GetProcessMemoryInfo lives in kernel32 (Vista+), so this needs no psapi link.
+    return K32GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)) ? (uint64_t) pmc.PageFaultCount : 0;
+}
+
 double process_cpu_seconds() {
     return 0.0;
 }
@@ -267,6 +281,14 @@ uint64_t major_faults() {
     // RUSAGE_SELF aggregates every thread of the process, matching the multi-threaded decode.
     struct rusage ru;
     return getrusage(RUSAGE_SELF, &ru) == 0 ? (uint64_t) ru.ru_majflt : 0;
+}
+
+uint64_t minor_faults() {
+    // ru_minflt counts faults served without backing store. The expert cache's evict decommits
+    // (MADV_DONTNEED) and vm_commit is a no-op here, so every byte the reader writes into an evicted
+    // entry costs one of these plus the kernel zeroing a page we are about to overwrite whole.
+    struct rusage ru;
+    return getrusage(RUSAGE_SELF, &ru) == 0 ? (uint64_t) ru.ru_minflt : 0;
 }
 
 double process_cpu_seconds() {

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -119,17 +119,28 @@ uint64_t mem_available_bytes();
 
 // Process-wide compute-decomposition counters, cumulative since process start; the caller deltas
 // them across a single decode to split the per-token "compute" residual into its real causes.
-// Both return 0 when the platform cannot report them (Windows host build), which the metrics treat
-// as "unmeasured" rather than "zero work".
+// They return 0 when the platform cannot report them, which the metrics treat as "unmeasured"
+// rather than "zero work". minor_faults() is the exception that IS measured on the Windows host:
+// there the cache decommits and recommits explicitly (MEM_DECOMMIT/MEM_COMMIT), so the same refault
+// cost exists and PageFaultCount sees it. That count is soft+hard rather than minor-only — coarser
+// than ru_minflt, but the quantity being sized here is the refault volume, and it reports that.
 //
 //   * major_faults(): hard page faults served from backing store (getrusage ru_majflt). A non-zero
 //     per-token delta means a mmap-resident weight was re-faulted from flash *inside* the decode —
 //     the >RAM residency stall that would otherwise masquerade as compute.
+//   * minor_faults(): faults served without touching backing store — the expert cache's own cost.
+//     Evicting decommits the entry's pages; the next miss reads into that same address, so the
+//     kernel must hand back a page and ZERO it before the read can land, and the read then
+//     overwrites every byte of that zeroing. Nothing charges this to the cache: on POSIX vm_commit
+//     is a no-op (pages arrive on first touch, inside the reader), so `mgmt_ms` misses it entirely
+//     and the cost surfaces as io/stall/compute. A per-token delta near read_bytes/fault_bytes()
+//     means essentially every streamed byte is landing in a freshly zeroed page.
 //   * process_cpu_seconds(): CPU time summed across all threads (CLOCK_PROCESS_CPUTIME_ID). Compared
 //     against wall×threads it reveals occupancy: cpu≈wall×threads is genuine compute-bound work;
 //     cpu≪wall×threads means the threads were descheduled or blocked (frequency cap, preemption,
 //     fault wait) rather than computing.
 uint64_t major_faults();
+uint64_t minor_faults();
 double process_cpu_seconds();
 
 // Bytes one major fault moves: the page size. Faults are counted, but what a reader wants to know is

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -56,13 +56,13 @@ public:
         write_header(); // a caller that never sent RunInfo still gets a readable file
         std::fprintf(f_,
                      "%d,%d,%.3f,%.3f,%.3f,%llu,%.2f,%.3f,%.3f,%llu,%.3f,%.3f,%d,%.2f,%.1f,%.1f,%.1f,"
-                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f,%d,%.3f,%.3f,%.3f,%.3f,%.3f\n",
+                     "%.1f,%.1f,%.1f,%.1f,%.1f,%.3f,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%llu,%.2f\n",
                      m.step, m.steps, m.wall_ms, m.io_ms, m.compute_ms, (unsigned long long) m.read_bytes,
                      m.cache_hit_pct, m.stall_ms, m.mgmt_ms, (unsigned long long) m.majflt, m.cpu_ms,
                      m.dense_resident_frac, m.turn, m.majflt_mib, m.cache_budget_mib, m.rss_mib, m.rss_anon_mib,
                      m.rss_file_mib, m.swap_mib, m.mem_available_mib, m.mem_free_mib, m.swap_free_mib,
-                     m.loop_overhead_ms, m.mtp_batch, m.mtp_draft_ms, m.drain_ms, m.adopt_ms, m.ra_issue_ms,
-                     m.ra_wd_ms);
+                     m.loop_overhead_ms, m.mtp_batch, m.mtp_draft_ms, m.drain_ms, m.adopt_ms, m.ra_issue_ms, m.ra_wd_ms,
+                     (unsigned long long) m.minflt, m.minflt_mib);
         std::fflush(f_);
     }
     void on_summary(const RunSummary & s) override {
@@ -74,7 +74,7 @@ public:
                      "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
                      "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
                      "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
-                     "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
+                     "majflt/tok=%.2f minflt/tok=%.1f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
                      "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f "
                      "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld mtp_draft_s/tok=%.4f "
                      "drafted_steps=%lld "
@@ -86,9 +86,9 @@ public:
                      s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
                      s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
                      s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
-                     s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped,
-                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes, s.mtp_draft_s_per_token,
-                     s.drafted_steps, s.route_ahead_overridden, s.route_ahead_passthrough,
+                     s.minflt_per_token, s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed,
+                     s.experts_dropped, s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes,
+                     s.mtp_draft_s_per_token, s.drafted_steps, s.route_ahead_overridden, s.route_ahead_passthrough,
                      s.route_ahead_slots > 0 ? 100.0 * s.route_ahead_hits / s.route_ahead_slots : 0.0,
                      s.n_generated ? s.route_ahead_gemv_ns / 1e6 / s.n_generated : 0.0,
                      s.n_generated ? s.route_ahead_issue_ns / 1e6 / s.n_generated : 0.0,
@@ -114,7 +114,7 @@ private:
         std::fprintf(f_, "step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,"
                          "dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,"
                          "rss_file_mib,swap_mib,mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,"
-                         "mtp_batch,mtp_draft_ms,drain_ms,adopt_ms,ra_issue_ms,ra_wd_ms\n");
+                         "mtp_batch,mtp_draft_ms,drain_ms,adopt_ms,ra_issue_ms,ra_wd_ms,minflt,minflt_mib\n");
     }
 
     std::FILE * f_ = nullptr;

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -36,14 +36,15 @@ public:
                      r.n_ubatch, r.chatml);
         std::fprintf(f_,
                      "# moe_stream=%d cache_mb=%d cache_auto=%d cache_floor_mb=%d cache_ceil_mb=%d "
-                     "cache_cycle_mb=%d force_cache=%d load_all=%d io_threads=%d o_direct=%d "
+                     "cache_cycle_mb=%d cache_slot_bank=%d force_cache=%d load_all=%d io_threads=%d o_direct=%d "
                      "overlap=%d io_two_wave=%d prefetch=%d "
                      "route_ahead=%d predict_prefetch=%d predict_log=%d predict_spec_max=%d prefetch_sync=%d "
                      "dense_weights=%s drop_cold_frac=%.4g drop_renorm=%d drop_prefill=%d\n",
                      r.moe_stream, r.cache_mb, r.cache_auto, r.cache_floor_mb, r.cache_ceil_mb, r.cache_cycle_mb,
-                     r.force_cache, r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave, r.prefetch_layers,
-                     r.route_ahead, r.predict_prefetch, r.predict_log, r.predict_spec_max, r.prefetch_sync,
-                     r.dense_weights.c_str(), (double) r.drop_cold_frac, r.drop_renorm, r.drop_prefill);
+                     r.cache_slot_bank, r.force_cache, r.load_all, r.io_threads, r.o_direct, r.overlap, r.io_two_wave,
+                     r.prefetch_layers, r.route_ahead, r.predict_prefetch, r.predict_log, r.predict_spec_max,
+                     r.prefetch_sync, r.dense_weights.c_str(), (double) r.drop_cold_frac, r.drop_renorm,
+                     r.drop_prefill);
         std::fprintf(f_,
                      "# temp=%.4g top_k=%d top_p=%.4g seed=%u compute_trace_layers=%d spec=%s "
                      "spec_draft_max=%d mtp_p_min=%.4g ngram_min_match=%d\n",

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -53,6 +53,7 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
     spec_adopt_ = cfg.route_ahead > 0;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
+    slot_bank_ = std::max(0, cfg.cache_slot_bank);
     page_ = pio::vm_page(); // the real OS page size, for the dense-residency probe in any cache mode
 
     // Largest full-tensor byte size per projection, over all bound layers → shared-slot
@@ -163,6 +164,50 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
                 L.proj[p].tensor->data = lbuf_[p][il];
             }
         }
+        // Decode-only slot bank, alongside (never instead of) the reserved buffers above. Allocated
+        // and FAULTED IN here, once: the whole point is that no page of it is ever released, so a
+        // miss overwrites bytes the kernel has already given us rather than asking for a zeroed page
+        // it must find and clear. See config.h for the measurement that motivates it.
+        if (slot_bank_ > 0) {
+            bool ok = slot_bank_ <= n_expert_; // a slot index is fed to mul_mat_id in an expert's place
+            if (!ok)
+                std::fprintf(stderr, "bmoe: --cache-slot-bank %d exceeds n_expert %d; slot bank off\n", slot_bank_,
+                             n_expert_);
+            for (int p = 0; ok && p < MoeRecipe::max_exps; ++p)
+                bank_[p].assign(n_layer_, nullptr);
+            for (int il = 0; ok && il < n_layer_; ++il) {
+                LayerExperts & L = layers_[il];
+                if (!L.bound) continue;
+                for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                    if (!L.proj[p].tensor) continue;
+                    const size_t sz = (size_t) L.proj[p].nb2 * (size_t) slot_bank_;
+                    bank_[p][il] = pio::alloc_aligned(align_, sz);
+                    if (!bank_[p][il]) {
+                        std::fprintf(stderr, "bmoe: slot-bank alloc %zu failed (layer %d); slot bank off\n", sz, il);
+                        ok = false;
+                        break;
+                    }
+                    // Touch every page now. Without this the first miss into each slot still takes
+                    // the fault this mode exists to remove, and the warm-up would look like the cost.
+                    std::memset(bank_[p][il], 0, sz);
+                }
+            }
+            bank_ready_ = ok;
+            if (ok) {
+                slot_of_.assign((size_t) n_layer_ * n_expert_, (int16_t) -1);
+                bank_owner_.assign((size_t) n_layer_ * slot_bank_, -1);
+                bank_stamp_.assign((size_t) n_layer_ * slot_bank_, 0u);
+                bank_slot_.assign((size_t) n_expert_, (int16_t) -1);
+            } else {
+                for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                    for (void * b : bank_[p])
+                        if (b) pio::aligned_free(b);
+                    bank_[p].clear();
+                }
+                slot_bank_ = 0;
+            }
+        }
+
         const size_t n_entry = (size_t) n_layer_ * n_expert_;
         cvalid_.assign(n_entry, 0);
         cstamp_.assign(n_entry, 0);
@@ -377,7 +422,11 @@ void ExpertStreamSource::io_worker(int lane) {
 // Prefetch: on the eval thread, commit pages and enqueue speculative per-projection reads for the
 // given experts of layer il. LRU-safe (same thread as load_layer); workers only read the bytes.
 void ExpertStreamSource::prefetch(int il, const int32_t * ids, int n_ids) {
-    if (!active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids || n_ids <= 0) return;
+    // bank_active_: speculation lands in lbuf_, which a banked decode never reads — it would spend
+    // flash on bytes nothing can consume.
+    if (!active_ || bank_active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids ||
+        n_ids <= 0)
+        return;
     const LayerExperts & L = layers_[il];
     bool any = false;
 
@@ -753,7 +802,9 @@ void ExpertStreamSource::evict_tail() {
 // prediction is not a routing — inflating the hit rate from here would corrupt the one metric
 // every cache decision in this project is argued from. Eval-thread only (LRU mutation).
 void ExpertStreamSource::retain(int il, const int32_t * ids, int n_ids) {
-    if (!active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids) return;
+    // bank_active_: the bank has its own recency (bank_stamp_), and the LRU list below orders
+    // entries a banked decode does not read.
+    if (!active_ || bank_active_ || cache_max_ == 0 || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids) return;
     for (int i = 0; i < n_ids; ++i) {
         const int e = ids[i];
         if (e < 0 || e >= n_expert_) continue;
@@ -861,6 +912,15 @@ void ExpertStreamSource::query_residency(int il, const int32_t * ids, int n_ids,
     for (int i = 0; i < n_ids; ++i)
         out[i] = 0;
     if (!active_ || il < 0 || il >= n_layer_ || !layers_[il].bound || !ids) return;
+    if (bank_active_) {
+        // Bank mode: residency is "does this expert hold a slot", and there is no speculation here,
+        // so the answer is only ever 0 or 1.
+        for (int i = 0; i < n_ids; ++i) {
+            const int e = ids[i];
+            if (e >= 0 && e < n_expert_ && slot_of_[(size_t) il * n_expert_ + (size_t) e] >= 0) out[i] = 1;
+        }
+        return;
+    }
     if (cache_max_ == 0) return; // shared-slot mode: nothing is kept, so every routing re-reads
     for (int i = 0; i < n_ids; ++i) {
         const int e = ids[i];
@@ -890,6 +950,89 @@ bool ExpertStreamSource::commit_proj_pages(int il, int e, int p) {
         return false;
     }
     return true;
+}
+
+// ── decode-only slot bank ───────────────────────────────────────────────────────────
+// The bank's whole reason to exist is that eviction here costs nothing: a slot is reassigned and
+// its bytes are overwritten in place. No vm_commit, no vm_evict, and above all no page handed back
+// by the kernel with a zero-fill the reader is about to obliterate. Everything below runs on the
+// eval thread, under the same eval-callback barrier as the LRU cache.
+
+// Point every bound layer's expert tensors at the home this graph will address. mul_mat_id reads
+// `src0->data + id*nb2`, so moving the base and rewriting the ids are two halves of one change and
+// must not be applied separately: with the base moved and the ids left alone, the kernel would read
+// past the bank; with the ids rewritten and the base left alone, it would read the wrong expert.
+// The hook calls this before the first load of a graph and never mid-graph.
+void ExpertStreamSource::set_decode_graph(bool single_token) {
+    const bool want = bank_ready_ && single_token;
+    if (want == bank_active_) return; // the common case: nothing moved since the last graph
+    bank_active_ = want;
+    for (int il = 0; il < n_layer_; ++il) {
+        LayerExperts & L = layers_[il];
+        if (!L.bound) continue;
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            if (!L.proj[p].tensor) continue;
+            void * base = want ? bank_base(il, p) : canonical_base(il, p);
+            if (base) L.proj[p].tensor->data = base;
+        }
+    }
+}
+
+int ExpertStreamSource::slot_of_expert(int il, int e) const {
+    if (!bank_active_ || il < 0 || il >= n_layer_ || e < 0 || e >= n_expert_) return -1;
+    return slot_of_[(size_t) il * n_expert_ + (size_t) e];
+}
+
+void * ExpertStreamSource::bank_base(int il, int p) const {
+    if (!bank_ready_ || il < 0 || il >= n_layer_ || p < 0 || p >= MoeRecipe::max_exps) return nullptr;
+    return bank_[p].empty() ? nullptr : bank_[p][il];
+}
+
+void * ExpertStreamSource::canonical_base(int il, int p) const {
+    if (il < 0 || il >= n_layer_ || p < 0 || p >= MoeRecipe::max_exps) return nullptr;
+    if (!lbuf_[p].empty()) return lbuf_[p][il]; // LRU mode: one reserved buffer per (layer, proj)
+    return slot_[p];                            // cache-off mode: one shared buffer per projection
+}
+
+// Give expert `e` of layer `il` a slot, evicting this layer's coldest if the bank is full. Returns
+// the slot, or -1 if the layer has no bank. `hit` is true when the expert was already banked, which
+// is the only case where no read is needed.
+int ExpertStreamSource::bank_assign(int il, int e, bool & hit) {
+    const size_t key = (size_t) il * n_expert_ + (size_t) e;
+    const int16_t cur = slot_of_[key];
+    if (cur >= 0) {
+        hit = true;
+        bank_stamp_[(size_t) il * slot_bank_ + (size_t) cur] = cgen_;
+        return cur;
+    }
+    hit = false;
+    // Free slot first, then the coldest. Linear over slot_bank_ (tens), once per miss — cheaper
+    // than threading an LRU list through a structure this small.
+    int victim = -1;
+    uint32_t oldest = 0xffffffffu;
+    for (int s = 0; s < slot_bank_; ++s) {
+        const size_t bs = (size_t) il * slot_bank_ + (size_t) s;
+        if (bank_owner_[bs] < 0) {
+            victim = s;
+            break;
+        }
+        if (bank_stamp_[bs] < oldest) {
+            oldest = bank_stamp_[bs];
+            victim = s;
+        }
+    }
+    if (victim < 0) return -1;
+    const size_t vs = (size_t) il * slot_bank_ + (size_t) victim;
+    const int32_t prev = bank_owner_[vs];
+    if (prev >= 0) {
+        slot_of_[(size_t) il * n_expert_ + (size_t) prev] = -1;
+        ++evictions_;
+        ++rereads_; // the displaced expert will be bought again if it routes; same meaning as the LRU's
+    }
+    bank_owner_[vs] = e;
+    bank_stamp_[vs] = cgen_;
+    slot_of_[key] = (int16_t) victim;
+    return victim;
 }
 
 bool ExpertStreamSource::touch_entry(int il, int e, bool & hit, bool promote, int commit_only_proj) {
@@ -946,6 +1089,27 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
     if (cache_max_) quiesce_spec(spec_adopt_ ? il : -1);
 
     auto stage = [&](int e) -> bool {
+        if (bank_active_) {
+            // Slot bank: the destination is the expert's slot, not its canonical offset, because the
+            // hook has rewritten this layer's ids to slot indices. No commit, no evict — a displaced
+            // slot is simply overwritten. Serial drains everything below, so no ready flag is needed.
+            bool hit = false;
+            const int slot = bank_assign(il, e, hit);
+            if (slot < 0) return false;
+            clookups_++;
+            if (hit) {
+                chits_++;
+                return true;
+            }
+            for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+                const uint64_t slice = L.proj[p].nb2;
+                if (slice == 0) continue;
+                jobs_.push_back({(char *) bank_[p][il] + (uint64_t) slot * slice,
+                                 L.proj[p].file_off + (uint64_t) e * slice, slice, -1, (int16_t) L.proj[p].file_idx, e,
+                                 (int16_t) il, (int8_t) p, 0});
+            }
+            return true;
+        }
         if (cache_max_ == 0) {
             for (int p = 0; p < MoeRecipe::max_exps; ++p) {
                 const uint64_t slice = L.proj[p].nb2;
@@ -1108,7 +1272,44 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
 
     bool published = false; // a two-wave batch publishes inside the staging branch
 
-    if (cache_max_ == 0) {
+    if (bank_active_) {
+        // Slot bank (single-token graphs only). Same shape as the cache-on branch below, minus
+        // every page-management syscall: a miss is handed a slot whose pages are already ours, so
+        // there is nothing to commit here and nothing to release when it is displaced.
+        //
+        // The kernel will address src0 by SLOT, because the hook rewrites the ids before mul_mat_id
+        // reads them — so the ready flag and the job's wait key are keyed by slot too, and
+        // on_expert_ready needs no notion of the bank at all: it is handed the same index we
+        // published. Slots are < n_expert_, so the existing flag array still fits.
+        for (int e : staged_) {
+            bool hit = false;
+            const int slot = bank_assign(il, e, hit);
+            if (slot < 0) { // no bank for this layer — cannot serve the graph we already promised
+                fatal_.store(true, std::memory_order_release);
+                return false;
+            }
+            clookups_++;
+            if (hit) {
+                chits_++;
+                for (int p = 0; p < MoeRecipe::max_exps; ++p)
+                    if (L.proj[p].nb2) mark_ready(p, slot);
+            }
+            bank_slot_[e] = (int16_t) slot;
+            seen_[e] = hit ? 0 : 1; // reuse as the miss marker, as the cache-on branch does
+        }
+        for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+            const uint64_t slice = L.proj[p].nb2;
+            if (slice == 0) continue;
+            for (int e : staged_) {
+                if (!seen_[e]) continue; // already banked
+                const int slot = bank_slot_[e];
+                const int32_t flag = (int32_t) ((size_t) p * (size_t) n_expert_ + (size_t) slot);
+                jobs_.push_back({(char *) bank_[p][il] + (uint64_t) slot * slice,
+                                 L.proj[p].file_off + (uint64_t) e * slice, slice, flag, (int16_t) L.proj[p].file_idx,
+                                 e, (int16_t) il, (int8_t) p, 0});
+            }
+        }
+    } else if (cache_max_ == 0) {
         // Cache off: every (projection, expert) is a fresh read into the shared full-size slot
         // at its canonical offset e*slice. Emit projection-major.
         for (int p = 0; p < MoeRecipe::max_exps; ++p) {
@@ -1416,6 +1617,13 @@ void ExpertStreamSource::shutdown() {
         lbuf_[p].clear();
         lbuf_sz_[p].clear();
     }
+    for (int p = 0; p < MoeRecipe::max_exps; ++p) {
+        for (void * b : bank_[p])
+            if (b) pio::aligned_free(b);
+        bank_[p].clear();
+    }
+    bank_ready_ = false;
+    bank_active_ = false;
     // The dense-weights module frees its own anon buffers here. Safe: the context (whose rebound
     // dense tensors point at them) is torn down after the source, and no decode is in flight — same
     // contract as the slot and LRU buffers freed above.

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -27,6 +27,7 @@ ExpertStreamSource::~ExpertStreamSource() {
 // ── init: allocate buffers, rebind expert tensors, start the read pool ──────────────
 bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
                               int n_expert,
+                              int top_k,
                               std::vector<LayerExperts> layers,
                               const MoeStreamConfig & cfg) {
     if (active_) return false;
@@ -53,7 +54,6 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
     spec_adopt_ = cfg.route_ahead > 0;
     cache_max_ = (size_t) std::max(0, cfg.cache_mb) * 1024ull * 1024ull;
     io_threads_ = std::max(1, std::min(MoeStreamConfig::io_threads_max, cfg.io_threads));
-    slot_bank_ = std::max(0, cfg.cache_slot_bank);
     page_ = pio::vm_page(); // the real OS page size, for the dense-residency probe in any cache mode
 
     // Largest full-tensor byte size per projection, over all bound layers → shared-slot
@@ -164,15 +164,46 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
                 L.proj[p].tensor->data = lbuf_[p][il];
             }
         }
-        // Decode-only slot bank, alongside (never instead of) the reserved buffers above. Allocated
-        // and FAULTED IN here, once: the whole point is that no page of it is ever released, so a
-        // miss overwrites bytes the kernel has already given us rather than asking for a zeroed page
-        // it must find and clear. See config.h for the measurement that motivates it.
-        if (slot_bank_ > 0) {
-            bool ok = slot_bank_ <= n_expert_; // a slot index is fed to mul_mat_id in an expert's place
-            if (!ok)
-                std::fprintf(stderr, "bmoe: --cache-slot-bank %d exceeds n_expert %d; slot bank off\n", slot_bank_,
-                             n_expert_);
+        // Decode-only slot bank, alongside the reserved buffers above and paid for out of the same
+        // budget. Allocated and FAULTED IN here, once: the whole point is that no page of it is
+        // ever released, so a miss overwrites bytes the kernel has already given us rather than
+        // asking for a zeroed page it must find and clear. See config.h for the measurement.
+        if (cfg.cache_slot_bank) {
+            // Size the bank here, from what only the engine knows: the resolved budget, the bytes
+            // one expert occupies, and the routing width. The split is mechanical rather than
+            // tuned. Prefill keeps one worst-case token cycle, which is the floor the cache-cycle
+            // guard already names as the point below which a cache cannot hit at all; everything
+            // above that is dead weight during decode, because a banked decode never reads it. So
+            // the rest becomes slots, and the bank comes OUT of cache_mb instead of sitting on top
+            // of it: the two residencies both live for the whole run, and on a device already past
+            // its RAM the difference is a measurement versus a swap storm.
+            size_t per_slot = 0; // bytes one slot costs across every bound layer
+            for (int il = 0; il < n_layer_; ++il)
+                if (layers_[il].bound) per_slot += entry_bytes(il);
+            const size_t cycle = worst_cycle_bytes(top_k);
+            bool ok = per_slot > 0 && cache_max_ >= per_slot;
+            if (!ok) {
+                std::fprintf(stderr, "bmoe: slot bank off, a %zu MiB budget cannot hold one slot per layer (%zu MiB)\n",
+                             cache_max_ / (1024 * 1024), per_slot / (1024 * 1024));
+            } else {
+                // The bank IS the decode cache and takes the whole budget. It is not shared with the
+                // LRU below, because the two are never live at the same moment: prefill reads the
+                // LRU and never the bank, decode reads the bank and never the LRU. Splitting the
+                // budget between them, as the first version did, simply starved decode by whatever
+                // prefill was holding (measured: 1380 MiB of bank against a 2000 MiB baseline lost
+                // 13%, and matched a 1380 MiB baseline exactly — the bank was not slower, it was
+                // smaller). So the LRU keeps only what prefill genuinely needs, one worst-case token
+                // cycle, and hands it back the moment the first token is generated.
+                //
+                // Clamped at n_expert_: past that the slots outnumber the experts that could fill
+                // them, and a slot index would no longer be a legal expert index for mul_mat_id.
+                slot_bank_ = (int) std::min((size_t) n_expert_, cache_max_ / per_slot);
+                prefill_max_ = cycle ? std::min(cache_max_, cycle) : cache_max_;
+                std::fprintf(stderr,
+                             "bmoe: slot bank: %d slots/layer (%zu MiB) for decode, %zu MiB of prefill LRU "
+                             "released once generation starts\n",
+                             slot_bank_, (size_t) slot_bank_ * per_slot / (1024 * 1024), prefill_max_ / (1024 * 1024));
+            }
             for (int p = 0; ok && p < MoeRecipe::max_exps; ++p)
                 bank_[p].assign(n_layer_, nullptr);
             for (int il = 0; ok && il < n_layer_; ++il) {
@@ -717,7 +748,7 @@ void ExpertStreamSource::set_cache_budget(size_t bytes) {
     ++cache_resizes_;
     // No cstamp guard: with no decode in flight, nothing is staged for the current generation, so
     // every resident entry (coldest first) is a valid eviction target.
-    while (cresident_ > cache_max_ && ctail_ != -1)
+    while (cresident_ > lru_budget() && ctail_ != -1)
         evict_tail();
 }
 
@@ -967,6 +998,18 @@ void ExpertStreamSource::set_decode_graph(bool single_token) {
     const bool want = bank_ready_ && single_token;
     if (want == bank_active_) return; // the common case: nothing moved since the last graph
     bank_active_ = want;
+    if (want) {
+        // Generation starts here, so the prefill LRU is now unreachable: the tensors below are
+        // about to point at the bank, and nothing will read those pages again until the next
+        // prompt. Hand them back rather than hold them for the whole reply. Safe at this point for
+        // the same reason eviction ever is: the previous graph is complete, so no lane is mid-write
+        // into a page being released.
+        const auto te0 = clock_t_::now();
+        while (ctail_ != -1)
+            evict_tail();
+        mgmt_ns_.fetch_add(
+            (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - te0).count());
+    }
     for (int il = 0; il < n_layer_; ++il) {
         LayerExperts & L = layers_[il];
         if (!L.bound) continue;
@@ -1199,7 +1242,7 @@ bool ExpertStreamSource::load_layer(int il, const int32_t * ids, int n_ids) {
 
     if (cache_max_) {
         const auto te0 = clock_t_::now();
-        while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
+        while (cresident_ > lru_budget() && ctail_ != -1 && cstamp_[ctail_] != cgen_)
             evict_tail();
         mgmt_ns_.fetch_add(
             (long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - te0).count());
@@ -1454,7 +1497,7 @@ bool ExpertStreamSource::load_layer_async(int il, const int32_t * ids, int n_ids
     //    guaranteed no stale in-flight jobs, and current-gen entries (cstamp_ == cgen_) — the
     //    ones just staged — are never chosen, so eviction only releases pages nobody is reading.
     if (cache_max_) {
-        while (cresident_ > cache_max_ && ctail_ != -1 && cstamp_[ctail_] != cgen_)
+        while (cresident_ > lru_budget() && ctail_ != -1 && cstamp_[ctail_] != cgen_)
             evict_tail();
     }
     mgmt_ns_.fetch_add((long long) std::chrono::duration_cast<std::chrono::nanoseconds>(clock_t_::now() - tm0).count());

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -64,8 +64,12 @@ public:
     // I/O pool. `layers` is indexed by layer id (unbound entries are skipped); each tensor's
     // file_idx indexes `shard_paths` (a single-file model passes one path). Returns false on
     // any allocation/open failure or an inconsistent tensor.
+    // `top_k` is the run's EFFECTIVE routing width (an --n-expert-used override, else the model's
+    // own). Only the slot bank reads it, to price one worst-case token cycle while sizing itself;
+    // pass 0 when it is unknown and the bank simply stays off.
     bool init(const std::vector<std::string> & shard_paths,
               int n_expert,
+              int top_k,
               std::vector<LayerExperts> layers,
               const MoeStreamConfig & cfg);
 
@@ -83,6 +87,10 @@ public:
     uint64_t expert_bytes(int il) const override;
 
     bool slot_bank_on() const override { return bank_ready_; }
+
+    // Slots per layer the bank actually got, 0 when it is off for any reason. What telemetry must
+    // record: the request is a switch, this is the number a reader can compare two runs by.
+    int slot_bank_slots() const { return bank_ready_ ? slot_bank_ : 0; }
     void set_decode_graph(bool single_token) override;
     int slot_of_expert(int il, int e) const override;
     Stats stats() const override;
@@ -297,10 +305,15 @@ private:
     std::vector<uint32_t> bank_stamp_;              // [il*slot_bank_+s] → cgen_ of last use (LRU)
     bool bank_active_ = false;                      // this layer's reads target the bank, not lbuf_
     bool bank_ready_ = false;                       // init succeeded and the arch allows remapping
-    int bank_assign(int il, int e, bool & hit);     // slot for an expert, evicting the layer's coldest
-    void * bank_base(int il, int p) const;          // layer's bank for one projection (null if none)
-    void * canonical_base(int il, int p) const;     // where the same tensor points outside the bank
-    std::vector<int16_t> bank_slot_;                // scratch: staged expert → its slot, this layer
+    // With a bank, the LRU below serves prefill only, so it is budgeted separately and released the
+    // moment generation starts: from there on nothing can read it, and every byte it still holds is
+    // a byte the bank could have been. lru_budget() is the one place that difference lives.
+    size_t prefill_max_ = 0;
+    size_t lru_budget() const { return bank_ready_ ? prefill_max_ : cache_max_; }
+    int bank_assign(int il, int e, bool & hit); // slot for an expert, evicting the layer's coldest
+    void * bank_base(int il, int p) const;      // layer's bank for one projection (null if none)
+    void * canonical_base(int il, int p) const; // where the same tensor points outside the bank
+    std::vector<int16_t> bank_slot_;            // scratch: staged expert → its slot, this layer
 
     std::vector<uint8_t> cvalid_;
     std::vector<int32_t> cprev_, cnext_;

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -81,6 +81,10 @@ public:
     void settle_spec() override;
     void query_residency(int il, const int32_t * ids, int n_ids, uint8_t * out) const override;
     uint64_t expert_bytes(int il) const override;
+
+    bool slot_bank_on() const override { return bank_ready_; }
+    void set_decode_graph(bool single_token) override;
+    int slot_of_expert(int il, int e) const override;
     Stats stats() const override;
 
     // Register the process-global expert-ready hook so the CPU matmul blocks per expert
@@ -276,6 +280,28 @@ private:
     int last_il_ = -1;
     std::vector<void *> lbuf_[MoeRecipe::max_exps];
     std::vector<size_t> lbuf_sz_[MoeRecipe::max_exps];
+
+    // ── decode-only slot bank (cfg.moe.cache_slot_bank; see config.h for why it exists) ──
+    // A second, separate home for expert bytes, used only when a graph decodes a single token. Its
+    // pages are allocated and faulted in ONCE at init and never released: an eviction here is a
+    // reassignment, so a miss overwrites bytes instead of asking the kernel for a zeroed page. That
+    // is legal only because the router's ids are rewritten to slot indices before mul_mat_id runs.
+    //
+    // Residency is tracked independently of the LRU cache above: prefill fills lbuf_, decode fills
+    // the bank, and neither can see the other's bytes. So the bank is cold on the first generated
+    // token — a one-off cost the measurement has to amortize, not a steady-state property.
+    int slot_bank_ = 0;                             // slots per layer; 0 = off (the shipping path)
+    std::vector<void *> bank_[MoeRecipe::max_exps]; // per layer: slot_bank_ contiguous slices
+    std::vector<int16_t> slot_of_;                  // [il*n_expert_+e] → slot holding it, or -1
+    std::vector<int32_t> bank_owner_;               // [il*slot_bank_+s] → expert in that slot, or -1
+    std::vector<uint32_t> bank_stamp_;              // [il*slot_bank_+s] → cgen_ of last use (LRU)
+    bool bank_active_ = false;                      // this layer's reads target the bank, not lbuf_
+    bool bank_ready_ = false;                       // init succeeded and the arch allows remapping
+    int bank_assign(int il, int e, bool & hit);     // slot for an expert, evicting the layer's coldest
+    void * bank_base(int il, int p) const;          // layer's bank for one projection (null if none)
+    void * canonical_base(int il, int p) const;     // where the same tensor points outside the bank
+    std::vector<int16_t> bank_slot_;                // scratch: staged expert → its slot, this layer
+
     std::vector<uint8_t> cvalid_;
     std::vector<int32_t> cprev_, cnext_;
     std::vector<uint32_t> cstamp_;

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -174,6 +174,28 @@ bool RouterHook::drop_armed() const {
 //     matmul, which is the right trade on a decode bound by flash rather than arithmetic.
 // The top-weighted expert is never dropped, so a routing always keeps at least one live expert
 // whatever the threshold — the guarantee does not rest on frac <= 1 alone.
+// Rewrite layer `il`'s selected-expert ids from expert index to slot index, so mul_mat_id reads the
+// bank. Nothing else in the graph consumes these ids: the weight gather has already run (this is
+// its terminal node), and the architectures that would read them again after the matmul — those
+// with a per-expert bias (ggml_add_id) or a per-expert scale (get_rows inside build_lora_mm_id) —
+// are rejected at init, precisely because there is no seam left to fix them up at.
+//
+// An expert with no slot is left alone. That cannot normally happen (load_layer banked every routed
+// id a moment ago) but a stale or dropped id would otherwise index the bank out of bounds, and the
+// cost of the check is one compare per routed slot.
+void RouterHook::apply_slot_remap(int il) {
+    if (!source_ || !source_->slot_bank_on()) return;
+    ggml_tensor * ids = drop_.ids;
+    if (!ids || !ids->data || drop_.nu <= 0 || drop_.nt <= 0) return;
+    for (int j = 0; j < drop_.nt; ++j) {
+        for (int k = 0; k < drop_.nu; ++k) {
+            int32_t * p = id_at(ids, j, k);
+            const int slot = source_->slot_of_expert(il, *p);
+            if (slot >= 0) *p = (int32_t) slot;
+        }
+    }
+}
+
 void RouterHook::apply_drop(ggml_tensor * wt) {
     PendingDrop & D = drop_;
     const int nu = D.nu, nt = D.nt;
@@ -1242,13 +1264,32 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
     // One prefix test decides whether any of the three matchers below can possibly fire. The vast
     // majority of a graph's nodes fail it and leave having done nothing else.
     const bool moe_node = is_moe_node(t->name);
+    // Slot-bank safety, decided from the graph rather than from a list of architecture names. Two
+    // node families read the selected-expert ids AFTER the matmul has consumed them: a per-expert
+    // bias (ggml_add_id → "ffn_moe_*_biased") and a per-expert scale (a get_rows inside
+    // build_lora_mm_id → "ffn_moe_*_scaled"). Both would index their small resident tensor by slot
+    // and silently apply the wrong row, so seeing either one disarms the bank for the run.
+    //
+    // Because a node is offered immediately before it is computed, a graph cannot be judged until
+    // it has been walked once — hence the bank arms only from the SECOND graph on. In any real run
+    // the first is the prompt's prefill, which never banks anyway.
+    if (moe_node && !bank_unsafe_ && (std::strstr(t->name, "_biased-") || std::strstr(t->name, "_scaled-"))) {
+        bank_unsafe_ = true;
+        if (source_ && source_->slot_bank_on())
+            std::fprintf(stderr,
+                         "bmoe: slot bank off — this model's experts carry a per-expert bias or scale (%s),\n"
+                         "      which reads the routing ids after the matmul the remap is for\n",
+                         t->name);
+    }
     const int il = moe_node ? match_layer_node(t->name, "ffn_moe_topk-") : -1;
     const bool is_topk = il >= 0;
     // The weight nodes are asked for by a traced run, and by the drop policy, which decides on the
     // weights the matmul will actually apply. Each extra ask is another barrier — a handful per MoE
     // layer, on tensors of a few floats — so neither is on by default.
     int wl = -1;
-    const bool want_weights = trace_on_ || drop_armed();
+    // The slot bank joins the trace and the drop policy in needing the weight chain: its remap has
+    // exactly one legal node, and that node has to be identified before it can be used.
+    const bool want_weights = trace_on_ || drop_armed() || (source_ && source_->slot_bank_on());
     const int weight_variant = (moe_node && want_weights) ? match_weights(t->name, wl) : -1;
     const bool is_weights = weight_variant >= 0;
     // Which of them is worth a BARRIER is a narrower question than which of them we recognise. The
@@ -1323,6 +1364,13 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         chain_last_ = (int8_t) weight_variant;
         if (drop_.deferred && wl >= 0 && wl < (int) term_variant_.size() && term_variant_[wl] == weight_variant)
             apply_drop(t);
+        // The slot-bank remap, and this is the ONLY node in the graph where it is legal. The ids
+        // feed two consumers: ggml_get_rows(probs, ids), which produced the very tensor being
+        // offered here and so is already done with them, and the mul_mat_ids that have not run yet.
+        // Rewriting between the two swaps the expert's ADDRESS without touching which expert the
+        // router picked or what weight it carries. Doing it at the topk instead would corrupt the
+        // weights; doing it later is impossible, there is no node in between.
+        if (wl >= 0 && wl < (int) term_variant_.size() && term_variant_[wl] == weight_variant) apply_slot_remap(wl);
     }
 
     if (source_ && is_topk && t->data && t->type == GGML_TYPE_I32) {
@@ -1334,6 +1382,12 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         close_drop_layer();
 
         const int nu = (int) t->ne[0], nt = (int) t->ne[1];
+        // Tell the source which home the expert bytes must have for THIS graph, before anything
+        // asks it to load or to report residency. nt is the constraint itself, not a proxy for it:
+        // one mul_mat_id serves the whole batch, so a multi-token graph would need every expert it
+        // touches banked at once. Idempotent, and cheap enough to repeat per layer.
+        if (il == 0) ++bank_graphs_;
+        if (source_->slot_bank_on()) source_->set_decode_graph(nt == 1 && bank_graphs_ > 1 && !bank_unsafe_);
         // Route-ahead, in submission order: first the watchdog sample and the ranking job for
         // layer il+N (both need the ROUTER's ids, still untouched here), then the commit — BEFORE
         // the ids are gathered, so everything downstream — the trace, the drop policy, load_layer,

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -1277,7 +1277,7 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
         bank_unsafe_ = true;
         if (source_ && source_->slot_bank_on())
             std::fprintf(stderr,
-                         "bmoe: slot bank off — this model's experts carry a per-expert bias or scale (%s),\n"
+                         "bmoe: slot bank off, this model's experts carry a per-expert bias or scale (%s),\n"
                          "      which reads the routing ids after the matmul the remap is for\n",
                          t->name);
     }

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -240,6 +240,9 @@ private:
     void flush_pending();
     bool drop_armed() const;
     void apply_drop(ggml_tensor * weights);
+    void apply_slot_remap(int il); // expert ids → slot indices, at the terminal weight node only
+    bool bank_unsafe_ = false;     // graph reads the ids after the matmul (per-expert bias/scale)
+    int bank_graphs_ = 0;          // graphs walked; the bank arms only once one is fully seen
     void close_drop_layer();
     void ctrace_close_segment(int interval_layer, const char * tail_name);
 

--- a/docs/cache-sizing.md
+++ b/docs/cache-sizing.md
@@ -130,6 +130,44 @@ see the ordering warning below.
 
 `auto` is a real LRU cache, so it satisfies the cache requirement of `--prefetch`.
 
+## `--cache-slot-bank N` (experimental, decode only)
+
+The cache above is *direct-mapped*: `mul_mat_id` reads expert `e` at `data + e*nb2`, so every
+expert has one fixed address, and the only way to bound the budget is to physically release the
+pages of whatever is evicted. That makes eviction cost a syscall, and it makes the next miss read
+into an address the kernel must hand back and zero first, a zeroing the read then overwrites whole.
+Neither cost is billed to `mgmt_ms`: on POSIX `vm_commit` is a no-op, so the page arrives later,
+inside the reader. `minflt` (see [telemetry.md](telemetry.md)) is what makes it visible.
+
+`--cache-slot-bank N` gives each layer `N` slots whose pages are claimed once at load and never
+released. Eviction becomes a reassignment, and a miss overwrites bytes that are already ours. What
+buys that is rewriting the router's selected-expert ids to slot indices, which is legal because the
+kernel addresses `src0` by `data + id*nb2` and never asks what the id means. The rewrite happens at
+exactly one node, the terminal of the layer's weight chain: after `ggml_get_rows(probs, ids)` has
+taken the routing weights, before the first `mul_mat_id` reads the same ids. There is no other seam.
+
+Two limits follow from the mechanism, and the engine enforces both rather than documenting them:
+
+- **Decode only.** Every token of a batch goes through one `mul_mat_id`, so a prefill batch would
+  need its whole expert set banked at once. Prefill keeps the canonical buffers and the normal LRU;
+  the bank serves single-token graphs. The two hold separate residency, so the bank starts cold on
+  the first generated token of a turn.
+- **`N` at most `n_expert`,** because a slot index is handed to `mul_mat_id` in an expert index's
+  place and the kernel sizes its per-expert scratch from the tensor's expert count.
+
+Architectures whose experts carry a per-expert bias (`ggml_add_id`) or scale read the same ids
+*after* the matmul, where no seam is left to fix them up. The engine detects those from the graph's
+own node names and disarms the bank for the run, printing why.
+
+Measured on the host on Qwen3.6-35B at `--cache-mb 2000`, three pairs: 2.805 to 3.035 tok/s
+(+8.2 %), minor faults 61 323 to 0 per token, `mgmt_ms` 31.1 to 0.9 ms, output byte-identical.
+Read the attribution before assuming it transfers: **ms per MiB read did not move** (1.487 vs
+1.480), so on that machine the zeroing was already hidden behind the SSD wait. The gain came from
+the eviction syscalls disappearing and from a hit-rate rise (54.9 to 57.5 %) that falls out of the
+bank's per-layer LRU, where each layer keeps a floor of slots instead of competing in one global
+list. The balance differs on a phone, where `vm_commit` costs nothing but the cores are far weaker,
+so the flag stays off by default and off in the app until a device A/B says otherwise.
+
 ## Explicit control
 
 Embedders that link the engine can also resize the cache directly with

--- a/docs/cache-sizing.md
+++ b/docs/cache-sizing.md
@@ -130,7 +130,7 @@ see the ordering warning below.
 
 `auto` is a real LRU cache, so it satisfies the cache requirement of `--prefetch`.
 
-## `--cache-slot-bank N` (experimental, decode only)
+## `--cache-slot-bank` (experimental, decode only, measured negative on Android)
 
 The cache above is *direct-mapped*: `mul_mat_id` reads expert `e` at `data + e*nb2`, so every
 expert has one fixed address, and the only way to bound the budget is to physically release the
@@ -139,12 +139,21 @@ into an address the kernel must hand back and zero first, a zeroing the read the
 Neither cost is billed to `mgmt_ms`: on POSIX `vm_commit` is a no-op, so the page arrives later,
 inside the reader. `minflt` (see [telemetry.md](telemetry.md)) is what makes it visible.
 
-`--cache-slot-bank N` gives each layer `N` slots whose pages are claimed once at load and never
+`--cache-slot-bank` gives each layer a set of slots whose pages are claimed once at load and never
 released. Eviction becomes a reassignment, and a miss overwrites bytes that are already ours. What
 buys that is rewriting the router's selected-expert ids to slot indices, which is legal because the
 kernel addresses `src0` by `data + id*nb2` and never asks what the id means. The rewrite happens at
 exactly one node, the terminal of the layer's weight chain: after `ggml_get_rows(probs, ids)` has
 taken the routing weights, before the first `mul_mat_id` reads the same ids. There is no other seam.
+
+It is a switch, not a size. The slot count is derived at load from the budget and the per-expert
+bytes, because those are the only inputs the answer depends on and the engine has both. The bank
+comes out of `--cache-mb` rather than adding to it: it IS the decode cache, and the LRU it replaces
+keeps only one token cycle for prefill, released the moment generation starts. An earlier revision
+split the budget between the two and simply starved decode, which measured as a 13 % loss against
+an untouched baseline and as an exact tie against a baseline given the same smaller budget. The
+bank was never slower there; it was smaller. That is the trap this flag makes easy to fall into,
+so: compare at equal memory, always.
 
 Two limits follow from the mechanism, and the engine enforces both rather than documenting them:
 
@@ -159,14 +168,48 @@ Architectures whose experts carry a per-expert bias (`ggml_add_id`) or scale rea
 *after* the matmul, where no seam is left to fix them up. The engine detects those from the graph's
 own node names and disarms the bank for the run, printing why.
 
-Measured on the host on Qwen3.6-35B at `--cache-mb 2000`, three pairs: 2.805 to 3.035 tok/s
-(+8.2 %), minor faults 61 323 to 0 per token, `mgmt_ms` 31.1 to 0.9 ms, output byte-identical.
-Read the attribution before assuming it transfers: **ms per MiB read did not move** (1.487 vs
-1.480), so on that machine the zeroing was already hidden behind the SSD wait. The gain came from
-the eviction syscalls disappearing and from a hit-rate rise (54.9 to 57.5 %) that falls out of the
-bank's per-layer LRU, where each layer keeps a floor of slots instead of competing in one global
-list. The balance differs on a phone, where `vm_commit` costs nothing but the cores are far weaker,
-so the flag stays off by default and off in the app until a device A/B says otherwise.
+### What it measured
+
+The mechanism does what it claims, on both platforms. Host, Qwen3.6-35B at `--cache-mb 2000`:
+minor faults 61 323 to 0 per token, `mgmt_ms` 31.1 to 1.1, +1.8 % tok/s at matched decode capacity.
+Device, Qwen3.6-35B Q4_0 at 3000 MiB: minor faults per 4 KiB streamed go from **1.04 to 0.04**,
+`mgmt_ms` from 6.4 to 0.9, +2.2 % on a good run. Generated text byte-identical throughout.
+
+**It still does not pay on Android, and the reason is the interesting part.** Read `majflt` next to
+`minflt`, because either alone lies:
+
+| | minflt/tok | majflt/tok | swap | tok/s |
+|---|---:|---:|---:|---:|
+| baseline | 14 454 | **4-116** | ~100 MiB | 7.69-7.73 |
+| slot bank | 615 | **1 676-5 484** | 155-393 MiB | 4.35-8.06 |
+
+The bank is permanently dirty anonymous memory, and with a working set of `top_k` slots out of
+however many it holds, most of it is untouched at any moment. That is precisely the profile
+Android's `swappiness 160` compresses into zram, so the pages we refused to give back get taken
+anyway, and come back as major faults. Throughput tracks the swap: 8.06 tok/s at 155 MiB of swap,
+4.35 at 393 MiB. Note `rss_anon` was *lower* with the bank (2875-2949 vs 3073), so this is not
+about asking for too much memory. It is about offering the kernel a large pool of lukewarm pages.
+
+Which inverts the premise: **the decommit the bank removes is not waste.** It is how the cache
+tells the kernel it genuinely does not need those pages, and that is what keeps it out of reclaim.
+The baseline's 14 454 cheap minor faults per token buy 4 major ones. The bank trades them for a few
+thousand expensive ones.
+
+Two design faults remain, both visible in the numbers above and neither fixed:
+
+- **Uniform slots per layer is a worse policy than a global LRU.** Every layer gets the same count
+  whether or not it reuses experts, where the global list lets layers that benefit take more. Hit
+  rate falls 73.4 % to 70.0 % on device, which is 17 % more flash read, eating most of the saving.
+- **The disarm check is broader than the danger.** It matches any MoE node named `_biased`/`_scaled`,
+  which catches the harmless router bias (`ffn_moe_probs_biased`) and routing-weight scale as well
+  as the genuinely unsafe per-expert ones. Combined with a graph counter that waits for layer 0's
+  top-k, which never appears on architectures with leading dense blocks, the bank silently never
+  arms on DeepSeek V4, Ling 3.0 and LFM2, so a run there measures nothing at all.
+
+The regime where the axis might still have room is the one that was not tested properly: heavily
+I/O-bound decode. On DeepSeek V4 Flash the same device reads 1300 MiB per token with 360 ms of
+stall and 335 000 minor faults, against Qwen3.6's 64 MiB and 24 ms. That run needs the two faults
+above fixed first, and a budget above the token cycle.
 
 ## Explicit control
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -69,6 +69,17 @@ BMOE_PROGRESS {"step":<int>,"steps":<int>,"wall_ms":<float>,"io_ms":<float>,
   near 100% is genuinely compute-bound, well below means the cores were throttled, preempted, or
   blocked (a low-clock frequency cap or a co-resident process), not doing more math. Both are `0`
   when the platform can't report them (the Windows host build); treat `0` as "unmeasured".
+- `minflt` / `minflt_mib` are the **expert cache's own page cost**, and they are invisible in
+  `mgmt_ms` by construction. Evicting an entry releases its pages, so the next miss reads into an
+  address the kernel must hand back and zero before the read can land, and that happens inside the
+  reader, long after `vm_commit` returned (on POSIX it is a no-op; pages arrive on first touch).
+  Read `minflt_mib` against `read_bytes`: a ratio near 1 means every streamed byte lands in a page
+  that was zeroed for it first, and the zeroing is pure waste. `--cache-slot-bank` drives this to
+  zero by committing the bank once and overwriting slots instead of releasing them. Measured on the
+  host on Qwen3.6-35B at `--cache-mb 2000`: 61 323 faults and 239.7 MiB re-faulted per token against
+  239.7 MiB read, going to 0 with a 32-slot bank. `0` when unmeasured. Note that the Windows host
+  reports this one (as soft+hard `PageFaultCount`) even though `majflt`/`cpu_ms` stay unmeasured
+  there, because the host cache really does decommit and recommit.
 - `dense_resident_frac` is the sampled fraction of the DENSE (non-expert) weights still in RAM (by
   `mincore`, throttled). Under `--dense-weights anon` it samples our own buffers (is zram holding
   them?); under mmap/warm the model's mmap (is the kernel dropping it?). A diagnostic read alongside
@@ -270,7 +281,7 @@ next to the `turn` column.
 step,steps,wall_ms,io_ms,compute_ms,read_bytes,cache_hit_pct,stall_ms,mgmt_ms,majflt,cpu_ms,
 dense_resident_frac,turn,majflt_mib,cache_budget_mib,rss_mib,rss_anon_mib,rss_file_mib,swap_mib,
 mem_available_mib,mem_free_mib,swap_free_mib,loop_overhead_ms,mtp_batch,mtp_draft_ms,drain_ms,
-adopt_ms,ra_issue_ms,ra_wd_ms
+adopt_ms,ra_issue_ms,ra_wd_ms,minflt,minflt_mib
 ```
 
 `stall_ms`, `mgmt_ms`, `majflt`, `cpu_ms` and `dense_resident_frac` are trailing columns appended
@@ -280,7 +291,8 @@ dense-residency probe); `majflt`/`cpu_ms` are the fault + CPU-time decomposition
 residual (see the `BMOE_PROGRESS` notes above), `0` when unmeasured; `dense_resident_frac` is the
 sampled dense-weight residency, `-1` when unmeasured. All are additive: older CSVs have fewer columns,
 so consumers must read by column NAME (from the header row) and treat any as optional. The `# summary`
-line likewise gains `stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>`, `cpu_s/tok=<s>`,
+line likewise gains `stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>`, `minflt/tok=<f>`,
+`cpu_s/tok=<s>`,
 `token_demand_MiB=<f>` (the expert bytes one token routes, measured — where cache hits start, NOT a
 floor to defend; see [pressure.md](pressure.md)), `experts_routed=<n>` / `experts_dropped=<n>` (what
 [cache-aware dropping](expert-dropping.md) actually discarded during generation — the flag sets a

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -139,9 +139,10 @@ Three worth knowing before you turn them on:
 - **"Slot-bank cache"** (`--cache-slot-bank`) gives each layer a fixed set of expert slots whose
   memory is claimed once and reused, so evicting stops handing pages back to the system and taking
   them again. It applies while a reply is being written, not while the prompt is being read, and it
-  leaves the reply itself byte-identical. On the host it was worth +8.2 %, but the reason it won
-  there (the page work the system was doing on our behalf) behaves differently on a phone, which is
-  exactly why it ships off. See `../../docs/cache-sizing.md`.
+  leaves the reply byte-identical. It is off because the device says so: never handing memory back
+  makes the system compress it instead, and the reply then waits on decompression. Measured at
+  +2.2 % on a good run and 44 % slower on a bad one, where the difference is how much of the cache
+  the system decided to take. See `../../docs/cache-sizing.md`.
 
 - **"Ask the next layer what it wants"** (`--predict-prefetch`) predicts each layer's experts one
   layer early and fetches or retains what the prediction names. It is markedly more accurate than

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -134,7 +134,14 @@ number needs the device, the model and the day beside it to be worth anything. T
 CLI flags and the evidence behind each one lives in the docs, and the **metrics screen** keeps the
 flag names so a reading there can be matched against a CSV column.
 
-Two worth knowing before you turn them on:
+Three worth knowing before you turn them on:
+
+- **"Slot-bank cache"** (`--cache-slot-bank`) gives each layer a fixed set of expert slots whose
+  memory is claimed once and reused, so evicting stops handing pages back to the system and taking
+  them again. It applies while a reply is being written, not while the prompt is being read, and it
+  leaves the reply itself byte-identical. On the host it was worth +8.2 %, but the reason it won
+  there (the page work the system was doing on our behalf) behaves differently on a phone, which is
+  exactly why it ships off. See `../../docs/cache-sizing.md`.
 
 - **"Ask the next layer what it wants"** (`--predict-prefetch`) predicts each layer's experts one
   layer early and fetches or retains what the prediction names. It is markedly more accurate than

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -26,14 +26,15 @@ data class AppSettings(
     val mmap: Boolean = false,          // baseline: no streaming — llama.cpp mmap loads the whole model
     val cacheMb: Int = 2000,            // LRU expert cache budget; Auto / 0 / 500..6000 (see CACHE_CHOICES)
     val cacheCeilMb: Int = 3000,        // with cacheMb=Auto: upper bound on the auto budget (0 = no cap)
-    // Slot-bank cache (experimental, decode only). Off by default until the device A/B says
-    // otherwise. The bank's pages are committed once and overwritten rather than released, so
-    // eviction stops costing a syscall and a miss stops landing in a page the kernel had to zero
-    // first. On the host it removed all 61323 minor faults per token and 30 of 31 ms of cache
-    // management, for +8.2% tok/s on Qwen3.6-35B — but the fault half of that was free there
-    // (ms per MiB read did not move), so the phone is a genuinely different question.
-    // 0 = off; otherwise slots per layer, and it must not exceed the model's expert count.
-    val cacheSlotBank: Int = 0,
+    // Slot-bank cache (experimental, decode only). A plain switch: how many slots per layer it
+    // buys is the engine's arithmetic, not a number to pick — it divides the budget above rather
+    // than adding to it, giving prefill one token cycle of LRU and turning the rest into slots.
+    // The bank's pages are claimed once and overwritten rather than released, so eviction stops
+    // costing a syscall and a miss stops landing in a page the kernel had to zero first. On the
+    // host it removed all 61323 minor faults per token and 30 of 31 ms of cache management, for
+    // +8.2% tok/s on Qwen3.6-35B — but the fault half of that was free there (ms per MiB read did
+    // not move), so the phone is a genuinely different question. Off until the device A/B says.
+    val cacheSlotBank: Boolean = false,
     val ioThreads: Int = 4,             // parallel expert-read lanes
     val threads: Int = 4,               // compute threads (-t)
     val nExpertUsed: Int = 0,           // top-k override (0 = model default); lower = faster, changes output
@@ -146,8 +147,7 @@ data class AppSettings(
             }
             // Needs a live cache to sit alongside: the bank serves decode, the LRU still serves
             // prefill, and with no LRU there is no prefill home for the bytes.
-            if (cacheSlotBank > 0 && (cacheMb == CACHE_AUTO || cacheMb > 0))
-                a += listOf("--cache-slot-bank", cacheSlotBank.toString())
+            if (cacheSlotBank && (cacheMb == CACHE_AUTO || cacheMb > 0)) a += "--cache-slot-bank"
             a += listOf("--io-threads", ioThreads.toString())
             if (!oDirect) a += "--no-odirect"
             if (overlap) a += "--overlap"
@@ -211,7 +211,7 @@ data class AppSettings(
         ctx.prefs().edit()
             .putBoolean("mmap", mmap)
             .putInt("cacheMb", cacheMb).putInt("cacheCeilMb", cacheCeilMb)
-            .putInt("cacheSlotBank", cacheSlotBank)
+            .putBoolean("cacheSlotBank", cacheSlotBank)
             .putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nExpertUsed", nExpertUsed)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
@@ -313,9 +313,6 @@ data class AppSettings(
         // memory pressure on devices where free RAM is tight.
         val CACHE_CEIL_CHOICES = intArrayOf(0, 2000, 3000, 4000, 5000, 6000)
         val IO_CHOICES = intArrayOf(1, 2, 4, 8)
-        // Slots per layer for the decode-only bank. The rungs bracket what a 2000 MiB budget holds
-        // on the test model (~32/layer over 40 layers); the engine caps anything above n_expert.
-        val SLOT_BANK_CHOICES = intArrayOf(0, 16, 24, 32, 48, 64)
         // 0 = model default (top-k as trained). 6/4/3/2 trade output quality for tok/s (fewer routed experts).
         val N_EXPERT_CHOICES = intArrayOf(0, 6, 4, 3, 2)
         val PREFETCH_CHOICES = intArrayOf(0, 1, 2, 4)
@@ -341,7 +338,7 @@ data class AppSettings(
                 mmap = p.getBoolean("mmap", d.mmap),
                 cacheMb = p.getInt("cacheMb", d.cacheMb),
                 cacheCeilMb = p.getInt("cacheCeilMb", d.cacheCeilMb),
-                cacheSlotBank = p.getInt("cacheSlotBank", d.cacheSlotBank),
+                cacheSlotBank = p.getBoolean("cacheSlotBank", d.cacheSlotBank),
                 ioThreads = p.getInt("ioThreads", d.ioThreads),
                 threads = p.getInt("threads", d.threads),
                 nExpertUsed = p.getInt("nExpertUsed", d.nExpertUsed),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -26,6 +26,14 @@ data class AppSettings(
     val mmap: Boolean = false,          // baseline: no streaming — llama.cpp mmap loads the whole model
     val cacheMb: Int = 2000,            // LRU expert cache budget; Auto / 0 / 500..6000 (see CACHE_CHOICES)
     val cacheCeilMb: Int = 3000,        // with cacheMb=Auto: upper bound on the auto budget (0 = no cap)
+    // Slot-bank cache (experimental, decode only). Off by default until the device A/B says
+    // otherwise. The bank's pages are committed once and overwritten rather than released, so
+    // eviction stops costing a syscall and a miss stops landing in a page the kernel had to zero
+    // first. On the host it removed all 61323 minor faults per token and 30 of 31 ms of cache
+    // management, for +8.2% tok/s on Qwen3.6-35B — but the fault half of that was free there
+    // (ms per MiB read did not move), so the phone is a genuinely different question.
+    // 0 = off; otherwise slots per layer, and it must not exceed the model's expert count.
+    val cacheSlotBank: Int = 0,
     val ioThreads: Int = 4,             // parallel expert-read lanes
     val threads: Int = 4,               // compute threads (-t)
     val nExpertUsed: Int = 0,           // top-k override (0 = model default); lower = faster, changes output
@@ -136,6 +144,10 @@ data class AppSettings(
                 // small rungs exist precisely to probe that floor, so send the override with them.
                 if (cacheNeedsForce(cacheMb)) a += "--force-cache"
             }
+            // Needs a live cache to sit alongside: the bank serves decode, the LRU still serves
+            // prefill, and with no LRU there is no prefill home for the bytes.
+            if (cacheSlotBank > 0 && (cacheMb == CACHE_AUTO || cacheMb > 0))
+                a += listOf("--cache-slot-bank", cacheSlotBank.toString())
             a += listOf("--io-threads", ioThreads.toString())
             if (!oDirect) a += "--no-odirect"
             if (overlap) a += "--overlap"
@@ -199,6 +211,7 @@ data class AppSettings(
         ctx.prefs().edit()
             .putBoolean("mmap", mmap)
             .putInt("cacheMb", cacheMb).putInt("cacheCeilMb", cacheCeilMb)
+            .putInt("cacheSlotBank", cacheSlotBank)
             .putInt("ioThreads", ioThreads).putInt("threads", threads)
             .putInt("nExpertUsed", nExpertUsed)
             .putInt("nPredict", nPredict).putBoolean("oDirect", oDirect)
@@ -300,6 +313,9 @@ data class AppSettings(
         // memory pressure on devices where free RAM is tight.
         val CACHE_CEIL_CHOICES = intArrayOf(0, 2000, 3000, 4000, 5000, 6000)
         val IO_CHOICES = intArrayOf(1, 2, 4, 8)
+        // Slots per layer for the decode-only bank. The rungs bracket what a 2000 MiB budget holds
+        // on the test model (~32/layer over 40 layers); the engine caps anything above n_expert.
+        val SLOT_BANK_CHOICES = intArrayOf(0, 16, 24, 32, 48, 64)
         // 0 = model default (top-k as trained). 6/4/3/2 trade output quality for tok/s (fewer routed experts).
         val N_EXPERT_CHOICES = intArrayOf(0, 6, 4, 3, 2)
         val PREFETCH_CHOICES = intArrayOf(0, 1, 2, 4)
@@ -325,6 +341,7 @@ data class AppSettings(
                 mmap = p.getBoolean("mmap", d.mmap),
                 cacheMb = p.getInt("cacheMb", d.cacheMb),
                 cacheCeilMb = p.getInt("cacheCeilMb", d.cacheCeilMb),
+                cacheSlotBank = p.getInt("cacheSlotBank", d.cacheSlotBank),
                 ioThreads = p.getInt("ioThreads", d.ioThreads),
                 threads = p.getInt("threads", d.threads),
                 nExpertUsed = p.getInt("nExpertUsed", d.nExpertUsed),

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -118,17 +118,14 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 Hint(current.denseWeights.blurb)
 
                 ExperimentalGroup {
-                    IntSetting(
-                        "Slot-bank cache (slots/layer)", AppSettings.SLOT_BANK_CHOICES, current.cacheSlotBank,
-                        format = { if (it == 0) "off" else "$it" },
-                        enabled = stream && cacheOn,
-                    ) { onChange(current.copy(cacheSlotBank = it)) }
-                    Hint(
+                    SwitchRow(
+                        "Slot-bank cache",
                         "Gives each layer a fixed set of expert slots whose memory is claimed once and " +
-                            "reused. Evicting then costs nothing instead of handing pages back to the " +
-                            "system and taking them again. Decode only; the prompt still uses the normal " +
-                            "cache, so the bank starts cold on the first word of a reply."
-                    )
+                            "reused, so evicting costs nothing instead of handing pages back to the system " +
+                            "and taking them again. It divides the cache size you already chose, it does " +
+                            "not add to it. Applies while a reply is written, not while the prompt is read.",
+                        current.cacheSlotBank, enabled = stream && cacheOn,
+                    ) { onChange(current.copy(cacheSlotBank = it)) }
                     IntSetting(
                         "Temporal prefetch (layers)", AppSettings.PREFETCH_CHOICES, current.prefetchLayers,
                         format = { if (it == 0) "off" else "$it" },

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -119,6 +119,17 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
 
                 ExperimentalGroup {
                     IntSetting(
+                        "Slot-bank cache (slots/layer)", AppSettings.SLOT_BANK_CHOICES, current.cacheSlotBank,
+                        format = { if (it == 0) "off" else "$it" },
+                        enabled = stream && cacheOn,
+                    ) { onChange(current.copy(cacheSlotBank = it)) }
+                    Hint(
+                        "Gives each layer a fixed set of expert slots whose memory is claimed once and " +
+                            "reused. Evicting then costs nothing instead of handing pages back to the " +
+                            "system and taking them again. Decode only; the prompt still uses the normal " +
+                            "cache, so the bank starts cold on the first word of a reply."
+                    )
+                    IntSetting(
                         "Temporal prefetch (layers)", AppSettings.PREFETCH_CHOICES, current.prefetchLayers,
                         format = { if (it == 0) "off" else "$it" },
                         // Mutually exclusive with predictive prefetch: two predictors would speculate


### PR DESCRIPTION
> **Draft, and not proposed for merge as it stands.** The device measured the slot bank as a
> negative on Android. What is worth keeping here is the telemetry and the demonstrated seam; the
> flag itself is parked. The history of this branch, including a wrong claim it carried for an
> hour, is left intact because the correction is the useful part.

## What this is

Two things: a metric that exposes a cost the streaming path was paying invisibly, and an opt-in
cache mode that removes it. The metric is the keeper. The mode works exactly as designed and still
loses on a phone, for a reason worth writing down.

## The cost, and why nothing could see it

The expert cache is direct-mapped by construction. `mul_mat_id` reads expert `e` at
`data + e*nb2`, so every expert has one address, and the only way to hold a byte budget is to
release the pages of whatever gets evicted. The next miss then reads into an address the kernel
must hand back and **zero** first, and the read overwrites every byte of that zeroing.

None of it reaches `mgmt_ms`. On POSIX `vm_commit` is a no-op, so the page materialises later, on
first touch, inside the reader, and bills `io`/`stall`/`compute`.

`minflt` and `minflt_mib` now travel with every token and in the run summary. Read against
`read_bytes`, the ratio is the finding, and it is the same on both platforms: **1.04 minor faults
per 4 KiB streamed** on device, 1.00 on host. Every streamed byte lands in a page zeroed for it
first.

## The lever

`--cache-slot-bank` gives each layer slots whose pages are claimed once and never released.
Eviction becomes a reassignment; a miss overwrites bytes already ours. What buys that is rewriting
the router's selected-expert ids to slot indices, legal because the kernel addresses `src0` as
`data + id*nb2` and never asks what the id means. The rewrite lands at the one node where no other
consumer is left to mislead: the terminal of the layer's weight chain, after `ggml_get_rows` has
taken the routing weights and before the first expert matmul.

No llama.cpp patch. This rides the existing eval-callback seam and the `tensor->data` rebinding the
streamer already does. It is a switch, not a size: the slot count is derived at load from the
budget and the per-expert bytes, and the bank comes out of `--cache-mb` rather than adding to it.

Constraints the engine enforces rather than documents: decode only (one `mul_mat_id` serves a whole
batch, so a prefill batch would need its entire expert set banked at once); slot count capped at
`n_expert`; and architectures whose experts carry a per-expert bias or scale read the same ids
after the matmul, so the bank disarms itself.

## What the device measured

Qwen3.6-35B-A3B Q4_0, 3000 MiB budget, in-app, six runs:

| | minflt/tok | **majflt/tok** | swap | hit | read | mgmt | tok/s |
|---|---:|---:|---:|---:|---:|---:|---:|
| baseline | 14 454 | **4-116** | ~100 MiB | 73.4 % | 54.4 MiB | 6.4 ms | 7.69-7.73 |
| slot bank | 615 | **1 676-5 484** | 155-393 MiB | 70.0 % | 63.7 MiB | 0.9 ms | 4.35-8.06 |

The mechanism works: 96 % of the minor faults gone, `mgmt_ms` down to noise, output
byte-identical. It loses anyway, and `majflt` says why.

The bank is permanently dirty anonymous memory, and with a working set of `top_k` slots out of the
27 it holds, most of it is untouched at any instant. That is precisely the profile Android's
`swappiness 160` compresses into zram. The pages we refused to hand back get taken anyway and come
back as major faults. Throughput tracks the swap directly: 8.06 tok/s at 155 MiB of swap, 4.35 at
393 MiB.

`rss_anon` was *lower* with the bank (2875-2949 vs 3073), so this is not about asking for too much
memory. It is about offering the kernel a large pool of lukewarm pages.

Which inverts the premise the branch was built on. **The decommit the bank removes is not waste.**
It is how the cache tells the kernel it genuinely does not need those pages, and that is what keeps
it out of reclaim. The baseline's 14 454 cheap minor faults per token buy it 4 major ones.

## A correction

An earlier revision of this branch claimed +8.2 % on the host. That number was taken with the bank
allocated *on top of* `--cache-mb` instead of out of it, so it was measured at 2.15x the baseline's
memory. Corrected sizing gives +1.8 % on the host at equal memory, and the device figures above.
The bank was never faster; it was bigger. Fixed in 07045c1, and the trap is documented in
`docs/cache-sizing.md` so the next reader does not repeat it.

## Two design faults still in it

- **Uniform slots per layer is a worse policy than a global LRU.** Every layer gets the same count
  whether it reuses experts or not. Hit rate 73.4 % to 70.0 %, which is 17 % more flash read.
- **The disarm check is broader than the danger.** It matches any MoE node named
  `_biased`/`_scaled`, catching the harmless router bias and routing-weight scale along with the
  genuinely unsafe per-expert ones. Combined with a graph counter that waits for layer 0's top-k,
  which never appears where there are leading dense blocks, the bank silently never arms on
  DeepSeek V4, Ling 3.0 or LFM2.

## Verification

- Byte-identity gates 10/10; generated text identical to baseline over 128 tokens
- Android cross-build clean (the only build that compiles the POSIX half of `platform_io.cpp`)
- clang-format 18 clean
- Device runs in-app on the branch build

## Docs

`CHANGELOG.md`, `docs/telemetry.md` (the new columns), `docs/cache-sizing.md` (the mode, its
limits, and the measured verdict), `examples/android/README.md`.
