### PR TITLE
feat(bench): community benchmarks: one-command host protocol, issue form, results table

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark-report.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark-report.yml
@@ -1,0 +1,71 @@
+name: Benchmark report
+description: Share a measured run of the engine on your hardware (phone, SBC, mini PC, laptop, desktop).
+title: "[bench] <hardware> / <model>"
+labels: ["benchmark"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for measuring. The protocol and the results table are in
+        [docs/community-benchmarks.md](../blob/main/docs/community-benchmarks.md). On Linux/macOS,
+        `scripts/bench-report.sh MODEL.gguf` runs the fixed protocol and prints the two tables below
+        for you; on Android use the app's telemetry panel or the CSV from `scripts/bench-run.sh`.
+        Every accepted row lands in the table with your GitHub handle.
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      description: Device or board, CPU, RAM, storage. Phones as a class is fine ("12 GB, UFS 4.x phone").
+      placeholder: "Mini PC, Intel N100 4C, 16 GB LPDDR5-4800, NVMe PCIe 3.0 x4 (WD SN770 1 TB)"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / kernel
+      placeholder: "Ubuntu 24.04, Linux 6.8"
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model and quantization
+      description: Any MoE the engine supports (`bmoe-cli --list-archs`), in any quant. Name, quant, file size, and where it came from.
+      placeholder: "Qwen3.6-35B-A3B Q4_K_M, 22.3 GB, bartowski/Qwen_Qwen3.6-35B-A3B-GGUF"
+    validations:
+      required: true
+  - type: input
+    id: engine
+    attributes:
+      label: Engine version or commit
+      placeholder: "0.21.0 (release APK)" or "7ad04fa"
+    validations:
+      required: true
+  - type: textarea
+    id: report
+    attributes:
+      label: Measured result
+      description: |
+        Paste the block `scripts/bench-report.sh` prints (both tables), or the `=== perf ===` lines
+        plus the `# summary` trailer of the CSV. tok/s alone is not enough: stall, cache hit and
+        flash/token are what make the number comparable.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Exact command
+      description: If you changed anything from the script's defaults (threads, cache, lanes, extra flags), say so here.
+      render: shell
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything unusual
+      description: Thermal throttling, other load on the machine, storage rate lower than expected, build problems on your platform.
+  - type: checkboxes
+    id: attach
+    attributes:
+      label: Raw data
+      options:
+        - label: I attached the CSV the run wrote (drag it into the issue). Optional, but it lets the row be checked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Semantic Versioning.
 
 ## [0.23.0] - 2026-08-27
 
+### Added
+- **Community benchmarks.** `scripts/bench-report.sh MODEL.gguf` runs the fixed README protocol on
+  any Linux/macOS host (256 greedy tokens, the reference prompt, auto cache, 4 lanes, overlap,
+  dense weights out of the page cache), records CPU / RAM / drive and the drive's measured
+  O_DIRECT rate at 512 KiB requests from the model file itself, and prints the two markdown tables
+  a report needs, every column read from the CSV `# summary` trailer by name. A `benchmark-report`
+  issue form collects them and [docs/community-benchmarks.md](docs/community-benchmarks.md) holds
+  the protocol, the hardware wanted and the results table, seeded with the README rows. Any
+  supported MoE in any quantization is a row; the catalog models are listed as the ones that line
+  up with the README, not as a requirement.
+
 ### Changed
 - **Telemetry attribution stops calling unmeasured runtime "compute".** Overlap `stall` is now the
   **union of stalled intervals** — the cumulative wall time during which at least one compute thread

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ cd build && ctest --output-on-failure
 
 ## Good first contributions
 
+- **A benchmark on hardware we do not have.** No code needed: `scripts/bench-report.sh MODEL.gguf`
+  runs the fixed protocol and prints the tables; open a
+  [benchmark report](https://github.com/Helldez/BigMoeOnEdge/issues/new?template=benchmark-report.yml).
+  See `docs/community-benchmarks.md` for the hardware list and what a row needs.
 - A new MoE architecture recipe + its gate (`docs/adding-a-model.md`).
 - Read coalescing / expert-contiguous layout experiments (see `docs/roadmap.md`).
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,21 @@ Anything not measured is named as unmeasured. That is the rule the roadmap's
 [recorded negative results](docs/roadmap.md) exist to enforce: a simulation that predicted a win and
 a device that then delivered a 30% loss is why nothing here is published on an argument alone.
 
+### Measure it on your hardware
+
+Every row above comes from one phone and one laptop. NVMe mini PCs, ARM boards with a PCIe slot,
+other phones and unified-memory desktops are the machines we have not measured, and on Linux or
+macOS one command runs the fixed protocol on any supported MoE, in any quant, and prints the
+tables to paste into a
+[benchmark report](https://github.com/Helldez/BigMoeOnEdge/issues/new?template=benchmark-report.yml):
+
+```bash
+scripts/bench-report.sh /path/to/any-moe-model.gguf
+```
+
+Accepted rows land in [docs/community-benchmarks.md](docs/community-benchmarks.md) with your name,
+next to the stall, cache-hit and flash-per-token columns that make a tok/s figure comparable.
+
 ## Quickstart
 
 ### Host (Linux, macOS, Windows)
@@ -426,6 +441,8 @@ or reproduce the measurements. Most-wanted entry points:
 - [docs/adding-a-model.md](docs/adding-a-model.md): supporting a new MoE architecture.
 - [docs/benchmarks.md](docs/benchmarks.md): measured results and
   [how they were produced](docs/benchmark-method.md).
+- [docs/community-benchmarks.md](docs/community-benchmarks.md): results on hardware we do not own,
+  and how to add yours.
 - [docs/telemetry.md](docs/telemetry.md): the per-token line protocol, the CSV schema and the traces.
 - [docs/android-memory.md](docs/android-memory.md): what reclaims the engine's memory on a phone.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ for the idea the project is built on.
 | [benchmarks.md](benchmarks.md) | Measured results per model on Android, with device-pressure numbers. |
 | [benchmarks-gpt-oss.md](benchmarks-gpt-oss.md) | gpt-oss-120b: a 58 GB model at 5.2× device RAM, and what it costs. |
 | [benchmark-method.md](benchmark-method.md) | How the numbers are produced, so you can reproduce them. |
+| [community-benchmarks.md](community-benchmarks.md) | Results on hardware we do not own, the one-command protocol (`scripts/bench-report.sh`), and how to submit a row. |
 | [warmup-analysis.md](warmup-analysis.md) | Why first tokens are slow, and the two regimes behind it. |
 | [bench-data/](bench-data/) | Raw per-run CSVs and session notes. A dated archive — see its README. |
 

--- a/docs/community-benchmarks.md
+++ b/docs/community-benchmarks.md
@@ -1,0 +1,105 @@
+# Community benchmarks
+
+Every number in the README was measured on one phone (12 GB RAM, UFS 4.x) and one Windows laptop.
+The engine builds and runs unmodified on any Linux or macOS machine with a fast drive, and the
+question this page exists to answer is simple: **what does expert streaming do on hardware we do
+not own?** NVMe boards, mini PCs, other phones, Apple silicon, ARM SBCs with a PCIe slot.
+
+If you have one of those and ten minutes, run the protocol below and open a
+[benchmark report](https://github.com/Helldez/BigMoeOnEdge/issues/new?template=benchmark-report.yml).
+Accepted rows land in the table with your GitHub handle. You do not need to know the code.
+
+## Hardware we want to see
+
+In rough priority order, because each one answers a different question:
+
+| Class | Examples | What it tells us |
+|---|---|---|
+| NVMe mini PC, 16 GB | Intel N100/N150, Ryzen 3500U/5560U with a PCIe 3.0 x4 drive | Does a real NVMe queue remove the flash stall the phone shows? |
+| NVMe mini PC, 32-64 GB DDR5 | Ryzen 7840HS/8845HS, Core Ultra | Where the >RAM regime starts on a fast CPU |
+| ARM SBC with PCIe | RK3588 boards, Qualcomm Dragonwing boards, Raspberry Pi 5 (x1 lane, expected slow) | ARM Linux with a drive faster than UFS |
+| Unified-memory desktops | Ryzen AI Max (Strix Halo) 64/128 GB, Mac mini/Studio | The far end: the 284B DeepSeek past 128 GB |
+| Other phones | Snapdragon 8 Gen 2/3/Elite, Dimensity 9x00, Tensor | Same class as the reference device; does the number hold? |
+
+## The protocol
+
+One run, fixed settings, the same prompt as every README table, 256 greedy tokens. The settings
+are the ones that win on the reference phone (`docs/benchmark-method.md`), not tuned per machine,
+so rows are comparable across hardware.
+
+```bash
+git clone --recursive https://github.com/Helldez/BigMoeOnEdge.git
+cd BigMoeOnEdge
+scripts/bench-report.sh /path/to/any-moe-model.gguf
+```
+
+The script builds the CLI if needed, records CPU / RAM / drive, measures the drive's O_DIRECT
+read rate at 512 KiB requests **from the model file itself** (the request size the expert stream
+issues), runs the protocol and prints two markdown tables ready to paste. Defaults:
+`min(8, cores)` threads, 4 read lanes, auto-sized cache, `--overlap`, `--dense-weights anon`.
+Override with `THREADS=`, `IO_THREADS=`, `CACHE_MB=`, `N_PREDICT=`; extra flags after the model
+path go to `bmoe-cli` verbatim.
+
+**Any MoE the engine supports, in any quantization, is a valid row.** `bmoe-cli --list-archs`
+prints the architectures; the quant is whatever gguf you have, and the row records it. A different
+quant of the same model is its own row: the expert bytes per token change with the quant, so the
+flash column does too, and that comparison is one of the things the table is for.
+
+The models the app catalog ships, if you want a row that lines up with the README directly:
+
+| Model | Catalog quant | Size | Download | Notes |
+|---|---|---:|---|---|
+| Qwen3.6-35B-A3B | Q4_K_M | 22.3 GB | [bartowski/Qwen_Qwen3.6-35B-A3B-GGUF](https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF) | the README's reference row |
+| Qwen3-30B-A3B | Q4_K_M | 18.5 GB | [unsloth/Qwen3-30B-A3B-GGUF](https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF) | |
+| Gemma-4-26B-A4B-it | Q4_K_M | 17.0 GB | [bartowski/google_gemma-4-26B-A4B-it-GGUF](https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF) | |
+| gpt-oss-120b | Q4_K_M | 62.8 GB | [unsloth/gpt-oss-120b-GGUF](https://huggingface.co/unsloth/gpt-oss-120b-GGUF) | add `--no-think`; pass the first shard |
+| DeepSeek V4 Flash 0731 | UD-IQ2_M | 90.9 GB | [unsloth/DeepSeek-V4-Flash-0731-GGUF](https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF) | pass the first shard |
+| Qwen3.8-Flash-Next | UD-IQ3_XXS | 82.0 GB | [unsloth/Qwen3.8-Flash-Next-GGUF](https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF) | needs engine 0.22.0+; pass the first shard |
+
+A model **smaller than your RAM** is still a valid row: it shows the streaming overhead against
+plain llama.cpp on that machine. Say which regime you are in; the script prints model size and RAM
+side by side.
+
+### What makes a row comparable
+
+The script fills these in from the engine's own telemetry (`docs/telemetry.md`); a bare tok/s
+without them cannot be placed in the table.
+
+| Column | Meaning | Why it matters |
+|---|---|---|
+| Decode tok/s, Prefill tok/s | generation and prompt throughput | the headline, and the two are limited by different things |
+| Stall s/tok | time per token the compute waited for flash | the flash bottleneck, isolated; the number NVMe should shrink |
+| Compute s/tok | time per token in the expert math and cache management | the CPU bottleneck, isolated |
+| Flash/token | MiB read from the drive per generated token | whether the cache is working |
+| Cache hit | share of expert reads served from RAM | same, from the other side |
+| majflt/tok | major page faults per token | non-zero means the dense weights were being evicted mid-run: the OS, not the engine, is in charge |
+| Storage read, 512 KiB O_DIRECT | the drive's raw rate at the engine's request size | the ceiling; stall well above `Flash/token ÷ rate` means a request-size or queue problem, not bandwidth |
+
+On a phone, the app's telemetry panel and the CSV from `scripts/bench-run.sh` carry the same
+fields.
+
+### Doing it honestly
+
+- Nothing else heavy running. A browser with fifty tabs is heavy.
+- Passive-cooled boards throttle: run it twice, report the second, and say if the two differ.
+- If the storage probe reads far below the drive's rating, say so; a DRAM-less SSD or a PCIe x1
+  slot is a result in itself, and often the most useful one.
+- The first run after download has the file's head in the page cache. The probe skips a quarter
+  into the file for that reason; the engine run uses O_DIRECT and is not affected.
+
+## Results
+
+Rows are ordered by hardware class. "maintainer" rows are the ones already in the README, measured
+with the same protocol over `adb` on the reference phone and on the Windows laptop. Phone rows
+name the device class, not the model, on purpose.
+
+| Hardware | Storage (512 KiB rate) | Model, quant | k | Cache | Decode tok/s | Prefill tok/s | Stall s/tok | Flash/token | Cache hit | Engine | By |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|
+| Phone, 12 GB RAM, Snapdragon class | UFS 4.x (~2300 MiB/s) | Qwen3.6-35B-A3B Q4_K_M | 8 | 3000 MiB | 5.0 | n/a | n/a | 144 MiB | 65% | 0.21.0 | maintainer |
+| Phone, 12 GB RAM, Snapdragon class | UFS 4.x (~2300 MiB/s) | Qwen3-30B-A3B Q4_K_M | 8 | auto, cap 4000 | 5.2 | n/a | n/a | 225 MiB | 76% | 0.21.0 | maintainer |
+| Phone, 12 GB RAM, Snapdragon class | UFS 4.x (~2300 MiB/s) | Gemma-4-26B-A4B Q4_K_M | 8 | 4000 MiB | 4.1 | n/a | n/a | 144 MiB | 82% | 0.21.0 | maintainer |
+| Phone, 12 GB RAM, Snapdragon class | UFS 4.x (~2300 MiB/s) | gpt-oss-120b Q4_K_M | 2 | 2000 MiB | 2.2 | n/a | n/a | 590 MiB | 32% | 0.21.0 | maintainer |
+| Laptop, x86 8 cores, 16 GB DDR4 | NVMe | Qwen3.6-35B-A3B Q4_K_M | 8 | auto | 7.3 | n/a | n/a | 24 MiB | 92% | 0.21.0 | maintainer (`--drop-cold-experts 0.75`) |
+
+Columns the README rows did not record are `n/a`; new rows from `bench-report.sh` fill all of
+them. Full per-token CSVs for the maintainer rows are under `docs/bench-data/`.

--- a/scripts/bench-report.sh
+++ b/scripts/bench-report.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# One reproducible host benchmark, printed as a block you can paste into a benchmark-report issue
+# (docs/community-benchmarks.md). Linux first, macOS best effort.
+#
+#   scripts/bench-report.sh MODEL.gguf [extra bmoe-cli flags...]
+#
+# What it does, in order:
+#   1. builds bmoe-cli if build/cli/bmoe-cli is missing (BMOE_CLI overrides the binary);
+#   2. records the machine: CPU, cores, RAM, kernel, the drive the model sits on and its
+#      measured O_DIRECT read rate at 512 KiB requests, straight from the model file — the same
+#      request size the expert stream issues, so the number is the ceiling this engine can see;
+#   3. runs the fixed protocol from docs/benchmark-method.md: 256 greedy tokens, the same prompt
+#      every table in the README uses, streaming with an auto-sized cache, 4 read lanes,
+#      intra-layer overlap and the dense weights kept out of the page cache;
+#   4. parses the CSV trailer the engine writes and prints one markdown block.
+#
+# Env overrides: THREADS (default: min(8, online cores)), N_PREDICT (256), IO_THREADS (4),
+# CACHE_MB (auto), BENCH_OUT (.bench-report), BMOE_CLI (build/cli/bmoe-cli).
+# Anything after the model path is passed to bmoe-cli verbatim (e.g. --no-think for gpt-oss,
+# --n-expert-used 6 for the turbo top-k rows).
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ ! -f "$1" ]; then
+    echo "usage: $0 MODEL.gguf [extra bmoe-cli flags...]" >&2
+    exit 2
+fi
+MODEL="$1"; shift
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readf() { cat "$1" 2>/dev/null || true; }   # optional sysfs/procfs files: absent is not an error
+OS="$(uname -s)"
+NPROC="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+THREADS="${THREADS:-$(( NPROC < 8 ? NPROC : 8 ))}"
+N_PREDICT="${N_PREDICT:-256}"
+IO_THREADS="${IO_THREADS:-4}"
+CACHE_MB="${CACHE_MB:-auto}"
+BENCH_OUT="${BENCH_OUT:-$ROOT/.bench-report}"
+BMOE_CLI="${BMOE_CLI:-$ROOT/build/cli/bmoe-cli}"
+PROMPT="Write a long detailed essay about the history of computing including its origins its key milestones the people involved and the future directions of the field"
+
+# --- 1. binary ------------------------------------------------------------------------------
+if [ ! -x "$BMOE_CLI" ]; then
+    echo "bmoe-cli not found at $BMOE_CLI, building..." >&2
+    "$ROOT/scripts/build-host.sh" >&2
+fi
+ENGINE_VERSION="$("$BMOE_CLI" --version 2>/dev/null | head -1 || echo unknown)"
+GIT_REV="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+# --- 2. machine -----------------------------------------------------------------------------
+if [ "$OS" = "Darwin" ]; then
+    CPU_MODEL="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)"
+    RAM_GIB="$(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 ))"
+    KERNEL="macOS $(sw_vers -productVersion 2>/dev/null || uname -r)"
+    DRIVE_MODEL="unknown (macOS)"
+    DD_FLAGS=""
+else
+    CPU_MODEL="$(readf /proc/cpuinfo | sed -n 's/^model name[[:space:]]*: //p' | head -1 | sed 's/[[:space:]]*$//')"
+    # aarch64 boards usually have no "model name"; fall back to the device-tree model.
+    [ -n "$CPU_MODEL" ] || CPU_MODEL="$(readf /sys/firmware/devicetree/base/model | tr -d '\0')"
+    [ -n "$CPU_MODEL" ] || CPU_MODEL="unknown ($(uname -m))"
+    MEM_KB="$(readf /proc/meminfo | sed -n 's/^MemTotal:[[:space:]]*\([0-9]*\).*/\1/p' | head -1)"
+    RAM_GIB="$(( ${MEM_KB:-0} / 1024 / 1024 ))"
+    KERNEL="$(uname -sr)"
+    DEV="$(df --output=source "$MODEL" 2>/dev/null | tail -1)"
+    BLOCK="$(basename "$(readlink -f "$DEV" 2>/dev/null || echo "$DEV")" | sed -E 's/p?[0-9]+$//')"
+    DRIVE_MODEL="$(readf "/sys/block/$BLOCK/device/model" | tr -d '\n' | sed 's/[[:space:]]*$//')"
+    [ -n "$DRIVE_MODEL" ] || DRIVE_MODEL="$BLOCK"
+    DD_FLAGS="iflag=direct"
+fi
+MODEL_GIB="$(du -k "$MODEL" | awk '{printf "%.1f", $1/1024/1024}')"
+
+# Read 1 GiB of the model itself at 512 KiB, bypassing the page cache, from a random-ish offset
+# (one quarter in) so a freshly downloaded file's cached head does not flatter the number.
+probe_read_rate() {
+    local skip=$(( $(du -k "$MODEL" | cut -f1) / 4 / 512 ))
+    local t0 t1
+    t0="$(date +%s.%N)"
+    dd if="$MODEL" of=/dev/null bs=512k count=2048 skip="$skip" $DD_FLAGS 2>/dev/null || return 1
+    t1="$(date +%s.%N)"
+    awk -v a="$t0" -v b="$t1" 'BEGIN { d=b-a; if (d>0) printf "%.0f", 1024/d; else print "n/a" }'
+}
+READ_MIBS="$(probe_read_rate || echo n/a)"
+
+# --- 3. run ---------------------------------------------------------------------------------
+mkdir -p "$BENCH_OUT"
+TAG="$(basename "$MODEL" .gguf)"
+CSV="$BENCH_OUT/$TAG.csv"
+LOG="$BENCH_OUT/$TAG.log"
+echo "running: $TAG, $THREADS threads, $IO_THREADS lanes, cache $CACHE_MB, $N_PREDICT tokens" >&2
+"$BMOE_CLI" -m "$MODEL" --chatml -n "$N_PREDICT" -t "$THREADS" \
+    --moe-stream --cache-mb "$CACHE_MB" --io-threads "$IO_THREADS" --overlap --dense-weights anon \
+    --csv "$CSV" "$@" -p "$PROMPT" > "$LOG" 2>&1 || { echo "bmoe-cli failed, see $LOG" >&2; exit 1; }
+
+# --- 4. report ------------------------------------------------------------------------------
+# The trailer is whitespace-separated key=value; read by NAME, never by position.
+SUMMARY="$(grep '^# summary' "$CSV" | tail -1)"
+key() { echo "$SUMMARY" | tr ' ' '\n' | sed -n "s|^$1=||p" | head -1; }
+ARCH="$(grep -o 'arch=[^ ]*' "$CSV" | head -1 | cut -d= -f2)"
+TOPK="$(grep -o 'n_expert_used=[^ ]*' "$CSV" | head -1 | cut -d= -f2)"
+TOKS="$(key tok/s)"; PREFILL="$(key prefill_tps)"; STALL="$(key stall_s/tok)"
+COMPUTE="$(key compute_s/tok)"; HIT="$(key cache_hit_pct)"; READ_MIB="$(key read_MiB)"
+TOKENS="$(key tokens)"; BUDGET="$(key cache_budget_MiB)"; MAJFLT="$(key majflt/tok)"
+LOAD_S="$(key load_s)"; DROPPED="$(key experts_dropped)"
+MIB_PER_TOK="$(awk -v r="$READ_MIB" -v n="$TOKENS" 'BEGIN { if (n>0) printf "%.0f", r/n; else print "n/a" }')"
+
+cat <<EOF
+
+<!-- paste everything below into the benchmark-report issue -->
+**Machine**
+
+| CPU | Cores / threads used | RAM | Storage | Storage read (512 KiB, O_DIRECT) | OS |
+|---|---:|---:|---|---:|---|
+| $CPU_MODEL | $NPROC / $THREADS | $RAM_GIB GiB | $DRIVE_MODEL | $READ_MIBS MiB/s | $KERNEL |
+
+**Run** — engine $ENGINE_VERSION ($GIT_REV), model \`$(basename "$MODEL")\` ($MODEL_GIB GiB, arch \`$ARCH\`), $N_PREDICT tokens
+
+| Model | k | Cache | Lanes | Decode tok/s | Prefill tok/s | Stall s/tok | Compute s/tok | Flash/token | Cache hit | majflt/tok | Load s |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| $TAG | $TOPK | $BUDGET MiB | $IO_THREADS | $TOKS | $PREFILL | $STALL | $COMPUTE | $MIB_PER_TOK MiB | $HIT% | $MAJFLT | $LOAD_S |
+
+Extra flags: \`${*:-none}\`. Experts dropped: ${DROPPED:-0}. Raw CSV: \`$CSV\` (attach it to the issue).
+EOF


### PR DESCRIPTION
Every published number comes from one phone and one laptop. This adds what a contributor needs to add a row from hardware we do not own, without reading code.

- `scripts/bench-report.sh MODEL.gguf` runs the fixed README protocol on any Linux/macOS host (256 greedy tokens, the reference prompt, auto cache, 4 lanes, overlap, dense weights out of the page cache), records CPU / RAM / drive and the drive's measured O_DIRECT rate at 512 KiB requests from the model file itself, and prints the two markdown tables a report needs. Every figure is read from the CSV `# summary` trailer by key name.
- `.github/ISSUE_TEMPLATE/benchmark-report.yml`: the form. Any supported MoE in any quantization; tok/s alone is not accepted as a row.
- `docs/community-benchmarks.md`: protocol, hardware wanted and why, column meanings, results table seeded with the README rows.
- README, CONTRIBUTING, docs index and CHANGELOG point at it.

Smoke-tested on the Windows host build with Qwen3.6-35B-A3B Q4_K_M (32 tokens): the block prints with every column filled. Not yet run on a Linux/macOS host; the first contributor run is the test, and the doc says so.

No engine code touched; the byte-identity gates are unaffected.
