### PR TITLE
feat(moe): hold back dense tensors larger than RAM under every mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,16 @@ Semantic Versioning.
   largest dense tensor was an embedding or lm_head and read every dense tensor whole into its
   own buffer. On `qwen4exp` that meant Anonymous asked for a 28.8 GB allocation and Pinned hit
   the dma-buf ceiling, either way dying at load, for a table the graph touches a kilobyte at a
-  time. A dense tensor larger than the kernel's `MemAvailable` now leaves the resident set and
-  stays mmap'd, the rest of the dense weights still get the policy the run asked for, and one
-  stderr line names what stayed mapped and why. Inert on every other supported model: Qwen3.6-35B
-  reads the same 1785 MiB into the same 613 buffers as before.
+  time. A dense tensor larger than the kernel's `MemAvailable` is now held back under every mode:
+  it stays mmap'd, leaves the warm sweep and the residency sensor (which would otherwise report a
+  dense set that can never be resident), is not counted by the auto cache budget as a conversion
+  to reserve for, and gets `MADV_RANDOM` so a fault maps one page instead of a readahead window
+  the gather never touches. The rest of the dense weights still get the mode the run asked for,
+  and one stderr line names what was held back and why. The bound is size, not access shape: a
+  row-gathered table that fits keeps its mode, because demand-faulting one that fits measured
+  −16 % decode (#135). Inert on every other supported model: Qwen3.6-35B reads the same 1785 MiB
+  into the same 613 buffers under `anon`, and `warm` and `mmap` match their baselines to the
+  decimal. See [docs/android-memory.md](docs/android-memory.md).
 
 ### Added
 - **Community benchmarks.** `scripts/bench-report.sh MODEL.gguf` runs the fixed README protocol on

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -654,12 +654,13 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         std::vector<uint64_t> dense_bytes;
         if (route_trace) dense_bytes = dense_bytes_per_layer(offs, layers, n_layer_streamed);
 
-        // Anonymous dense-weights mode: hand the streamer the dense (non-expert) model weights to
-        // read into anon buffers. The list is every captured weight leaf that IS a gguf tensor
-        // (dropping graph inputs and KV, which share the leaf shape) and is NOT one of the streamed
-        // experts. Built before init consumes `layers`. Only this mode needs them; the others ignore
-        // an empty list.
-        if (cfg.moe.dense_weights == DenseWeightsMode::Anonymous || cfg.moe.dense_weights == DenseWeightsMode::Pinned) {
+        // Hand the streamer the dense (non-expert) model weights: every captured weight leaf that IS
+        // a gguf tensor (dropping graph inputs and KV, which share the leaf shape) and is NOT one of
+        // the streamed experts. Built before init consumes `layers`. Anonymous/Pinned read these into
+        // their own buffers; every mode needs the list to hold back a tensor too large to be
+        // resident at all (qwen4exp's n-gram table), which must also leave the warm sweep and the
+        // residency sensor — see DenseWeights::hold_back_oversized.
+        {
             const std::unordered_set<std::string> expert_names = expert_tensor_names(layers);
             std::vector<DenseTensorRef> dense;
             for (const auto & kv : im.hook->captured_weights()) {

--- a/core/src/io/platform_io.cpp
+++ b/core/src/io/platform_io.cpp
@@ -110,6 +110,10 @@ void vm_drop_file_pages(void * /*p*/, size_t /*sz*/) {
     // and the host build never mmaps the model for streaming — so there is nothing to drop.
 }
 
+void vm_advise_random(void * /*p*/, size_t /*sz*/) {
+    // No readahead to tame on a host build that never streams; the gates do not measure I/O.
+}
+
 // Unmeasured on the host build, like the fault counters below and for the same reason: the gates
 // prove byte-identity, they do not size a cache against a phone's reclaim. QueryWorkingSetEx could
 // answer this, but nothing here consumes it.
@@ -216,6 +220,12 @@ void vm_drop_file_pages(void * p, size_t sz) {
     // next access refaults them from the file. The tensor was rebound onto its anon copy, so nothing
     // touches this range again — the drop just reclaims the double residency, it does not lose data.
     if (sz) madvise(p, sz, MADV_DONTNEED);
+}
+
+void vm_advise_random(void * p, size_t sz) {
+    // MADV_RANDOM disables readahead for the range: each fault maps exactly the page that faulted.
+    // Advice only, so a failure changes nothing but the readahead and is not worth reporting.
+    if (sz) madvise(p, sz, MADV_RANDOM);
 }
 
 bool vm_resident_sample(const void * p, size_t sz, size_t * sampled, size_t * resident) {

--- a/core/src/io/platform_io.h
+++ b/core/src/io/platform_io.h
@@ -84,6 +84,14 @@ void vm_release(void * p, size_t sz);
 // VirtualFree-able, and the host build never streams). The range must be page-aligned by the caller.
 void vm_drop_file_pages(void * p, size_t sz);
 
+// Tell the kernel a FILE-BACKED range will be touched at random, so a fault brings in the page that
+// faulted and nothing around it. The default is sequential readahead sized in the hundreds of KiB
+// per fault, which is right for a weight that is read whole and wrong by two orders of magnitude for
+// a table the graph gathers a few rows from per token: the neighbours are never used, and they
+// occupy page cache the expert cache is competing for. A no-op on the Windows host (no streaming
+// there). The range must be page-aligned by the caller.
+void vm_advise_random(void * p, size_t sz);
+
 // How many of a committed range's pages the kernel still has in RAM. Counts only the pages fully
 // inside [p, p+sz) — the same clipping vm_evict's callers apply — and ADDS to *sampled/*resident,
 // so several ranges can be summed into one fraction (the caller zeroes them first).

--- a/core/src/moe/dense_weights.cpp
+++ b/core/src/moe/dense_weights.cpp
@@ -43,38 +43,12 @@ bool DenseWeights::init(DenseWeightsMode mode,
         basenames_.push_back(slash == std::string::npos ? p : p.substr(slash + 1));
     }
 
+    hold_back_oversized();
+
     if (mode_ == DenseWeightsMode::Anonymous || mode_ == DenseWeightsMode::Pinned) {
-        if (tensors_.empty()) return true; // nothing captured to rebind — behave as Mmap
-        // A dense tensor bigger than the memory the kernel says is available cannot be made
-        // resident by any policy: the read either fails or succeeds and takes the process with it.
-        // Such a tensor stays mmap'd and leaves the set entirely, so neither the read below nor
-        // drop_mmap_copies touches it, and the rest of the dense weights still get the policy the
-        // run asked for. Until qwen4exp this could not happen — the largest dense tensor was an
-        // embedding or lm_head — but its n-gram table (`per_layer_token_embd`, ~28.8 GB at IQ4_NL)
-        // exceeds any phone's RAM while being read a kilobyte at a time, so mmap is the only policy
-        // it can have. The bound is the kernel's own MemAvailable rather than a constant: it is the
-        // one number that already accounts for what this device can still hand out.
-        if (const uint64_t avail = pio::mem_available_bytes()) {
-            std::vector<DenseTensorRef> keep;
-            keep.reserve(tensors_.size());
-            uint64_t left_mapped = 0;
-            for (const DenseTensorRef & d : tensors_) {
-                if (d.size > avail) {
-                    left_mapped += d.size;
-                } else {
-                    keep.push_back(d);
-                }
-            }
-            const size_t n_left = tensors_.size() - keep.size();
-            tensors_ = std::move(keep);
-            if (left_mapped) {
-                std::fprintf(stderr,
-                             "bmoe: dense-weights=%s — %llu MiB in %zu tensor(s) exceeds the %llu MiB "
-                             "available and stays mmap'd\n",
-                             mode_ == DenseWeightsMode::Pinned ? "ahwb" : "anon",
-                             (unsigned long long) (left_mapped >> 20), n_left, (unsigned long long) (avail >> 20));
-            }
-            if (tensors_.empty()) return true; // all of it stayed mapped — behave as Mmap
+        if (tensors_.empty()) { // nothing (left) to rebind — behave as Mmap
+            advise_random_mapped();
+            return true;
         }
         if (mode_ == DenseWeightsMode::Pinned && pio::pinned_max_bytes() == 0) {
             std::fprintf(stderr, "bmoe: --dense-weights ahwb needs reclaim-exempt memory, which this "
@@ -98,7 +72,94 @@ bool DenseWeights::init(DenseWeightsMode mode,
     } else if (mode_ == DenseWeightsMode::Warmed) {
         warm();
     }
+    advise_random_mapped();
     return true;
+}
+
+static const char * mode_flag(DenseWeightsMode m) {
+    switch (m) {
+    case DenseWeightsMode::Mmap:
+        return "mmap";
+    case DenseWeightsMode::Warmed:
+        return "warm";
+    case DenseWeightsMode::Anonymous:
+        return "anon";
+    case DenseWeightsMode::Pinned:
+        return "ahwb";
+    }
+    return "?";
+}
+
+// Remove [a, b) from a sorted list of disjoint [first, second) ranges, splitting the one it falls in.
+static void subtract_range(std::vector<std::pair<uint64_t, uint64_t>> & ranges, uint64_t a, uint64_t b) {
+    std::vector<std::pair<uint64_t, uint64_t>> out;
+    out.reserve(ranges.size() + 1);
+    for (const auto & r : ranges) {
+        if (b <= r.first || a >= r.second) {
+            out.push_back(r); // disjoint
+            continue;
+        }
+        if (r.first < a) out.push_back({r.first, a});
+        if (b < r.second) out.push_back({b, r.second});
+    }
+    ranges.swap(out);
+}
+
+// ── Oversized dense tensors: mmap'd under every mode ─────────────────────────────────
+//
+// A dense tensor bigger than the memory the kernel says is available cannot be resident under any
+// mode: Anonymous/Pinned would ask for an allocation that fails or takes the process with it, and
+// Warmed would sweep it through a page cache it cannot fit in, evicting itself as it goes. Until
+// qwen4exp this could not happen — the largest dense tensor was an embedding or lm_head — but its
+// n-gram table (`per_layer_token_embd`, ~28.8 GB at IQ4_NL) exceeds any phone's RAM while the graph
+// gathers a few rows from it per token, so mmap is the only residency it can have. Such a tensor
+// leaves the set entirely: not read, not rebound, not dropped, not warmed, and not sampled — a
+// sensor that counted it would report a dense set that can never be resident. The rest of the
+// dense weights still get the mode the run asked for.
+//
+// The bound is the kernel's own MemAvailable rather than a constant, because it is the one number
+// that already accounts for what this device can still hand out; a tensor that FITS keeps its
+// mode even when it is row-gathered, since demand-faulting a table that fits costs more in prefill
+// than reading it once sequentially at load (measured: token_embd left mmap'd lost 16 % decode).
+void DenseWeights::hold_back_oversized() {
+    mapped_.clear();
+    const uint64_t avail = pio::mem_available_bytes();
+    if (!avail) return; // unmeasured on this platform: hold nothing back, as before
+    std::vector<DenseTensorRef> keep;
+    keep.reserve(tensors_.size());
+    uint64_t held = 0;
+    for (const DenseTensorRef & d : tensors_) {
+        if (d.size <= avail) {
+            keep.push_back(d);
+            continue;
+        }
+        mapped_.push_back(d);
+        held += d.size;
+        if (d.file_idx >= 0 && (size_t) d.file_idx < ranges_.size())
+            subtract_range(ranges_[(size_t) d.file_idx], d.file_off, d.file_off + d.size);
+    }
+    tensors_ = std::move(keep);
+    if (held)
+        std::fprintf(stderr,
+                     "bmoe: dense-weights=%s — %llu MiB in %zu tensor(s) exceeds the %llu MiB available: left "
+                     "mmap'd with random-access advice, outside the warm sweep and the residency sensor\n",
+                     mode_flag(mode_), (unsigned long long) (held >> 20), mapped_.size(),
+                     (unsigned long long) (avail >> 20));
+}
+
+void DenseWeights::advise_random_mapped() {
+    if (mapped_.empty()) return;
+    resolve_vmas();
+    const size_t page = pio::vm_page();
+    for (const DenseTensorRef & d : mapped_) {
+        const char * a = addr_of(d.file_idx, d.file_off);
+        if (!a) continue;
+        // Inward to whole pages, as drop_mmap_copies does: the edge pages are shared with neighbours
+        // that keep their own access pattern, and on a table this size two pages are nothing.
+        uintptr_t a0 = ((uintptr_t) a + page - 1) & ~(uintptr_t) (page - 1);
+        uintptr_t a1 = ((uintptr_t) a + d.size) & ~(uintptr_t) (page - 1);
+        if (a1 > a0) pio::vm_advise_random((void *) a0, (size_t) (a1 - a0));
+    }
 }
 
 // ── Anonymous / Pinned: read each dense tensor whole into our own buffer and rebind onto it ──

--- a/core/src/moe/dense_weights.h
+++ b/core/src/moe/dense_weights.h
@@ -54,9 +54,10 @@ public:
     byte_ranges(std::vector<std::pair<uint64_t, uint64_t>> expert_ranges, uint64_t file_size);
 
     // Apply `mode` for the model files `paths` (per-shard dense `ranges` precomputed via byte_ranges;
-    // `tensors` needed only for Anonymous/Pinned). `align` is the O_DIRECT block size. Runs once at
-    // load, before the streamer's workers start (Anonymous rebinds tensor->data on the caller's
-    // thread). Returns false only on a hard Anonymous failure (alloc/read); Mmap and Warmed cannot fail.
+    // `tensors` is what Anonymous/Pinned read, and what every mode checks for a tensor too large to
+    // be resident — see hold_back_oversized). `align` is the O_DIRECT block size. Runs once at load,
+    // before the streamer's workers start (Anonymous rebinds tensor->data on the caller's thread).
+    // Returns false only on a hard Anonymous failure (alloc/read); Mmap and Warmed cannot fail.
     bool init(DenseWeightsMode mode,
               const std::vector<std::string> & paths,
               size_t align,
@@ -74,6 +75,13 @@ public:
     static constexpr int sample_pages = 256; // stratified probe points across the dense bytes
 
 private:
+    // A dense tensor larger than the memory the kernel says is available cannot be resident under
+    // any mode. Moves such tensors from `tensors_` to `mapped_`, carves their bytes out of `ranges_`
+    // (so neither the warm sweep nor the sensor treats them as dense the run could hold), and says so.
+    void hold_back_oversized();
+    // Random-access advice on the mmap of every held-back tensor: a fault brings in one page, not a
+    // readahead window the gather will never touch.
+    void advise_random_mapped();
     bool read_anonymous(size_t align);
     void warm();
     void drop_mmap_copies(size_t page);
@@ -93,6 +101,7 @@ private:
     // one of which is populated for a given run.
     std::vector<std::unique_ptr<FileReader>> readers_;
     std::vector<DenseTensorRef> tensors_;
+    std::vector<DenseTensorRef> mapped_; // held back by hold_back_oversized: mmap'd under every mode
     std::vector<void *> bases_;
     std::vector<void *> bufs_;
     std::vector<pio::PinnedAlloc> pinned_;

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -95,8 +95,12 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
         // had already happened.
         if (cfg.dense_weights == DenseWeightsMode::Anonymous || cfg.dense_weights == DenseWeightsMode::Pinned) {
             uint64_t dense_pending = 0;
+            // The same rule dense_.init applies below: a tensor larger than what is available is
+            // never converted, it stays mmap'd (qwen4exp's ~28.8 GB n-gram table). Counting it here
+            // would reserve the whole of RAM for a conversion that will not happen and size the
+            // cache to nothing.
             for (const DenseTensorRef & d : dense_tensors_)
-                if (d.tensor) dense_pending += d.size;
+                if (d.tensor && d.size <= avail) dense_pending += d.size;
             const uint64_t deduct = std::min(avail, dense_pending);
             if (deduct > 0) {
                 avail -= deduct;

--- a/docs/android-memory.md
+++ b/docs/android-memory.md
@@ -216,6 +216,29 @@ effect cannot be excluded (the reversed pair is owed), and it is one device, one
 The general lesson outlives the flag: `compute_ms` has been absorbing zram decompression all along,
 so any earlier conclusion of the form *"this regime is compute-bound"* deserves re-examination.
 
+### A dense tensor larger than RAM
+
+Every mode above assumes the dense set fits. `qwen4exp` (Qwen3.8-Flash-Next) breaks that with one
+tensor: `per_layer_token_embd`, a 51B-parameter n-gram embedding table, ~28.8 GB at IQ4_NL, that the
+graph gathers sixteen rows from per token. No mode can hold it, and each would fail differently:
+`anon` asks for an allocation the OS kills the process over, `ahwb` hits the 2047 MiB dma-buf
+ceiling, `warm` would sweep 28.8 GB through a page cache that evicts it as it goes, and the residency
+sensor would report a dense set that can never be resident. So the engine applies one rule before
+any mode: a dense tensor larger than the kernel's `MemAvailable` is held back. It stays mmap'd, leaves
+the warm sweep and the sensor, and the auto cache budget does not reserve for a conversion that will
+not happen. One stderr line names what was held back.
+
+The held-back mapping also gets `MADV_RANDOM`. Default readahead brings in a window of hundreds of
+KiB per fault, right for a weight read whole and wrong by two orders of magnitude for a row gather:
+the neighbours are never touched and they take page cache the expert cache is competing for. With
+the advice a fault maps one page. Per token that is sixteen 4 KiB reads, under 1 % of a decode step;
+the cost that remains is prefill, where every prompt token faults its rows on the compute thread.
+Not measured on a device yet.
+
+The size bound is deliberate and the access shape is not the criterion: a row-gathered table that
+*fits* keeps its mode, because demand-faulting it costs more in prefill than reading it once at load
+(`token_embd` left mmap'd measured −16 % decode, [PR #135](https://github.com/Helldez/BigMoeOnEdge/pull/135)).
+
 ## Why restoring reclaimed pages cannot win
 
 `MADV_WILLNEED` on anon does swap them back in — but `read_swap_cache_async` puts them on the


### PR DESCRIPTION
Was stacked on #172, now on `main` after that merge. Engine behaviour rather than architecture support, so it is reviewed on its own, but it can only be exercised by the model that PR adds.

### The problem

The dense policy assumes the dense set fits. Qwen3.8-Flash-Next breaks that with one tensor, `per_layer_token_embd`: a 51B-parameter n-gram table, ~28.8 GB at IQ4_NL, that the graph gathers sixteen rows from per token. Every mode fails its own way on it. `anon` asks for an allocation the OS kills the process over, `ahwb` hits the 2047 MiB dma-buf ceiling, `warm` would sweep 28.8 GB through a page cache that evicts it as it goes, and the residency sensor would report a dense set that can never be resident. #172 guards `anon` and `ahwb` only.

### The rule

Before any mode: a dense tensor larger than the kernel's `MemAvailable` is held back. It stays mmap'd, its bytes leave the dense ranges so neither the warm sweep nor the sensor see it, the auto cache budget stops reserving for a conversion that will not happen (counting it would have reserved the whole of RAM and sized the cache to nothing), and one stderr line names what was held back. The rest of the dense weights get the mode the run asked for.

The held-back mapping gets `MADV_RANDOM`. Default readahead pulls a window of hundreds of KiB per fault, right for a weight read whole and wrong by two orders of magnitude for a row gather: the neighbours are never touched and they take page cache the expert cache is competing for. With the advice a fault maps one page.

The bound is size, not access shape, on purpose: a row-gathered table that fits keeps its mode, because demand-faulting one that fits measured -16 percent decode (#135).

### Why this and not a direct-read streamer for the table

The thread on the upstream PR is asking for exactly that, and Qwen's own tech report describes the table as "deterministically addressed" and meant for "off-accelerator storage". It is the easy streaming case: the rows depend only on token ids and are known a whole layer stack before any expert address is. But on this engine it is not where the time goes. Per token the table costs sixteen 4 KiB faults, under 1 percent of a decode step, while the expert cycle is about 734 MiB (10 of 512 experts, 48 layers, ~1.53 MiB each), 2.7 times Qwen3.6-35B's. Throughput on this model lives where it always has, in expert bytes per token, and the levers for that already apply to it unchanged. A row prefetcher would also need the n-gram hashing inside the engine, the first model logic it would ever carry. The one cost this leaves open is prefill, where every prompt token faults its rows on the compute thread; that number comes from a device, not from here.

### Verified

Inert on every other supported model, Qwen3.6-35B-A3B on the host: `anon` reads the same 1785 MiB into the same 613 buffers, `warm` sweeps the same 2652 MiB, `mmap` and `auto` match their baselines to the decimal (271.36 MiB/token, 36.8 percent hit; `auto` reserves the same 1785 MiB and resolves the same budget). Byte-identity gates pass. On the 12 GB test phone with Qwen3.8-Flash-Next UD-IQ3_XXS the guard fires (the n-gram table is the one held-back tensor) and `ahwb` survives load and runs at 1.79 tok/s; `anon` survives load too but swaps 6 GB to zram, which is a RAM budget problem, not the guard's. Pre-release `v0.22.0-rc1` is cut from this branch.

### Before this leaves draft

- [x] A run on device with the stderr line present and the pinned mode surviving load
- [x] #172 merges (retarget to `main` first): merged as `927e2d3`, this PR retargeted to `main`

