### PR TITLE
feat(moe): serve row-gathered dense tables from flash (--row-stream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 Semantic Versioning.
 
+## [0.24.0] - unreleased
+
+### Added
+- **`--row-stream`: dense tables the graph only gathers rows from, served from flash.** The dense
+  policy has one shape for every non-expert weight, and it is the right shape for a weight that is
+  multiplied: read it whole, keep it resident. A token embedding table is not that. The graph
+  gathers one row of it per decoded token out of a vocabulary of hundreds of thousands, and on a
+  big model that is hundreds of MiB of RAM bought for a kilobyte of use. With this flag such a
+  table is bound to reserved address space and only the rows the graph is about to read are pulled
+  in, in 16 KiB slabs, inside a bounded LRU window (`--row-stream-mb`, default 64). The
+  reservation mirrors the tensor's own byte layout, so ggml's address arithmetic is unchanged and
+  the gather kernel is untouched: the trick the expert cache plays on `mul_mat_id`, at row
+  granularity.
+
+  Which tables qualify is not a list and not a name pattern. During the capture decode every
+  reference to a dense weight is classified by how the node used it, and a table is served only if
+  every reference was a row gather taking it as the table, with an index that is materialized
+  before the node runs. Both are properties of the graph, so a model with tied embeddings, where
+  the table is also the output head, fails the first test on that matmul and is left alone on any
+  architecture without a special case; Qwen3.8-Flash-Next's 51B n-gram table is row-gathered but by
+  hashes computed inside the graph, so it fails the second and keeps the size guard measured for it
+  in 0.22.0. `IRowSource::materialize()` is the fallback if some later graph reads a served table
+  any other way: the whole table is pulled in and the run says so on stderr.
+
+  Measured, byte-identical to the resident reference in every cell. On the 12 GB test phone via
+  adb: Qwen3.8-Flash-Next UD-IQ3_XXS, pinned dense **4313 to 3816 MiB** (-497), and
+  Qwen3.6-35B-A3B UD-Q3_K_XL, pinned dense **2436 to 1921 MiB** (-515), for 0.3 MiB resident and
+  0.4 MiB of flash read across the generation, against 4.5 GB of expert reads on the same run.
+  Expert bytes, cache hit rate, evictions and re-reads are identical to the digit with the flag on
+  and off. Throughput is neutral so far: interleaved host cells on Qwen3.6-35B-A3B Q4_K_M gave 2.22
+  and 2.30 tok/s off against 2.27 and 2.31 on, a spread smaller than the one between the two
+  baselines, so the flag ships off by default and the claim it makes is about RAM, not speed. The
+  RAM is the point: on the model whose 4.3 GB pinned dense set is invisible to the kernel's reclaim
+  accounting, half a gigabyte handed back goes straight to the cause of the 2 to 7 second tokens
+  documented in 0.22.0. Gates `G15a`/`G15b` prove identity on all three tiny models, the second
+  with a window of one slab so nearly every gather re-reads what the last one handed back. New
+  port `bmoe/row_source.h`, adapter `core/src/moe/row_stream.cpp`, docs in
+  `docs/row-gathered-tables.md`, app switch **Stream row-gathered tables**.
+
+### Changed
+- The CSV summary trailer gains `row_table_MiB`, `row_resident_MiB`, `row_rows`, `row_reads`,
+  `row_read_MiB`, `row_evictions` and `row_io_errors`, and a `moe-rows:` end-of-run line appears
+  when a table qualified. All are absent from the per-token rows, which the policy does not touch.
+- `--cache-mb auto` no longer reserves the size of a row-streamed table for a conversion that will
+  not happen. It deducts the window instead, so the cache gets the RAM the policy freed rather than
+  the engine planning for both.
 ## [0.23.0] - 2026-08-29
 
 ### Fixed

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -451,6 +451,13 @@ static void print_usage(const char * argv0) {
         "                          Android-only; measured +17.9%% on a long generation, off by default)\n"
         "                          Deprecated aliases kept for old scripts: --dense-odirect means\n"
         "                          `--dense-weights anon`, --no-warm-dense means `--dense-weights mmap`\n"
+        "      --row-stream        serve dense tables the graph only GATHERS ROWS from (a token\n"
+        "                          embedding) from flash instead of RAM: the tensor is bound to\n"
+        "                          reserved address space and only the rows a token needs are\n"
+        "                          read. Which tables qualify comes from the graph, not from a\n"
+        "                          name list, so a model that also multiplies by its embedding\n"
+        "                          table is left alone, on any architecture\n"
+        "      --row-stream-mb N   resident window for those tables in MiB (default 64)\n"
         "      --load-all          debug: read ALL experts each token (A/B baseline)\n"
         "      --force-cache       allow a cache-mb in the pathological band\n"
         "      --overlap           overlap async expert reads with FFN compute (needs the fork)\n"
@@ -646,6 +653,10 @@ int main(int argc, char ** argv) {
             cfg.moe.io_threads = std::atoi(next("--io-threads"));
         else if (a == "--no-odirect")
             cfg.moe.o_direct = false;
+        else if (a == "--row-stream")
+            cfg.moe.row_stream = true;
+        else if (a == "--row-stream-mb")
+            cfg.moe.row_stream_mb = std::atoi(next("--row-stream-mb"));
         else if (a == "--dense-weights") {
             const std::string m = next("--dense-weights");
             if (m == "mmap")
@@ -884,6 +895,16 @@ int main(int argc, char ** argv) {
                             "already paid for once\n",
                             s.cache_evictions, s.cache_rereads,
                             s.n_generated ? (double) s.cache_rereads / s.n_generated : 0.0);
+        }
+        // The row policy's own line: what it took out of RAM, what it holds instead, and what
+        // that cost in reads. Printed only when a table qualified, so a run that discovered
+        // none says nothing rather than printing a row of zeroes.
+        if (s.row_table_mib > 0.0) {
+            std::printf("moe-rows: %.0f MiB of row-gathered table(s) off the resident set, %.1f MiB resident, "
+                        "%lld rows gathered, %lld reads (%.1f MiB)\n",
+                        s.row_table_mib, s.row_resident_mib, s.row_rows, s.row_slab_reads, s.row_read_mib);
+            if (s.row_io_errors > 0)
+                std::printf("moe-rows: %lld FAILED reads — this run's output is not trustworthy\n", s.row_io_errors);
         }
         if (cfg.moe.overlap)
             std::printf("moe-overlap: stall %.3f s/token (flash reads overlapped with FFN compute)\n",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ if(BMOE_HAVE_LLAMA)
         src/io/platform_io.cpp
         src/io/file_reader.cpp
         src/moe/dense_weights.cpp
+        src/moe/row_stream.cpp
         src/moe/gguf_offsets.cpp
         src/moe/expert_stream_source.cpp
         src/moe/router_hook.cpp

--- a/core/include/bmoe/config.h
+++ b/core/include/bmoe/config.h
@@ -103,6 +103,23 @@ struct MoeStreamConfig {
     //             and the policy the Android app ships by default — the CLI matches it here.
     DenseWeightsMode dense_weights = DenseWeightsMode::Anonymous;
 
+    // ── row-gathered dense tables served from flash (see bmoe/row_source.h) ──────────
+    // A dense weight the graph only ever GATHERS ROWS from — a token embedding table is the pure
+    // case — is resident for nothing: one row of it is read per decoded token and the rest of the
+    // hundreds of MiB sits in RAM the expert cache is competing for. With this on, such a table is
+    // bound to reserved address space and only the rows the graph asks for are pulled from flash,
+    // inside a bounded window.
+    //
+    // WHICH tables qualify is decided by the graph at capture time and by nothing else: every
+    // reference to the tensor must be a row gather with a readable index. No architecture, tensor
+    // name or size threshold appears in the rule, so a model whose embeddings are also used as the
+    // output head simply never qualifies, on any architecture, without a special case for it.
+    //
+    // Off by default: it trades residency for a read per gather miss, and which way that trade goes
+    // is a measurement per device class, not a foregone conclusion.
+    bool row_stream = false;
+    int row_stream_mb = 64; // resident window across all row-streamed tables, in MiB
+
     // ── cache-aware expert dropping (lossy; opt-in) ──────────────────────────────────
     // Skip a routed expert when it is a cache MISS *and* the router weighted it below
     // drop_cold_frac × (1 / n_expert_used) — i.e. below that fraction of the uniform share a

--- a/core/include/bmoe/metrics.h
+++ b/core/include/bmoe/metrics.h
@@ -154,6 +154,18 @@ struct RunSummary {
     // claiming its reads are useful is doing it here.
     long long cache_evictions = 0;
     long long cache_rereads = 0;
+
+    // Row-gathered dense tables served from flash (MoeStreamConfig::row_stream). The pair that says
+    // whether the policy paid: row_table_mib is what those tables would have occupied resident,
+    // row_resident_mib what they occupy now, and row_read_mib what buying that cost in flash. Zero
+    // throughout when the policy is off or no table qualified.
+    double row_table_mib = 0.0;
+    double row_resident_mib = 0.0;
+    double row_read_mib = 0.0;
+    long long row_rows = 0;       // row indices gathered, duplicates included
+    long long row_slab_reads = 0; // gather misses that went to flash
+    long long row_evictions = 0;
+    long long row_io_errors = 0; // non-zero means a decode read bytes that were never fetched
     // The named eval-thread waits (see TokenMetrics): the async load's previous-batch drain (part
     // of the compute residual) and the route-ahead adoption wait (part of mgmt), per token.
     double moe_drain_s_per_token = 0.0;

--- a/core/include/bmoe/row_source.h
+++ b/core/include/bmoe/row_source.h
@@ -1,0 +1,67 @@
+// The row-gathered residency port.
+//
+// Some dense (non-expert) model weights are not walked whole on a token: the graph gathers a
+// handful of ROWS out of them (`ggml_get_rows`) and never touches the rest. A token embedding
+// table is the pure case — one row per decoded token out of a vocabulary of hundreds of
+// thousands — and it is also, on a big model, hundreds of MiB of RAM that is resident so that
+// 0.0004 % of it can be read.
+//
+// An IRowSource owns such a table's residency at ROW granularity: it holds the address space the
+// tensor is bound to, and makes only the rows the graph is about to gather physically present,
+// reading them from flash. The engine's router hook calls gather() in the eval callback's ask
+// pass, before the gather node runs, with the indices the graph is about to use.
+//
+// This is a port for the same reason IExpertSource is one: "which rows are resident" is a policy,
+// and the flash-backed sliding window is one implementation of it. A test fake, an all-resident
+// implementation, or a future per-row cache are others.
+#pragma once
+
+#include <cstdint>
+
+struct ggml_tensor;
+
+namespace bmoe {
+
+// What a row source is holding and what it has done, for telemetry and for the one line a run
+// prints about it. `table_bytes` is what the tables would occupy under the ordinary dense policy
+// and `resident_bytes` what they occupy now: the pair the policy is judged on.
+struct RowSourceStats {
+    uint64_t table_bytes = 0;
+    uint64_t resident_bytes = 0;
+    uint64_t gathers = 0;      // gather() calls (one per row-gather node executed)
+    uint64_t rows = 0;         // row indices asked for, duplicates included
+    uint64_t slab_reads = 0;   // reads actually issued to flash (the misses)
+    uint64_t bytes_read = 0;   // bytes those reads moved
+    uint64_t evictions = 0;    // slabs handed back to stay inside the budget
+    uint64_t materialized = 0; // whole-table fallbacks taken (see materialize())
+    uint64_t io_errors = 0;    // failed fetches; any non-zero value means a decode read garbage
+};
+
+class IRowSource {
+public:
+    virtual ~IRowSource() = default;
+
+    // Does this source own `table`'s residency? A cheap identity test on the bound tensor pointer;
+    // the hook calls it for every gather node in the graph, so it must not allocate or lock.
+    virtual bool serves(const ggml_tensor * table) const = 0;
+
+    // Make rows `idx[0..n)` of `table` present before the gather reads them. Indices are the raw
+    // i32 contents of the gather's index tensor: duplicates are expected, and an out-of-range index
+    // is ignored rather than treated as an error (the graph, not this source, defines validity).
+    // Called on the eval thread only, from the ask pass of the node that is about to run.
+    // Returns false on an I/O failure, which the caller must treat as fatal for the decode: the
+    // rows would otherwise be read as whatever the address space holds.
+    virtual bool gather(const ggml_tensor * table, const int32_t * idx, int n) = 0;
+
+    // Make the WHOLE table present. The safety net for a graph shape that was not seen when the
+    // policy was chosen: residency was granted to a table on the evidence that every reference to
+    // it in the captured graph was a row gather, and if some later graph reads it any other way,
+    // the bytes must all be there before that node runs. Idempotent; returns false on I/O failure.
+    virtual bool materialize(const ggml_tensor * table) = 0;
+
+    // Cumulative accounting since the source was built. Read off the eval thread, so the counters
+    // are individually current but not a consistent snapshot.
+    virtual RowSourceStats stats() const = 0;
+};
+
+} // namespace bmoe

--- a/core/src/config.cpp
+++ b/core/src/config.cpp
@@ -123,6 +123,17 @@ ValidationResult validate(const RunConfig & cfg) {
                     "streamer isolates, and off the streaming path there is nothing to commit to");
     }
 
+    // The row policy is discovered during the streamer's capture decode and acted on in its eval
+    // callback; without streaming neither exists. It is also not a dense-mode variant — it applies
+    // under every DenseWeightsMode, because what it changes is which tensors the mode is applied to.
+    if (cfg.moe.row_stream && !cfg.moe.enabled) {
+        return fail("moe.row_stream requires moe.enabled: the tables it serves are discovered by the "
+                    "capture pass and fed by the eval callback, neither of which runs off the streaming path");
+    }
+    if (cfg.moe.row_stream_mb < 0) {
+        return fail("moe.row_stream_mb must be >= 0 (0 = the built-in window)");
+    }
+
     if (cfg.moe.enabled) {
         const MoeStreamConfig & m = cfg.moe;
         if (m.io_threads < 1 || m.io_threads > MoeStreamConfig::io_threads_max) {

--- a/core/src/engine/session.cpp
+++ b/core/src/engine/session.cpp
@@ -696,7 +696,12 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
         // residency sensor — see DenseWeights::hold_back_oversized.
         {
             const std::unordered_set<std::string> expert_names = expert_tensor_names(layers);
-            std::vector<DenseTensorRef> dense;
+            // The subset the graph only row-gathers, when the run asked for the row policy. Their
+            // membership is the hook's verdict on what the graph did, and this is a filter over the
+            // dense list rather than a second list, so a table cannot be both resident and streamed.
+            const std::unordered_set<std::string> row_names =
+                cfg.moe.row_stream ? im.hook->row_gathered_weights() : std::unordered_set<std::string>();
+            std::vector<DenseTensorRef> dense, rows;
             for (const auto & kv : im.hook->captured_weights()) {
                 const std::string & name = kv.first;
                 if (expert_names.count(name)) continue;
@@ -709,13 +714,19 @@ std::unique_ptr<Session> Session::open(const SessionConfig & cfg,
                 d.size = sz->second;
                 d.file_idx = offs.file_by_name.at(name);
                 dense.push_back(d);
+                if (row_names.count(name)) rows.push_back(d);
             }
+            const uint64_t row_budget = (uint64_t) std::max(0, cfg.moe.row_stream_mb) * 1024ull * 1024ull;
             im.source.set_dense_tensors(std::move(dense));
+            im.source.set_row_tensors(std::move(rows), row_budget);
         }
 
         if (!im.source.init(offs.shard_paths, n_expert, std::move(layers), cfg.moe))
             return fail("expert stream source init failed");
         im.hook->set_source(&im.source);
+        // The row policy exists only once dense_.init has taken the tables over; null means nothing
+        // qualified or the takeover declined, and the hook then costs exactly nothing per node.
+        im.hook->set_row_source(im.source.row_source());
 
         if (route_trace) {
             im.route_trace = route_trace;
@@ -1525,6 +1536,14 @@ RunResult Session::generate(const GenerateRequest & req,
         s.cache_resizes = st.cache_resizes;
         s.cache_evictions = st.evictions;
         s.cache_rereads = st.rereads;
+        const RowSourceStats rs = im.source.row_stats();
+        s.row_table_mib = rs.table_bytes / (1024.0 * 1024.0);
+        s.row_resident_mib = rs.resident_bytes / (1024.0 * 1024.0);
+        s.row_read_mib = rs.bytes_read / (1024.0 * 1024.0);
+        s.row_rows = (long long) rs.rows;
+        s.row_slab_reads = (long long) rs.slab_reads;
+        s.row_evictions = (long long) rs.evictions;
+        s.row_io_errors = (long long) rs.io_errors;
         s.moe_drain_s_per_token = n_gen ? tally.drain_seconds / n_gen : 0.0;
         s.moe_adopt_s_per_token = n_gen ? tally.adopt_seconds / n_gen : 0.0;
         s.token_demand_mib = st.token_demand_bytes / (1024.0 * 1024.0);

--- a/core/src/metrics/csv_metrics_sink.cpp
+++ b/core/src/metrics/csv_metrics_sink.cpp
@@ -68,35 +68,38 @@ public:
     void on_summary(const RunSummary & s) override {
         // Run-level trailer parsed by scripts/bench-analyze.py as whitespace-separated key=value
         // tokens (order-independent). New keys are appended freely; older parsers ignore unknowns.
-        std::fprintf(f_,
-                     "# summary tokens=%d s/tok=%.3f tok/s=%.3f read_MiB=%.1f "
-                     "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f "
-                     "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
-                     "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
-                     "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
-                     "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
-                     "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f "
-                     "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld mtp_draft_s/tok=%.4f "
-                     "drafted_steps=%lld "
-                     "ra_committed=%lld ra_passthrough=%lld ra_agree_pct=%.1f ra_gemv_ms/tok=%.2f "
-                     "ra_issue_ms/tok=%.2f ra_wd_ms/tok=%.2f drain_s/tok=%.3f adopt_s/tok=%.3f "
-                     "evictions=%lld rereads=%lld "
-                     "prefill_cpu_s=%.3f prefill_read_mib=%.1f prefill_io_s=%.3f "
-                     "prefill_stall_s=%.3f prefill_mgmt_s=%.3f\n",
-                     s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
-                     s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
-                     s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0,
-                     s.moe_stall_s_per_token, s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib,
-                     s.cache_resizes, s.moe_spec_read_mib, s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token,
-                     s.cpu_s_per_token, s.token_demand_mib, s.layer_demand_mib, s.experts_routed, s.experts_dropped,
-                     s.loop_overhead_s_per_token, s.mtp_drafted, s.mtp_accepted, s.mtp_decodes, s.mtp_draft_s_per_token,
-                     s.drafted_steps, s.route_ahead_overridden, s.route_ahead_passthrough,
-                     s.route_ahead_slots > 0 ? 100.0 * s.route_ahead_hits / s.route_ahead_slots : 0.0,
-                     s.n_generated ? s.route_ahead_gemv_ns / 1e6 / s.n_generated : 0.0,
-                     s.n_generated ? s.route_ahead_issue_ns / 1e6 / s.n_generated : 0.0,
-                     s.n_generated ? s.route_ahead_wd_ns / 1e6 / s.n_generated : 0.0, s.moe_drain_s_per_token,
-                     s.moe_adopt_s_per_token, s.cache_evictions, s.cache_rereads, s.prefill_cpu_seconds,
-                     s.prefill_read_mib, s.prefill_io_seconds, s.prefill_stall_seconds, s.prefill_mgmt_seconds);
+        std::fprintf(
+            f_,
+            "# summary tokens=%d s/tok=%.3f tok/s=%.3f read_MiB=%.1f "
+            "io_s=%.2f compute_s/tok=%.3f io_s/tok=%.3f cache_hit_pct=%.1f "
+            "n_prompt=%d load_s=%.3f prefill_s=%.3f prefill_tps=%.2f stall_s/tok=%.3f mgmt_s/tok=%.3f "
+            "cache_resident_MiB=%.1f cache_budget_MiB=%.1f cache_resizes=%lld "
+            "spec_read_MiB=%.1f spec_experts=%lld spec_useful=%lld "
+            "majflt/tok=%.2f cpu_s/tok=%.4f token_demand_MiB=%.1f layer_demand_MiB=%.1f "
+            "experts_routed=%lld experts_dropped=%lld loop_overhead_s/tok=%.4f "
+            "mtp_drafted=%lld mtp_accepted=%lld mtp_decodes=%lld mtp_draft_s/tok=%.4f "
+            "drafted_steps=%lld "
+            "ra_committed=%lld ra_passthrough=%lld ra_agree_pct=%.1f ra_gemv_ms/tok=%.2f "
+            "ra_issue_ms/tok=%.2f ra_wd_ms/tok=%.2f drain_s/tok=%.3f adopt_s/tok=%.3f "
+            "evictions=%lld rereads=%lld "
+            "prefill_cpu_s=%.3f prefill_read_mib=%.1f prefill_io_s=%.3f "
+            "prefill_stall_s=%.3f prefill_mgmt_s=%.3f "
+            "row_table_MiB=%.1f row_resident_MiB=%.1f row_rows=%lld row_reads=%lld "
+            "row_read_MiB=%.1f row_evictions=%lld row_io_errors=%lld\n",
+            s.n_generated, s.s_per_token, s.tokens_per_second, s.moe_read_mib, s.moe_io_seconds,
+            s.moe_compute_s_per_token, s.moe_io_s_per_token, s.cache_hit_pct, s.n_prompt, s.load_seconds,
+            s.prefill_seconds, s.prefill_seconds > 0 ? s.n_prompt / s.prefill_seconds : 0.0, s.moe_stall_s_per_token,
+            s.moe_mgmt_s_per_token, s.cache_resident_mib, s.cache_budget_mib, s.cache_resizes, s.moe_spec_read_mib,
+            s.moe_spec_experts, s.moe_spec_useful, s.majflt_per_token, s.cpu_s_per_token, s.token_demand_mib,
+            s.layer_demand_mib, s.experts_routed, s.experts_dropped, s.loop_overhead_s_per_token, s.mtp_drafted,
+            s.mtp_accepted, s.mtp_decodes, s.mtp_draft_s_per_token, s.drafted_steps, s.route_ahead_overridden,
+            s.route_ahead_passthrough, s.route_ahead_slots > 0 ? 100.0 * s.route_ahead_hits / s.route_ahead_slots : 0.0,
+            s.n_generated ? s.route_ahead_gemv_ns / 1e6 / s.n_generated : 0.0,
+            s.n_generated ? s.route_ahead_issue_ns / 1e6 / s.n_generated : 0.0,
+            s.n_generated ? s.route_ahead_wd_ns / 1e6 / s.n_generated : 0.0, s.moe_drain_s_per_token,
+            s.moe_adopt_s_per_token, s.cache_evictions, s.cache_rereads, s.prefill_cpu_seconds, s.prefill_read_mib,
+            s.prefill_io_seconds, s.prefill_stall_seconds, s.prefill_mgmt_seconds, s.row_table_mib, s.row_resident_mib,
+            s.row_rows, s.row_slab_reads, s.row_read_mib, s.row_evictions, s.row_io_errors);
         std::fflush(f_);
     }
 

--- a/core/src/moe/dense_weights.cpp
+++ b/core/src/moe/dense_weights.cpp
@@ -1,6 +1,7 @@
 #include "dense_weights.h"
 
 #include "ggml.h"
+#include "row_stream.h"
 
 #include <algorithm>
 #include <chrono>
@@ -9,6 +10,8 @@
 namespace bmoe {
 
 using clock_t_ = std::chrono::steady_clock;
+
+DenseWeights::DenseWeights() = default;
 
 DenseWeights::~DenseWeights() {
     shutdown();
@@ -44,6 +47,7 @@ bool DenseWeights::init(DenseWeightsMode mode,
     }
 
     hold_back_oversized();
+    take_row_gathered();
 
     if (mode_ == DenseWeightsMode::Anonymous || mode_ == DenseWeightsMode::Pinned) {
         if (tensors_.empty()) { // nothing (left) to rebind — behave as Mmap
@@ -145,6 +149,72 @@ void DenseWeights::hold_back_oversized() {
                      "mmap'd with random-access advice, outside the warm sweep and the residency sensor\n",
                      mode_flag(mode_), (unsigned long long) (held >> 20), mapped_.size(),
                      (unsigned long long) (avail >> 20));
+}
+
+void DenseWeights::set_row_gathered(std::vector<DenseTensorRef> tables, uint64_t budget_bytes) {
+    row_pending_ = std::move(tables);
+    row_budget_ = budget_bytes;
+}
+
+IRowSource * DenseWeights::row_source() const {
+    return rows_ && !rows_->empty() ? rows_.get() : nullptr;
+}
+
+RowSourceStats DenseWeights::row_stats() const {
+    return rows_ ? rows_->stats() : RowSourceStats{};
+}
+
+// ── Row-gathered tables: bound to reserved space, served from flash ──────────────────
+//
+// Runs after hold_back_oversized, which is what restricts this to tables that COULD have been
+// resident. That is deliberate rather than incidental: materialize() — the fallback for a graph
+// shape the capture pass never saw — has to be able to pull the whole table in, and a table larger
+// than memory could not honour it. An oversized row-gathered table keeps the mmap policy that was
+// measured for it.
+//
+// A table only leaves the resident set once the takeover has actually succeeded, so a failed
+// reservation or a reader that will not open costs nothing but the log line.
+void DenseWeights::take_row_gathered() {
+    if (row_pending_.empty()) return;
+    // Intersect with what is still resident-eligible, by tensor identity: the caller's list was
+    // built from the same capture, but hold_back_oversized may have taken some of it already.
+    std::vector<DenseTensorRef> take;
+    for (const DenseTensorRef & want : row_pending_)
+        for (const DenseTensorRef & have : tensors_)
+            if (have.tensor == want.tensor) {
+                take.push_back(have);
+                break;
+            }
+    row_pending_.clear();
+    if (take.empty()) return;
+
+    rows_.reset(new RowStream());
+    if (!rows_->init(take, paths_, align_, row_budget_) || rows_->empty()) {
+        rows_.reset();
+        return; // the tables keep the mode the run asked for
+    }
+
+    std::vector<DenseTensorRef> keep;
+    keep.reserve(tensors_.size());
+    uint64_t freed = 0;
+    for (const DenseTensorRef & d : tensors_) {
+        bool taken = false;
+        for (const DenseTensorRef & t : take)
+            if (t.tensor == d.tensor) {
+                taken = true;
+                break;
+            }
+        if (!taken) {
+            keep.push_back(d);
+            continue;
+        }
+        freed += d.size;
+        if (d.file_idx >= 0 && (size_t) d.file_idx < ranges_.size())
+            subtract_range(ranges_[(size_t) d.file_idx], d.file_off, d.file_off + d.size);
+    }
+    tensors_ = std::move(keep);
+    std::fprintf(stderr, "bmoe: dense-weights=%s — %llu MiB of row-gathered table(s) left out of the resident set\n",
+                 mode_flag(mode_), (unsigned long long) (freed >> 20));
 }
 
 void DenseWeights::advise_random_mapped() {
@@ -377,6 +447,8 @@ void DenseWeights::sample_mmap(size_t page) {
 }
 
 void DenseWeights::shutdown() {
+    if (rows_) rows_->shutdown();
+    rows_.reset();
     for (void * b : bufs_)
         if (b) pio::aligned_free(b);
     for (pio::PinnedAlloc & p : pinned_)

--- a/core/src/moe/dense_weights.h
+++ b/core/src/moe/dense_weights.h
@@ -19,6 +19,7 @@
 #include "../io/file_reader.h"
 #include "../io/platform_io.h"
 #include "bmoe/config.h" // DenseWeightsMode
+#include "bmoe/row_source.h"
 
 #include <cstdint>
 #include <memory>
@@ -29,6 +30,8 @@
 struct ggml_tensor;
 
 namespace bmoe {
+
+class RowStream;
 
 // One dense weight tensor: where its bytes live in the gguf, and the tensor whose ->data we rebind.
 // Read whole and contiguous (`size` bytes from `file_off` in shard `file_idx`), unlike an expert slice.
@@ -41,7 +44,9 @@ struct DenseTensorRef {
 
 class DenseWeights {
 public:
-    DenseWeights() = default;
+    // Both defined in the .cpp: the row policy is an incomplete type here, and a defaulted
+    // constructor in the header would have to instantiate its deleter.
+    DenseWeights();
     ~DenseWeights();
 
     DenseWeights(const DenseWeights &) = delete;
@@ -64,6 +69,20 @@ public:
               std::vector<std::vector<std::pair<uint64_t, uint64_t>>> ranges,
               std::vector<DenseTensorRef> tensors);
 
+    // Tables the graph only ever ROW-GATHERS (discovered by RouterHook, never named here): instead
+    // of being made resident, they are bound to reserved address space and served from flash a row
+    // at a time, inside `budget_bytes` of window. Call BEFORE init. A table taken over leaves the
+    // resident dense set entirely — not read, not rebound, not warmed, not sampled — exactly as an
+    // oversized one does, because a sensor that counted it would report a set that is resident by
+    // design only in part. If the takeover fails, the tables silently keep the mode the run asked
+    // for: this is a residency optimisation, never a reason for a run not to start.
+    void set_row_gathered(std::vector<DenseTensorRef> tables, uint64_t budget_bytes);
+
+    // The row policy, once init has run: null when no table qualified or the takeover failed. The
+    // engine's graph adapter needs it to make rows present before a gather node runs.
+    IRowSource * row_source() const;
+    RowSourceStats row_stats() const;
+
     // Sample how much of the dense set the kernel still has in RAM (mincore), setting resident_frac().
     // Anonymous samples the anon buffers; Mmap/Warmed sample the mmap ranges via /proc/self/maps.
     // The caller throttles (calls this only when it wants a fresh sample); `page` is the OS page size.
@@ -79,6 +98,8 @@ private:
     // any mode. Moves such tensors from `tensors_` to `mapped_`, carves their bytes out of `ranges_`
     // (so neither the warm sweep nor the sensor treats them as dense the run could hold), and says so.
     void hold_back_oversized();
+    // Hand the qualifying tables to the row policy and take them out of the resident dense set.
+    void take_row_gathered();
     // Random-access advice on the mmap of every held-back tensor: a fault brings in one page, not a
     // readahead window the gather will never touch.
     void advise_random_mapped();
@@ -102,6 +123,10 @@ private:
     std::vector<std::unique_ptr<FileReader>> readers_;
     std::vector<DenseTensorRef> tensors_;
     std::vector<DenseTensorRef> mapped_; // held back by hold_back_oversized: mmap'd under every mode
+    // Row-gathered tables: what was asked for, the window budget, and the policy that owns them.
+    std::vector<DenseTensorRef> row_pending_;
+    uint64_t row_budget_ = 0;
+    std::unique_ptr<RowStream> rows_;
     std::vector<void *> bases_;
     std::vector<void *> bufs_;
     std::vector<pio::PinnedAlloc> pinned_;

--- a/core/src/moe/expert_stream_source.cpp
+++ b/core/src/moe/expert_stream_source.cpp
@@ -1,5 +1,7 @@
 #include "expert_stream_source.h"
 
+#include "row_stream.h"
+
 #include "ggml.h"
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
 #include "ggml-cpu.h" // ggml_cpu_set_expert_ready_hook (fork-only)
@@ -99,8 +101,19 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
             // never converted, it stays mmap'd (qwen4exp's ~28.8 GB n-gram table). Counting it here
             // would reserve the whole of RAM for a conversion that will not happen and size the
             // cache to nothing.
-            for (const DenseTensorRef & d : dense_tensors_)
-                if (d.tensor && d.size <= avail) dense_pending += d.size;
+            for (const DenseTensorRef & d : dense_tensors_) {
+                if (!d.tensor || d.size > avail) continue;
+                // Nor is a row-gathered table converted: it costs its window, not its size, and
+                // reserving the difference would hand the cache back exactly what this policy freed.
+                bool row = false;
+                for (const DenseTensorRef & r : row_tensors_)
+                    if (r.tensor == d.tensor) {
+                        row = true;
+                        break;
+                    }
+                dense_pending += row ? 0 : d.size;
+            }
+            if (!row_tensors_.empty()) dense_pending += row_budget_ ? row_budget_ : RowStream::default_budget_bytes;
             const uint64_t deduct = std::min(avail, dense_pending);
             if (deduct > 0) {
                 avail -= deduct;
@@ -250,6 +263,7 @@ bool ExpertStreamSource::init(const std::vector<std::string> & shard_paths,
         std::vector<std::vector<std::pair<uint64_t, uint64_t>>> ranges(readers_.size());
         for (size_t s = 0; s < readers_.size(); ++s)
             ranges[s] = DenseWeights::byte_ranges(std::move(exp[s]), readers_[s]->file_size());
+        dense_.set_row_gathered(std::move(row_tensors_), row_budget_);
         if (!dense_.init(cfg.dense_weights, shard_paths, align_, std::move(ranges), std::move(dense_tensors_))) {
             std::fprintf(stderr, "bmoe: dense-weights init failed\n");
             return false;
@@ -1427,6 +1441,7 @@ void ExpertStreamSource::shutdown() {
     // contract as the slot and LRU buffers freed above.
     dense_.shutdown();
     dense_tensors_.clear();
+    row_tensors_.clear();
     readers_.clear(); // closes every shard's lane fds and frees the bounces
     jobs_.clear();
     layers_.clear();

--- a/core/src/moe/expert_stream_source.h
+++ b/core/src/moe/expert_stream_source.h
@@ -75,6 +75,19 @@ public:
     // The runtime builds the list from the captured weight leaves and the gguf offsets.
     void set_dense_tensors(std::vector<DenseTensorRef> dense) { dense_tensors_ = std::move(dense); }
 
+    // Supply the subset of those weights the graph only ROW-GATHERS, which the dense policy serves
+    // from flash inside a `budget_bytes` window instead of making resident (see bmoe/row_source.h).
+    // Call BEFORE init, like set_dense_tensors; an empty list turns the policy off.
+    void set_row_tensors(std::vector<DenseTensorRef> rows, uint64_t budget_bytes) {
+        row_tensors_ = std::move(rows);
+        row_budget_ = budget_bytes;
+    }
+
+    // The row policy after init, for the graph adapter that must make rows present before a gather
+    // node runs; null when nothing qualified. Its accounting, for telemetry, is row_stats().
+    IRowSource * row_source() const { return dense_.row_source(); }
+    RowSourceStats row_stats() const { return dense_.row_stats(); }
+
     // IExpertSource
     bool load_layer(int il, const int32_t * ids, int n_ids) override;
     void prefetch(int il, const int32_t * ids, int n_ids) override;
@@ -256,6 +269,8 @@ private:
     static constexpr unsigned dense_probe_every = 128; // load_layer calls between dense samples (~2-3 tokens)
     unsigned dense_probe_tick_ = 0;
     std::vector<DenseTensorRef> dense_tensors_; // pending, set before init; moved into dense_
+    std::vector<DenseTensorRef> row_tensors_;   // pending row-gathered subset; moved into dense_
+    uint64_t row_budget_ = 0;
     DenseWeights dense_;
 
     // Two measured demands. Both are pure telemetry now that the governor is gone — nothing here

--- a/core/src/moe/router_hook.cpp
+++ b/core/src/moe/router_hook.cpp
@@ -134,11 +134,42 @@ static int32_t * id_at(ggml_tensor * t, int j, int k) {
     return (int32_t *) ((char *) t->data + (size_t) j * t->nb[1] + (size_t) k * t->nb[0]);
 }
 
+// Is `t` readable the moment the node that consumes it is offered to the callback? A graph input is
+// (llama.cpp fills it before the graph runs), and so is a pure view of one — a view shares its
+// source's memory, so no computation stands between the two. Anything else is produced by a node
+// that may not have run yet, and reading it would be reading uninitialized memory.
+static bool index_materialized(const ggml_tensor * t) {
+    for (int guard = 0; t && guard < 8; ++guard) {
+        switch (t->op) {
+        case GGML_OP_NONE:
+            return t->type == GGML_TYPE_I32; // an index we can actually read as row numbers
+        case GGML_OP_VIEW:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_TRANSPOSE:
+            t = t->src[0];
+            break;
+        default:
+            return false;
+        }
+    }
+    return false;
+}
+
+std::unordered_set<std::string> RouterHook::row_gathered_weights() const {
+    std::unordered_set<std::string> out;
+    for (const std::string & n : row_gathered_)
+        if (!row_disqualified_.count(n)) out.insert(n);
+    return out;
+}
+
 void RouterHook::begin_capture() {
     capturing_ = true;
     for (auto & L : captured_)
         L = LayerExperts{};
     captured_weights_.clear();
+    row_gathered_.clear();
+    row_disqualified_.clear();
 }
 void RouterHook::end_capture() {
     capturing_ = false;
@@ -1232,10 +1263,43 @@ bool RouterHook::on_eval(ggml_tensor * t, bool ask) {
                 // A weight LEAF (op NONE, named) that is not an expert: the persistent dense weights
                 // --dense-weights anon may rebind. Graph inputs and KV tensors share this shape but are
                 // filtered out downstream by the gguf tensor set, so recording them here is harmless.
-                if (src->op == GGML_OP_NONE) captured_weights_[src->name] = src;
+                if (src->op != GGML_OP_NONE) continue;
+                captured_weights_[src->name] = src;
+                // …and HOW this node used it, which is what decides whether its residency can be
+                // reduced to the rows the graph asks for. Only the table position of a row gather
+                // counts, and only when the index is already in memory when the node runs.
+                if (t->op == GGML_OP_GET_ROWS && s == 0 && index_materialized(t->src[1]))
+                    row_gathered_.insert(src->name);
+                else
+                    row_disqualified_.insert(src->name);
             }
         }
         return false; // capture never isolates a node
+    }
+
+    // ── row-gathered dense tables: put the rows in place before the node reads them ──
+    //
+    // No barrier and no isolation: unlike the routing nodes, nothing here needs the node's OUTPUT —
+    // only to act before it runs, which the ask pass already offers for free. The op test rejects
+    // every node but the handful of gathers a graph contains; the scan in the other arm is the
+    // safety net for a graph shape the capture pass never saw, and it costs a few pointer compares
+    // against the one or two tables a policy actually serves.
+    if (row_source_ && ask) {
+        if (t->op == GGML_OP_GET_ROWS) {
+            ggml_tensor * table = t->src[0];
+            ggml_tensor * ids = t->src[1];
+            if (table && row_source_->serves(table)) {
+                if (ids && ids->data && ids->type == GGML_TYPE_I32)
+                    row_source_->gather(table, (const int32_t *) ids->data, (int) ggml_nelements(ids));
+                else
+                    row_source_->materialize(table); // an index we cannot read: take the whole table
+            }
+        } else {
+            for (int s = 0; s < GGML_MAX_SRC; ++s) {
+                ggml_tensor * src = t->src[s];
+                if (src && row_source_->serves(src)) row_source_->materialize(src);
+            }
+        }
     }
 
     // ── stream: the routing nodes get the single-node barrier so we see the selected ids ──

--- a/core/src/moe/router_hook.h
+++ b/core/src/moe/router_hook.h
@@ -31,6 +31,7 @@
 #include "bmoe/route_trace.h"
 #include "bmoe/decode_trace.h"
 #include "bmoe/predict_stats.h"
+#include "bmoe/row_source.h"
 #include "expert_stream_source.h"
 
 #include <atomic>
@@ -72,7 +73,23 @@ public:
     // against the gguf tensor set, which those do not belong to. Only .tensor is meaningful here.
     const std::unordered_map<std::string, ggml_tensor *> & captured_weights() const { return captured_weights_; }
 
+    // After capture, the subset of those weights the graph only ever GATHERS ROWS from — the shape a
+    // token embedding table has, and the one residency policy can exploit (see IRowSource). A name is
+    // in this set only if EVERY node that referenced the tensor was a row gather taking it as the
+    // table, and every such gather's index was materialized before the node ran (a graph input, or a
+    // view of one). One reference of any other kind — a matmul over the same tensor, which is what
+    // tied embeddings used as the output head look like — disqualifies it, because the whole tensor
+    // is then read and row residency would be a fault per row.
+    //
+    // Derived from what the graph did, not from tensor names: no architecture appears in this rule,
+    // and a model whose embedding table is multiplied simply never qualifies.
+    std::unordered_set<std::string> row_gathered_weights() const;
+
     void set_source(IExpertSource * src) { source_ = src; } // non-null → stream mode
+
+    // Install the row-gathered residency policy (see bmoe/row_source.h). Non-null makes the stream
+    // pass check every gather node against it and make the rows present before the node runs.
+    void set_row_source(IRowSource * src) { row_source_ = src; }
 
     // Temporal prefetch depth K: while streaming layer l, hint the source to read ahead the
     // experts the previous token used at layers l+1..l+K. 0 (default) disables it.
@@ -250,10 +267,15 @@ private:
     MoeRecipe recipe_;
     int n_layer_ = 0;
     bool capturing_ = false;
-    IExpertSource * source_ = nullptr; // non-null → stream mode
+    IExpertSource * source_ = nullptr;  // non-null → stream mode
+    IRowSource * row_source_ = nullptr; // row-gathered dense tables, when the policy is on
     std::vector<LayerExperts> captured_;
-    std::unordered_map<std::string, ggml_tensor *> captured_weights_; // non-expert weight leaves (see captured_weights)
-    std::vector<int32_t> gathered_;                                   // reused scratch for stream-mode id gather
+    std::unordered_map<std::string, ggml_tensor *> captured_weights_;
+    // Capture-time evidence for row_gathered_weights(): every weight seen as the TABLE of a row
+    // gather, and every weight seen in any way that rules that out. The verdict is the difference.
+    std::unordered_set<std::string> row_gathered_;
+    std::unordered_set<std::string> row_disqualified_; // non-expert weight leaves (see captured_weights)
+    std::vector<int32_t> gathered_;                    // reused scratch for stream-mode id gather
 
     // Temporal prefetch: K, and the previous token's routed experts per layer (last-token row
     // during prefill). Empty when prefetch is off or a layer has not been seen yet.

--- a/core/src/moe/row_stream.cpp
+++ b/core/src/moe/row_stream.cpp
@@ -1,0 +1,267 @@
+#include "row_stream.h"
+
+#include "ggml.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+namespace bmoe {
+
+RowStream::~RowStream() {
+    shutdown();
+}
+
+static uint64_t round_up(uint64_t v, uint64_t a) {
+    return (v + a - 1) / a * a;
+}
+
+bool RowStream::init(std::vector<DenseTensorRef> tensors,
+                     const std::vector<std::string> & paths,
+                     size_t align,
+                     uint64_t budget_bytes) {
+    if (tensors.empty()) return true;
+    align_ = align ? align : 4096;
+    page_ = pio::vm_page();
+    budget_bytes_ = budget_bytes ? budget_bytes : default_budget_bytes;
+    // A budget below one slab would make every gather evict what it just read. Round it up rather
+    // than reject the run: the caller asked for "as little as possible", not for a stall.
+    budget_bytes_ = std::max<uint64_t>(budget_bytes_, slab_bytes);
+
+    // One single-lane reader per shard, sized for a slab window. Independent of both the expert
+    // stream's readers and the dense loader's, for the same reason theirs are independent of each
+    // other: the O_DIRECT decision belongs to the consumer, not to the file.
+    for (const std::string & p : paths) {
+        readers_.push_back(std::unique_ptr<FileReader>(new FileReader()));
+        if (!readers_.back()->open(p, 1, /*direct=*/true, align_, (size_t) slab_bytes + 2 * align_)) {
+            std::fprintf(stderr, "bmoe: row-stream could not open %s — tables keep the dense policy\n", p.c_str());
+            readers_.clear();
+            return false;
+        }
+    }
+
+    tables_.reserve(tensors.size());
+    for (const DenseTensorRef & d : tensors) {
+        if (!d.tensor || d.size == 0) continue;
+        if (d.file_idx < 0 || (size_t) d.file_idx >= readers_.size()) {
+            std::fprintf(stderr, "bmoe: row-stream tensor points at shard %d of %zu\n", d.file_idx, readers_.size());
+            release();
+            return false;
+        }
+        Table t;
+        t.ref = d;
+        t.row_bytes = (uint64_t) d.tensor->nb[1];
+        t.n_rows = (uint64_t) d.tensor->ne[1];
+        if (t.row_bytes == 0 || t.n_rows == 0) continue; // not a row-shaped weight; leave it alone
+        t.span = round_up(d.size, page_);
+        t.base = (char *) pio::vm_reserve((size_t) t.span);
+        if (!t.base) {
+            std::fprintf(stderr, "bmoe: row-stream could not reserve %llu MiB for %s\n",
+                         (unsigned long long) (t.span >> 20), d.tensor->name);
+            release();
+            return false;
+        }
+        t.n_slabs = round_up(d.size, slab_bytes) / slab_bytes;
+        t.resident.assign((size_t) t.n_slabs, 0);
+        t.stamp.assign((size_t) t.n_slabs, 0);
+        t.spot.assign((size_t) t.n_slabs, lru_.end());
+        t.orig_data = d.tensor->data;
+        d.tensor->data = t.base; // the reservation mirrors the file layout, so nb/ne still address it
+        table_bytes_ += d.size;
+        tables_.push_back(std::move(t));
+    }
+
+    if (tables_.empty()) { // nothing qualified after the shape check
+        readers_.clear();
+        return true;
+    }
+
+    std::fprintf(stderr,
+                 "bmoe: row-stream — %llu MiB in %zu row-gathered table(s) served from flash, %llu MiB window\n",
+                 (unsigned long long) (table_bytes_ >> 20), tables_.size(), (unsigned long long) (budget_bytes_ >> 20));
+    return true;
+}
+
+RowStream::Table * RowStream::find(const ggml_tensor * table) {
+    for (Table & t : tables_)
+        if (t.ref.tensor == table) return &t;
+    return nullptr;
+}
+
+const RowStream::Table * RowStream::find(const ggml_tensor * table) const {
+    for (const Table & t : tables_)
+        if (t.ref.tensor == table) return &t;
+    return nullptr;
+}
+
+bool RowStream::serves(const ggml_tensor * table) const {
+    return find(table) != nullptr;
+}
+
+void RowStream::touch(Table & t, uint64_t s) {
+    const size_t ti = (size_t) (&t - tables_.data());
+    if (t.spot[(size_t) s] != lru_.end()) lru_.erase(t.spot[(size_t) s]);
+    lru_.push_back({ti, s});
+    t.spot[(size_t) s] = std::prev(lru_.end());
+}
+
+// Bytes a slab holds: the last one is short by whatever the table's size is not a multiple of.
+static uint64_t slab_len(const uint64_t size, const uint64_t s, const uint64_t slab) {
+    const uint64_t off = s * slab;
+    return std::min<uint64_t>(slab, size - off);
+}
+
+bool RowStream::fetch_slab(Table & t, uint64_t s) {
+    if (t.resident[(size_t) s]) {
+        touch(t, s);
+        return true;
+    }
+    const uint64_t off = s * slab_bytes;
+    const uint64_t len = slab_len(t.ref.size, s, slab_bytes);
+    // Commit whole pages: the slab is a multiple of the page and the reservation is page-aligned,
+    // so only the final short slab needs rounding, and it cannot run past the reservation.
+    const uint64_t commit = std::min<uint64_t>(round_up(len, page_), t.span - off);
+    if (!pio::vm_commit(t.base + off, (size_t) commit)) {
+        std::fprintf(stderr, "bmoe: row-stream commit failed at slab %llu of %s\n", (unsigned long long) s,
+                     t.ref.tensor->name);
+        io_errors_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+    const long long got = readers_[(size_t) t.ref.file_idx]->read(0, t.base + off, t.ref.file_off + off, len);
+    if (got < 0) {
+        std::fprintf(stderr, "bmoe: row-stream read failed at slab %llu of %s\n", (unsigned long long) s,
+                     t.ref.tensor->name);
+        io_errors_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+    t.resident[(size_t) s] = 1;
+    touch(t, s);
+    resident_bytes_.fetch_add(commit, std::memory_order_relaxed);
+    slab_reads_.fetch_add(1, std::memory_order_relaxed);
+    bytes_read_.fetch_add((uint64_t) got, std::memory_order_relaxed);
+    return true;
+}
+
+// Hand back the oldest slabs until `headroom` bytes fit under the budget. Slabs stamped for the
+// gather in flight are skipped: evicting a row the node about to run is going to read would be a
+// correctness bug wearing a performance decision's clothes.
+void RowStream::evict_to_budget(uint64_t headroom) {
+    if (resident_bytes_.load(std::memory_order_relaxed) + headroom <= budget_bytes_) return;
+    for (auto it = lru_.begin(); it != lru_.end();) {
+        if (resident_bytes_.load(std::memory_order_relaxed) + headroom <= budget_bytes_) break;
+        Table & t = tables_[it->first];
+        const uint64_t s = it->second;
+        if (t.stamp[(size_t) s] == gen_) { // needed by the gather in flight
+            ++it;
+            continue;
+        }
+        const uint64_t off = s * slab_bytes;
+        const uint64_t len = slab_len(t.ref.size, s, slab_bytes);
+        const uint64_t commit = std::min<uint64_t>(round_up(len, page_), t.span - off);
+        pio::vm_evict(t.base + off, (size_t) commit);
+        t.resident[(size_t) s] = 0;
+        t.spot[(size_t) s] = lru_.end();
+        resident_bytes_.fetch_sub(commit, std::memory_order_relaxed);
+        evictions_.fetch_add(1, std::memory_order_relaxed);
+        it = lru_.erase(it);
+    }
+}
+
+bool RowStream::gather(const ggml_tensor * table, const int32_t * idx, int n) {
+    Table * t = find(table);
+    if (!t) return true; // not ours: the caller checked serves(), so this is only belt-and-braces
+    gathers_.fetch_add(1, std::memory_order_relaxed);
+    if (t->whole || n <= 0 || !idx) return true;
+    rows_.fetch_add((uint64_t) n, std::memory_order_relaxed);
+
+    // Which slabs the rows land in, deduplicated. A row can straddle a slab boundary, so a row
+    // contributes the whole span it covers, not just the slab its first byte is in.
+    ++gen_;
+    if (gen_ == 0) { // wrapped: no stamp may claim to be from the current gather
+        for (Table & tt : tables_)
+            std::fill(tt.stamp.begin(), tt.stamp.end(), 0);
+        gen_ = 1;
+    }
+    need_.clear();
+    uint64_t missing = 0;
+    for (int i = 0; i < n; ++i) {
+        const int32_t r = idx[i];
+        if (r < 0 || (uint64_t) r >= t->n_rows) continue; // the graph defines validity, not us
+        const uint64_t a = (uint64_t) r * t->row_bytes;
+        const uint64_t b = std::min<uint64_t>(a + t->row_bytes, t->ref.size);
+        for (uint64_t s = a / slab_bytes; s * slab_bytes < b; ++s) {
+            if (s >= t->n_slabs) break;
+            if (t->stamp[(size_t) s] == gen_) continue;
+            t->stamp[(size_t) s] = gen_;
+            need_.push_back(s);
+            if (!t->resident[(size_t) s]) missing += slab_bytes;
+        }
+    }
+    if (need_.empty()) return true;
+
+    // Make room first, then read: an eviction pass that ran afterwards could take back a slab this
+    // very gather just paid for. A gather that alone exceeds the budget (a long prefill on a small
+    // window) simply overshoots it for one node rather than thrashing — the ceiling is there to
+    // bound the run, and no bound is worth a read per row.
+    evict_to_budget(missing);
+    std::sort(need_.begin(), need_.end()); // ascending file offsets: the drive's preferred order
+    for (uint64_t s : need_)
+        if (!fetch_slab(*t, s)) return false;
+    return true;
+}
+
+bool RowStream::materialize(const ggml_tensor * table) {
+    Table * t = find(table);
+    if (!t) return true;
+    if (t->whole) return true;
+    std::fprintf(stderr,
+                 "bmoe: row-stream — %s is read by a node that is not a row gather; pulling the whole "
+                 "%llu MiB table in\n",
+                 t->ref.tensor->name, (unsigned long long) (t->ref.size >> 20));
+    for (uint64_t s = 0; s < t->n_slabs; ++s)
+        if (!fetch_slab(*t, s)) return false;
+    // A materialized table leaves the LRU: it is resident for the rest of the run, and an eviction
+    // that took one of its slabs would put us right back at the fault this call exists to avoid.
+    for (uint64_t s = 0; s < t->n_slabs; ++s) {
+        if (t->spot[(size_t) s] != lru_.end()) {
+            lru_.erase(t->spot[(size_t) s]);
+            t->spot[(size_t) s] = lru_.end();
+        }
+    }
+    t->whole = true;
+    materialized_.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+RowSourceStats RowStream::stats() const {
+    RowSourceStats s;
+    s.table_bytes = table_bytes_;
+    s.resident_bytes = resident_bytes_.load(std::memory_order_relaxed);
+    s.gathers = gathers_.load(std::memory_order_relaxed);
+    s.rows = rows_.load(std::memory_order_relaxed);
+    s.slab_reads = slab_reads_.load(std::memory_order_relaxed);
+    s.bytes_read = bytes_read_.load(std::memory_order_relaxed);
+    s.evictions = evictions_.load(std::memory_order_relaxed);
+    s.materialized = materialized_.load(std::memory_order_relaxed);
+    s.io_errors = io_errors_.load(std::memory_order_relaxed);
+    return s;
+}
+
+void RowStream::release() {
+    for (Table & t : tables_) {
+        if (t.ref.tensor && t.orig_data) t.ref.tensor->data = t.orig_data; // back to the mmap
+        if (t.base) pio::vm_release(t.base, (size_t) t.span);
+        t.base = nullptr;
+    }
+    tables_.clear();
+    lru_.clear();
+    readers_.clear();
+    resident_bytes_.store(0, std::memory_order_relaxed);
+    table_bytes_ = 0;
+}
+
+void RowStream::shutdown() {
+    release();
+}
+
+} // namespace bmoe

--- a/core/src/moe/row_stream.h
+++ b/core/src/moe/row_stream.h
@@ -1,0 +1,129 @@
+// Row-gathered dense tables, served from flash instead of RAM.
+//
+// The default dense policy makes every non-expert weight resident, because that is what a weight
+// that is multiplied is: read whole, every token. A table the graph only GATHERS ROWS from is not
+// that. A token embedding is the extreme case — one row per decoded token out of a vocabulary of
+// hundreds of thousands — and on a big model it is hundreds of MiB of residency bought for a
+// kilobyte of use per token. On a phone that RAM is the whole budget: it is what the expert cache
+// does not get, and what the kernel reclaims to zram when it runs out.
+//
+// So: reserve the table's address space, bind the tensor to it, and commit only the pages the
+// graph is about to read, filled by an O_DIRECT read of exactly those bytes. The reservation
+// mirrors the tensor's own byte layout, so ggml's address arithmetic (`data + i*nb1`) is
+// unchanged and the gather kernel is untouched — the same trick the expert cache plays on
+// `mul_mat_id`, at row granularity instead of expert granularity.
+//
+// WHICH tables get this is not a list in this file and not a name pattern: it is what the graph
+// says (see RouterHook's capture pass). A table qualifies only when EVERY reference to it in the
+// captured graph is a row gather, and the index it is gathered by is materialized before the node
+// runs. Anything else — a weight that is also multiplied, tied embeddings used as the output head,
+// an index computed inside the graph — is not served here and keeps the dense policy it had.
+// materialize() is the belt to that braces: a graph shape we never saw still gets its bytes.
+//
+// The residency window is bounded (`budget_bytes`) and evicted LRU, in page-aligned SLABS rather
+// than single rows: a row is ~1 KiB, a read below the device's request floor costs the same as one
+// at it, and adjacent vocabulary rows recur. The budget is a ceiling, not a target — a run that
+// gathers few distinct rows simply never fills it.
+#pragma once
+
+#include "../io/file_reader.h"
+#include "../io/platform_io.h"
+#include "bmoe/row_source.h"
+#include "dense_weights.h" // DenseTensorRef
+
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
+struct ggml_tensor;
+
+namespace bmoe {
+
+class RowStream final : public IRowSource {
+public:
+    RowStream() = default;
+    ~RowStream() override;
+
+    RowStream(const RowStream &) = delete;
+    RowStream & operator=(const RowStream &) = delete;
+
+    // Take over `tensors` (already filtered by the caller to tables the graph only row-gathers),
+    // reserving address space for each and rebinding its ggml tensor onto it. `paths` are the shard
+    // files in shard order, `align` the O_DIRECT block size, `budget_bytes` the ceiling on resident
+    // slabs across all tables (0 = a built-in default). Returns false only if a table could not be
+    // taken over at all, in which case NOTHING has been rebound and the caller keeps its own policy:
+    // this module never leaves a tensor half-owned.
+    bool init(std::vector<DenseTensorRef> tensors,
+              const std::vector<std::string> & paths,
+              size_t align,
+              uint64_t budget_bytes);
+
+    bool empty() const { return tables_.empty(); }
+
+    // ── IRowSource ───────────────────────────────────────────────────────────────────
+    bool serves(const ggml_tensor * table) const override;
+    bool gather(const ggml_tensor * table, const int32_t * idx, int n) override;
+    bool materialize(const ggml_tensor * table) override;
+    RowSourceStats stats() const override;
+
+    void shutdown();
+
+    // A row is far below any device's request floor, so a slab is the unit actually read: large
+    // enough that the read costs what the floor costs anyway, small enough that a scattered
+    // vocabulary does not drag megabytes of neighbours in behind it. Not a per-model number —
+    // it is a property of the storage, and the same value serves every table.
+    static constexpr uint64_t slab_bytes = 16ull << 10;
+    static constexpr uint64_t default_budget_bytes = 64ull << 20;
+
+private:
+    struct Table {
+        DenseTensorRef ref;
+        char * base = nullptr;  // reserved span the tensor is bound to
+        uint64_t span = 0;      // reserved bytes (ref.size rounded up to a page)
+        uint64_t row_bytes = 0; // nb[1]
+        uint64_t n_rows = 0;    // ne[1]
+        uint64_t n_slabs = 0;
+        std::vector<uint8_t> resident; // one flag per slab
+        std::vector<uint32_t> stamp;   // last gather generation that needed the slab (eviction guard)
+        // LRU over resident slabs: the list holds (table, slab) oldest-first, `spot` the position of
+        // a resident slab in it (end() when not resident).
+        std::vector<std::list<std::pair<size_t, uint64_t>>::iterator> spot;
+        void * orig_data = nullptr; // what the tensor pointed at before we bound it, restored on release
+        bool whole = false;         // materialize() has pulled everything; gather() is then a no-op
+    };
+
+    // Make slab `s` of `t` present, reading it from the shard. No-op when already resident.
+    bool fetch_slab(Table & t, uint64_t s);
+    // Hand back oldest slabs until `headroom` more bytes fit under the budget.
+    void evict_to_budget(uint64_t headroom);
+    void touch(Table & t, uint64_t s);
+    Table * find(const ggml_tensor * table);
+    const Table * find(const ggml_tensor * table) const;
+    void release();
+
+    std::vector<Table> tables_;
+    std::vector<std::unique_ptr<FileReader>> readers_; // one per shard; FileReader is not movable
+    std::list<std::pair<size_t, uint64_t>> lru_;       // (table index, slab index), oldest first
+    uint64_t budget_bytes_ = default_budget_bytes;
+    uint64_t table_bytes_ = 0; // total size of the tables taken over
+    size_t align_ = 4096;
+    uint64_t page_ = 4096;
+    uint32_t gen_ = 0;           // gather generation, stamped on the slabs the current node needs
+    std::vector<uint64_t> need_; // scratch: the slabs of the gather in flight (eval thread only)
+
+    std::atomic<uint64_t> resident_bytes_{0};
+    // Counters are written on the eval thread and read by the metrics thread; relaxed atomics keep
+    // that honest without pretending the pair is a consistent snapshot.
+    std::atomic<uint64_t> gathers_{0};
+    std::atomic<uint64_t> rows_{0};
+    std::atomic<uint64_t> slab_reads_{0};
+    std::atomic<uint64_t> bytes_read_{0};
+    std::atomic<uint64_t> evictions_{0};
+    std::atomic<uint64_t> materialized_{0};
+    std::atomic<uint64_t> io_errors_{0};
+};
+
+} // namespace bmoe

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ for the idea the project is built on.
 | [cache-sizing.md](cache-sizing.md) | `--cache-mb auto`, the cache ceiling, and dense warm-up. |
 | [prefetch.md](prefetch.md) | `--prefetch K`: the design and why it cannot change output (with the lossy knobs off). |
 | [expert-dropping.md](expert-dropping.md) | `--drop-cold-experts F`: spending quality only where it buys a flash read, and why it is the one setting whose output is not reproducible. |
+| [row-gathered-tables.md](row-gathered-tables.md) | `--row-stream`: serving a dense table the graph only gathers rows from out of flash, and how the engine decides which tables those are without naming one. |
 | [mtp.md](mtp.md) | `--mtp`: drafting with the model's own MTP head and verifying a whole group per decode — lossless by construction, and why a wider decode can lose in the streamed regime. |
 | [ngram.md](ngram.md) | `--ngram`: drafting from text that repeats, with no head and no draft decode — and why a source that abstains costs exactly an unspeculated step. |
 | [expert-prediction.md](expert-prediction.md) | `--predict-log`: how much of a routing can be known a layer early, measured against the predictor `--prefetch` already bets on — and why a good score still would not mean a faster decode. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ core/
   include/bmoe/ ports (interfaces) + config, pure policy, no llama.cpp dependency
     config.h        RunConfig + validate()
     expert_source.h IExpertSource — the residency strategy port
+    row_source.h    IRowSource - the row-gathered residency port
     recipe.h        MoeRecipe + registry
     metrics.h       TokenMetrics / RunSummary + IMetricsSink
     runtime.h       run() entry point
@@ -24,6 +25,7 @@ core/
     moe/        gguf_offsets (tensor → (shard, offset), split ggufs included), arch_registry,
                 expert_stream_source (one reader per shard), router_hook
                 dense_weights — non-expert weight policy + the residency sensor
+                row_stream - row-gathered tables served from flash (see row-gathered-tables.md)
     engine/     session — composition + the generation loop (open/generate/close)
                 runtime — the one-shot run() wrapper over a Session
                 chat_parse — reasoning-parser wiring (llama.cpp `common`, see seam.md)

--- a/docs/row-gathered-tables.md
+++ b/docs/row-gathered-tables.md
@@ -1,0 +1,111 @@
+# Row-gathered dense tables (`--row-stream`)
+
+A dense weight that is *multiplied* is read whole, every token: making it resident is the only
+sensible policy, and that is what `--dense-weights` decides between. A dense weight the graph only
+**gathers rows from** is a different object. The token embedding table is the pure case, one row
+per decoded token out of a vocabulary of hundreds of thousands, and on a big model it is hundreds
+of MiB of RAM bought for a kilobyte of use per token.
+
+`--row-stream` binds such a table to *reserved address space* and pulls in only the rows the graph
+is about to read, from flash. Measured on the 12 GB test phone:
+
+| model | table | resident dense, off | resident dense, on | flash read for it |
+| --- | ---: | ---: | ---: | ---: |
+| Qwen3.6-35B-A3B UD-Q3_K_XL | `token_embd` 515 MiB | 2436 MiB | 1921 MiB | 0.4 MiB / 12 tokens |
+| Qwen3.8-Flash-Next UD-IQ3_XXS | `token_embd` 497 MiB | 4313 MiB | 3816 MiB | 0.4 MiB / 24 tokens |
+
+Output is byte-identical in every cell. That is not a quality claim but a structural fact: see
+[Why identity is the whole test](#why-identity-is-the-whole-test).
+
+## Which tables qualify, and why there is no list of them
+
+Nothing in the engine names a tensor. During the streamer's capture decode every graph node is
+already offered to the eval callback, and each reference to a dense weight is classified by *how
+the node used it*. A table qualifies only when both hold:
+
+1. **Every** reference to it in the captured graph is a row gather (`GGML_OP_GET_ROWS`) with the
+   table in the source position. One reference of any other kind disqualifies it.
+2. Every such gather's index tensor is already materialized when the node runs: a graph input, or
+   a pure view of one. An index computed inside the graph cannot be read before the node that
+   produces it has run.
+
+Both conditions are properties of the graph, so the rule carries to architectures nobody had in
+mind when it was written:
+
+- A model with **tied embeddings**, where `token_embd` is also the output head, fails rule 1 on
+  the head's matmul and keeps the residency it had. No special case, on any architecture.
+- Qwen3.8-Flash-Next's **n-gram table** (`per_layer_token_embd`, ~27 GB) *is* row-gathered, but by
+  hashes computed inside the graph, so it fails rule 2 and falls through to the size guard that
+  was measured for it: mmap'd with random-access advice (see [architecture.md](architecture.md)
+  and the 0.22.0 changelog entry).
+
+The policy is also restricted to tables that could have been resident at all, which is to say it
+runs after that size guard. That is deliberate: the fallback below has to be able to pull a whole
+table in, and a table larger than memory could not honour it.
+
+## Mechanism
+
+The reservation mirrors the tensor's own byte layout, so ggml's address arithmetic
+(`data + i*nb1`) is unchanged and the gather kernel is untouched. It is the same trick the expert
+cache plays on `mul_mat_id`, at row granularity instead of expert granularity.
+
+- **Slabs, not rows.** A row is ~1 KiB, far below any device's request floor, so the unit fetched
+  is a 16 KiB page-aligned slab: a read that size costs what the floor costs anyway, and adjacent
+  vocabulary rows recur. This is a property of the storage, not of a model.
+- **A bounded window.** `--row-stream-mb` (default 64) caps what all row-streamed tables hold
+  resident together, evicted LRU. In practice a run never approaches it, since the tables above
+  hold well under a MiB, but the ceiling is what makes the residency claim a guarantee rather than
+  a hope. A single gather that alone exceeds the window overshoots it for that one node rather
+  than reading a row at a time, and the slabs the gather in flight needs are never evicted under
+  it.
+- **Ordered reads.** A gather's slabs are deduplicated and issued in ascending file order.
+- **A fallback with teeth.** `IRowSource::materialize()` pulls the whole table in and says so on
+  stderr. It fires if a graph shape the capture pass never saw reads a served table any other way,
+  or if a gather's index turns out to be unreadable. The engine is then simply back to the
+  behaviour it would have had without the flag.
+
+The policy applies **under every `--dense-weights` mode**, because what it changes is not how a
+mode works but which tensors the mode is applied to. A table it takes over leaves the resident
+dense set entirely: not read, not rebound, not warmed, and outside the residency sensor. A sensor
+that counted it would report a set that is resident by design only in part.
+
+## Why identity is the whole test
+
+The tensor is bound to **reserved**, not allocated, memory. A row the policy failed to fetch is
+therefore not a slightly wrong weight: it is memory that was never written, and the output
+diverges on the first token that touches it. Byte-identity to the resident reference is proof that
+every gathered row arrived.
+
+Gates `G15a` and `G15b` in `tests/moe_gates.cpp` assert exactly that on all three tiny models,
+`G15b` with a window of one slab so that nearly every gather has to re-read what the previous one
+handed back. What a gate cannot prove is that a table qualified at all. That is what the run's own
+`moe-rows:` line reports, on the real model.
+
+## What it costs, and what it is for
+
+The read cost is negligible in both directions measured: 0.4 MiB across a whole generation,
+against 4.5 GB of expert reads on Qwen3.8. Expert bytes, cache hit rate, evictions and re-reads
+are identical to the digit with the flag on and off, so the expert path is not touched.
+
+Throughput is, so far, **neutral**. Interleaved host cells on Qwen3.6-35B-A3B Q4_K_M gave 2.22 and
+2.30 tok/s with the flag off, 2.27 and 2.31 with it on, a spread smaller than the one between the
+two baseline runs. The flag is off by default until a long on-device run says more.
+
+What it is actually for is the RAM. On the 12 GB phone, Qwen3.8-Flash-Next pins 4.3 GB of dense
+weights, and the kernel's reclaim accounting cannot see them: `MemAvailable` falls under ~0.9 GB
+and the anonymous expert cache starts being compacted to zram, which is what a 2 to 7 second token
+is (see the 0.22.0 changelog entry). Half a gigabyte handed back to the system addresses that
+cause directly, and is also half a gigabyte the expert cache can take instead.
+
+## Flags
+
+```
+--row-stream        serve row-gathered dense tables from flash instead of RAM
+--row-stream-mb N   resident window for those tables, in MiB (default 64)
+```
+
+Requires `--moe-stream`, since the tables are discovered by the capture pass and fed by the eval
+callback. In the Android app: **Stream row-gathered tables**, next to the dense-weight mode.
+
+Telemetry: the `moe-rows:` end-of-run line and the `row_*` keys in the CSV summary trailer, both
+in [telemetry.md](telemetry.md).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -141,6 +141,21 @@ tag, where the useful fraction sits at ~100% by construction: the "speculated" i
 committed routing itself (see [route-ahead.md](route-ahead.md)). The CSV preamble records which
 was active (`prefetch=` / `predict_prefetch=` / `route_ahead=`).
 
+With `--row-stream` a `moe-rows:` line is added, and only when a table actually qualified:
+
+```
+moe-rows: <mib> MiB of row-gathered table(s) off the resident set, <mib> MiB resident,
+<n> rows gathered, <n> reads (<mib> MiB)
+```
+
+The first two numbers are the trade: what those tables would have occupied under the ordinary
+dense policy, and what they occupy now. The last three are what buying it cost in flash - read
+them against the `moe-stream:` byte count on the same run. A second line appears only on failure
+(`<n> FAILED reads - this run's output is not trustworthy`); since the tables are bound to
+reserved address space, a fetch that did not happen is memory that was never written, so that line
+means the generated text is garbage rather than merely slow. See
+[row-gathered-tables.md](row-gathered-tables.md).
+
 With `--route-ahead N` a `moe-route-ahead:` line is added:
 
 ```
@@ -305,7 +320,7 @@ line likewise gains `stall_s/tok=<s>`, `mgmt_s/tok=<s>`, `majflt/tok=<f>`, `cpu_
 floor to defend; see [pressure.md](pressure.md)), `experts_routed=<n>` / `experts_dropped=<n>` (what
 [cache-aware dropping](expert-dropping.md) actually discarded during generation — the flag sets a
 threshold, not a rate, so this is the only record of the trade a run made) and
-`layer_demand_MiB=<f>` (the widest layer's routed
+`row_table_MiB=<f>` / `row_resident_MiB=<f>` / `row_rows=<n>` / `row_reads=<n>` / `row_read_MiB=<f>` / `row_evictions=<n>` / `row_io_errors=<n>` (the row-gathered tables described above; all zero when `--row-stream` is off or nothing qualified) and `layer_demand_MiB=<f>` (the widest layer's routed
 bytes: the mechanical floor the cache must be able to stage) and `loop_overhead_s/tok=<s>` (see
 [below](#what-toks-does-not-include)) and, under `--mtp` or `--ngram`, `mtp_drafted=<n>` /
 `mtp_accepted=<n>` / `mtp_decodes=<n>` (the acceptance rate and how many decodes the generation

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -119,6 +119,12 @@ with Mmap it is refaulted from flash every token. Its 51B n-gram table is held b
 stays mmap'd whatever the setting; the engine says so on stderr at load. Keep the expert cache at
 1000-1500 MiB on a 12 GB phone: the pinned dense set leaves no room for more.
 
+**Stream row-gathered tables** takes ~500 MiB more off that pinned set on this model, and 515 MiB
+on Qwen3.6: the token embedding table is read one row per token, so it does not need to be in
+RAM at all. The reply is identical either way. It is off by default until a long run on a phone
+says whether the RAM it hands back is worth the reads, which is exactly the kind of thing this
+app exists to find out.
+
 ## Expected numbers
 
 On a phone with UFS 4.x storage and ~12 GB RAM, streaming Qwen3-30B-A3B-Q4_K_M with the
@@ -150,3 +156,6 @@ Two worth knowing before you turn them on:
 - **"Decide the experts early"** (`--route-ahead`) commits each layer's routing before that layer
   runs, so the reads can never be wasted. It changes the reply, and it is refused alongside guessing
   ahead. See `../../docs/route-ahead.md`.
+- **"Stream row-gathered tables"** (`--row-stream`) serves the token embedding table out of flash
+  instead of RAM. Lossless, and which tables it applies to is read off the model's own graph, so
+  on a model where none qualify it does nothing. See `../../docs/row-gathered-tables.md`.

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -51,8 +51,8 @@ android {
         applicationId 'io.bigmoeonedge.example'
         minSdk 29
         targetSdk 34
-        versionCode 38
-        versionName '0.23.0'
+        versionCode 39
+        versionName '0.24.0'
         buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         ndk {
             // The engine ships as prebuilt arm64 binaries staged by build-android.ps1.

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/AppSettings.kt
@@ -58,6 +58,13 @@ data class AppSettings(
     // share itself). Stored as an Int because the settings are integer rungs; the flag takes a
     // fraction. LOSSY and cache-dependent — it changes the output, and not reproducibly.
     val dropColdPct: Int = 75,
+    // Serve the dense tables the graph only GATHERS ROWS from - a token embedding - out of flash
+    // instead of RAM. Which tables qualify is decided by the graph at load, so this is one switch
+    // for every model rather than a per-model list; on a model where nothing qualifies it does
+    // nothing at all. Lossless by construction (the rows read are the rows the graph asks for),
+    // so the only question it raises is whether the reads cost more than the RAM is worth - which
+    // is why it is off until the on-device A/B says otherwise.
+    val rowStream: Boolean = false,
     // Which source drafts for self-speculation: "off", "mtp" or "ngram". Both verify the same way —
     // one wider decode, greedy acceptance — and differ only in what a draft costs.
     //
@@ -164,6 +171,10 @@ data class AppSettings(
             // same cacheOn condition that guards prefetch guards this. The engine takes a fraction
             // of the uniform share; the setting is stored as a percentage.
             if (dropColdPct > 0 && cacheOn) a += listOf("--drop-cold-experts", (dropColdPct / 100.0).toString())
+            // Row-gathered dense tables. Inside the streaming block because the tables are
+            // discovered by the streamer's capture pass; independent of the cache and of the
+            // dense-weight mode, since what it changes is which tensors that mode applies to.
+            if (rowStream) a += "--row-stream"
         }
         // Outside the streaming block on purpose: speculation is a decode-loop change, not a
         // residency policy, so it applies to the mmap baseline too — which is what makes an A/B of
@@ -209,6 +220,7 @@ data class AppSettings(
             .putInt("predictSpecMax", predictSpecMax)
             .putInt("routeAhead", routeAhead)
             .putInt("dropColdPct", dropColdPct)
+            .putBoolean("rowStream", rowStream)
             .putInt("sessionCtx", sessionCtx)
             .putString("spec", spec).putInt("mtpDraft", mtpDraft).putInt("mtpPMinPct", mtpPMinPct)
             .putBoolean("thinking", thinking)
@@ -347,6 +359,7 @@ data class AppSettings(
                 predictSpecMax = p.getInt("predictSpecMax", d.predictSpecMax),
                 routeAhead = p.getInt("routeAhead", d.routeAhead),
                 dropColdPct = p.getInt("dropColdPct", d.dropColdPct),
+                rowStream = p.getBoolean("rowStream", d.rowStream),
                 sessionCtx = p.getInt("sessionCtx", d.sessionCtx),
                 spec = run {
                     val saved = p.getString("spec", null)

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/SettingsScreen.kt
@@ -117,6 +117,16 @@ fun SettingsScreen(current: AppSettings, onChange: (AppSettings) -> Unit, onBack
                 ) { onChange(current.copy(denseWeights = DenseWeights.values()[it])) }
                 Hint(current.denseWeights.blurb)
 
+                SwitchRow(
+                    "Stream row-gathered tables",
+                    "A dense table the model only reads a few ROWS from per token (the token " +
+                        "embedding) does not need to be in RAM: only the rows are read, from flash. " +
+                        "Lossless - the output is identical. Which tables qualify is read off the " +
+                        "graph at load, so on a model where none do this does nothing.",
+                    current.rowStream,
+                    enabled = stream,
+                ) { onChange(current.copy(rowStream = it)) }
+
                 ExperimentalGroup {
                     IntSetting(
                         "Temporal prefetch (layers)", AppSettings.PREFETCH_CHOICES, current.prefetchLayers,

--- a/tests/moe_gates.cpp
+++ b/tests/moe_gates.cpp
@@ -47,6 +47,16 @@
 //       abstains, so every step takes the plain path and the output must be identical
 //   G14 --route-ahead, in two halves: a horizon past every layer overrides nothing and must be
 //       identical, and a horizon of one must commit real routings and still generate
+////   G15 --row-stream, the dense tables the graph only gathers rows from: a) served from flash
+//       inside the default window and b) inside a window of one slab, so nearly every gather
+//       evicts what the last one fetched. Both must be byte-identical to the resident reference.
+//
+// G15 needs no separate "did it do anything" check of the G10 kind: the tensor is bound to
+// RESERVED address space, so a row the policy fails to fetch is not a slightly wrong weight but
+// memory that was never written, and the output diverges on the first token. Identity is proof
+// that every gathered row was fetched. What it cannot prove is that a table qualified at all —
+// on a tiny model with tied embeddings none would, and the gate would pass vacuously. That is
+// what the run's own "moe-rows:" line reports, on the real model.
 //
 // Gate numbers are allocated once and never reused: a failing label has to name one thing. G11 and
 // G12 are reserved for the zero-copy branch (PR #143) and must not be taken here.
@@ -205,6 +215,20 @@ int main(int argc, char ** argv) {
     RunConfig dense_od_buf = dense_od;
     dense_od_buf.moe.o_direct = false;
 
+    // Row-gathered dense tables served from flash instead of RAM. The table is bound to reserved
+    // address space, so a row the policy failed to fetch is not a slightly wrong weight — it is
+    // unwritten memory, and the output diverges immediately. That makes byte-identity the whole
+    // test: G15a covers the ordinary path, G15b the eviction path, with a window of one slab so that
+    // almost every gather has to re-read what the previous one just handed back.
+    RunConfig rows = base(model);
+    rows.moe.enabled = true;
+    rows.moe.cache_mb = 0;
+    rows.moe.io_threads = 4;
+    rows.moe.row_stream = true;
+
+    RunConfig rows_tight = rows;
+    rows_tight.moe.row_stream_mb = 0; // clamped to a single slab: maximum eviction pressure
+
     std::string s_res, s_s0, s_sc, s_all, s_dod, s_dodb, err;
     if (!gen(resident, s_res, err)) {
         std::fprintf(stderr, "resident run failed: %s\n", err.c_str());
@@ -230,6 +254,15 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "dense-odirect(no O_DIRECT) run failed: %s\n", err.c_str());
         return 2;
     }
+    std::string s_rows, s_rows_tight;
+    if (!gen(rows, s_rows, err)) {
+        std::fprintf(stderr, "row-stream run failed: %s\n", err.c_str());
+        return 2;
+    }
+    if (!gen(rows_tight, s_rows_tight, err)) {
+        std::fprintf(stderr, "row-stream(one-slab window) run failed: %s\n", err.c_str());
+        return 2;
+    }
 
     int fails = 0;
     fails += check("G1 resident == streaming(cache off)", s_res, s_s0);
@@ -241,6 +274,8 @@ int main(int argc, char ** argv) {
     fails += check("G6 dense-odirect(rebind) == resident", s_res, s_dod);
     // G7: the rebind is byte-identical whether or not the dense read bypassed the page cache.
     fails += check("G7 dense=anon + expert O_DIRECT off == resident", s_res, s_dodb);
+    fails += check("G15a row-stream(row-gathered tables from flash) == resident", s_res, s_rows);
+    fails += check("G15b row-stream(one-slab window, evicting) == resident", s_res, s_rows_tight);
 
 #ifdef BMOE_HAVE_EXPERT_READY_HOOK
     // overlap, cache off


### PR DESCRIPTION
The dense policy has one shape for every non-expert weight, and it is the right shape for a weight that is multiplied: read it whole, keep it resident. A token embedding table is not that. The graph gathers one row of it per decoded token out of a vocabulary of hundreds of thousands, and on a big model that is hundreds of MiB of RAM bought for a kilobyte of use per token.

`--row-stream` binds such a table to *reserved* address space and pulls in only the rows the graph is about to read, in 16 KiB slabs, inside a bounded LRU window (`--row-stream-mb`, default 64). The reservation mirrors the tensor's own byte layout, so ggml's address arithmetic is unchanged and the gather kernel is untouched: the trick the expert cache already plays on `mul_mat_id`, at row granularity instead of expert granularity.

## Which tables qualify, and why there is no list of them

Nothing in the engine names a tensor. During the streamer's capture decode every reference to a dense weight is classified by *how the node used it*, and a table is served only when both hold:

1. every reference to it was a row gather (`GGML_OP_GET_ROWS`) taking it as the table, and
2. every such gather's index is materialized before the node runs (a graph input, or a pure view of one).

Both are properties of the graph, so the rule carries to architectures it was not written for:

* a model with **tied embeddings**, where the table is also the output head, fails test 1 on that matmul and keeps the residency it had, on any architecture, with no special case;
* Qwen3.8-Flash-Next's **51B n-gram table** *is* row-gathered, but by hashes computed inside the graph, so it fails test 2 and keeps the size guard that was measured for it in 0.22.0. Confirmed on device: `27465 MiB in 1 tensor(s) exceeds the 5183 MiB available: left mmap'd`.

`IRowSource::materialize()` is the fallback if some later graph reads a served table any other way: the whole table is pulled in and the run says so on stderr.

## Measured

On the 12 GB test phone via `adb shell run-as`, thermal status 0 and full clocks before each cell, output byte-identical in every pair:

| model | table | pinned dense, off | pinned dense, on | flash read for it |
| --- | ---: | ---: | ---: | ---: |
| Qwen3.8-Flash-Next UD-IQ3_XXS | `token_embd` 497 MiB | 4313 MiB | **3816 MiB** | 0.4 MiB / 24 tokens |
| Qwen3.6-35B-A3B UD-Q3_K_XL | `token_embd` 515 MiB | 2436 MiB | **1921 MiB** | 0.4 MiB / 12 tokens |

Expert bytes, cache hit rate, evictions and re-reads are identical to the digit with the flag on and off, so the expert path is not touched. On Qwen3.8 the run reports `moe-rows: 497 MiB of row-gathered table(s) off the resident set, 0.3 MiB resident, 29 rows gathered, 19 reads (0.4 MiB)` against 4487 MiB of expert reads on the same generation.

**Throughput is neutral so far**, and this PR does not claim otherwise. Interleaved host cells on Qwen3.6-35B-A3B Q4_K_M (off, on, on, off) gave 2.22 and 2.30 tok/s off against 2.27 and 2.31 on: a spread smaller than the one between the two baselines. The flag ships off by default. The claim it makes is about RAM.

The RAM is the point. On the model whose 4.3 GB pinned dense set is invisible to the kernel's reclaim accounting, half a gigabyte handed back goes straight at the cause of the 2 to 7 second tokens documented in 0.22.0, and is also half a gigabyte the expert cache can take instead. That is a long in-app run, still owed.

## Why byte-identity is the whole test

The tensor is bound to reserved, not allocated, memory. A row the policy failed to fetch is not a slightly wrong weight, it is memory that was never written, and the output diverges on the first token that touches it. Identity to the resident reference is therefore proof that every gathered row arrived.

`G15a` and `G15b` assert exactly that on all three tiny models, `G15b` with a window of one slab so nearly every gather has to re-read what the previous one handed back. Gates 11/11 on the host.

## Shape of the change

* new port `core/include/bmoe/row_source.h` (`IRowSource`), adapter `core/src/moe/row_stream.cpp`, owned by `DenseWeights` since it is a dense residency policy, driven by `RouterHook` since the graph is where the rows are named;
* a served table leaves the resident dense set exactly as an oversized one does: not read, not rebound, not warmed, and outside the residency sensor;
* `--cache-mb auto` no longer reserves the size of a row-streamed table for a conversion that will not happen, so the cache gets the RAM the policy freed;
* applies under **every** `--dense-weights` mode, because what it changes is not how a mode works but which tensors it applies to;
* no llama.cpp change, no submodule bump, public eval callback only;
* app switch **Stream row-gathered tables**, app 0.23.0 / versionCode 38, docs in `docs/row-gathered-tables.md`, CSV summary keys `row_*` in `docs/telemetry.md`.

## Still owed

A long in-app run on the 12 GB phone to see whether the freed RAM removes the zram reclaim spike, which is the result this feature is actually for and which a 24 token adb run cannot show.
