### PR TITLE
ci: build the macOS host target on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,29 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBMOE_BUILD_TESTS=OFF
           cmake --build build --config Release -j
 
+  host-macos:
+    # Compile-check the Apple path on PRs; release-host was previously
+    # the only workflow that built __APPLE__ code.
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      # Keep this in sync with the macos-arm64 release-host configuration.
+      - name: Configure & build (compile-check the Apple I/O paths)
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBMOE_BUILD_TESTS=OFF \
+            -DGGML_NATIVE=OFF \
+            -DGGML_OPENMP=OFF \
+            -DLLAMA_CURL=OFF
+          cmake --build build --config Release -j --target bmoe-cli
+      - name: Smoke
+        run: build/cli/bmoe-cli --version
+
   # Cross-compiles the arm64 engine (the native compile gate) and packages the example
   # APK around it, uploading the APK as an artifact — and attaching it to the release on a
   # tag push. Debug-signed: for on-device validation, not Play distribution.


### PR DESCRIPTION
Follow-up to #182.

The Apple platform path was previously compiled only by the host-release workflow, so ordinary pull requests could merge without compiling `__APPLE__` code.

This adds a build-only `macos-14` CI job using the same host build configuration as the release path, so Apple-specific compile regressions are caught before merge rather than at release time.

No runtime behavior or release packaging changes.
