### PR TITLE
fix(app): a sharded catalog entry is on-device only when every shard is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Build debug APK (dev flavor — sideloaded, all-files access)
         working-directory: examples/android
         run: ./gradlew assembleDevDebug --no-daemon
+      - name: App unit tests
+        working-directory: examples/android
+        run: ./gradlew testDevDebugUnitTest --no-daemon
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ Semantic Versioning.
   of from the requested configuration, so a run served buffered says `0` on every platform. Host
   measurements in the PR (#179).
 
+### Fixed
+- A sharded catalog entry (DeepSeek V4 Flash, Qwen3.8-Flash-Next) read as on-device as soon as its
+  first shard landed, which is the smallest file of the set and arrives seconds into the download:
+  the row lost its progress bar, a Run on the incomplete set failed at load, and if the download
+  chain died there was no Download button left to resume it. The legacy-merged-file rule, meant for
+  a single-file gpt-oss from an earlier release, now applies only when the entry's file name is not
+  one of its shards. The app module gains its first JVM unit test for the rule, run in CI.
+
 ## [0.23.0] - 2026-08-29
 
 ### Fixed

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -28,6 +28,9 @@ research harness and keeps the app a thin driver over the CLI.
    adb install app/build/outputs/apk/dev/debug/app-dev-debug.apk
    ```
 
+   The app's pure-Kotlin rules (catalog status and the like) have JVM unit tests under
+   `app/src/test`; CI runs them, and so does `./gradlew testDevDebugUnitTest`.
+
    Published sideload builds are signed with a stable key instead, so an update installs over
    the previous one rather than being refused. That needs a `keystore.properties` next to `app/`
    (gitignored — it points at the keystore and holds its passwords); without it, builds fall back

--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -128,6 +128,9 @@ dependencies {
     // resumes multi-GB transfers (see DownloadWorker). Brings kotlinx-coroutines-android too.
     implementation 'androidx.work:work-runtime-ktx:2.9.1'
 
+    // Pure-Kotlin rules (catalog status, ...) get JVM unit tests: ./gradlew testDevDebugUnitTest
+    testImplementation 'junit:junit:4.13.2'
+
     def composeBom = platform('androidx.compose:compose-bom:2024.09.02')
     implementation composeBom
     implementation 'androidx.compose.ui:ui'

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -207,7 +207,11 @@ object ModelCatalog {
         // still in flight makes the whole entry DOWNLOADING: the set is downloaded sequentially,
         // so exactly one transfers at a time but the entry is one unit of progress to the user.
         e.shards.isNotEmpty() -> when {
-            e.fileName in present || e.shards.all { it.fileName in present } -> Status.ON_DEVICE
+            // The legacy-name branch must not fire when fileName IS the first shard: that file
+            // lands in seconds and would mark the whole set on-device while shards 2..N are still
+            // in flight (Run on an incomplete set, and no Download button left to resume it).
+            (e.fileName in present && e.shards.none { it.fileName == e.fileName }) ||
+                e.shards.all { it.fileName in present } -> Status.ON_DEVICE
             e.shards.any { it.fileName in downloading } -> Status.DOWNLOADING
             else -> Status.AVAILABLE
         }

--- a/examples/android/app/src/test/java/io/bigmoeonedge/example/ModelCatalogStatusTest.kt
+++ b/examples/android/app/src/test/java/io/bigmoeonedge/example/ModelCatalogStatusTest.kt
@@ -1,0 +1,55 @@
+package io.bigmoeonedge.example
+
+import io.bigmoeonedge.example.ModelCatalog.Entry
+import io.bigmoeonedge.example.ModelCatalog.Shard
+import io.bigmoeonedge.example.ModelCatalog.Status
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The on-device rule for sharded catalog entries. A set is on-device only when every shard is; the
+ * first shard alone (the file the engine opens, and the entry's fileName) is not enough, because it
+ * is the smallest and lands seconds into a multi-hour download.
+ */
+class ModelCatalogStatusTest {
+    private val shards = listOf(
+        Shard("m-00001-of-00003.gguf", "https://example.invalid/1", 1L),
+        Shard("m-00002-of-00003.gguf", "https://example.invalid/2", 2L),
+        Shard("m-00003-of-00003.gguf", "https://example.invalid/3", 3L),
+    )
+
+    /** fileName is the first shard, the shape every sharded entry has since gpt-oss. */
+    private val split = Entry(
+        title = "m", quant = "q", fileName = shards[0].fileName, approxBytes = 6L, url = null,
+        blurb = "", shards = shards,
+    )
+
+    /** fileName is a legacy merged file that is not one of the shards (gpt-oss). */
+    private val legacy = split.copy(fileName = "m.gguf")
+
+    @Test
+    fun firstShardAloneIsNotOnDevice() {
+        assertEquals(Status.AVAILABLE, ModelCatalog.statusOf(split, setOf(shards[0].fileName), emptySet()))
+    }
+
+    @Test
+    fun firstShardWithTheRestInFlightIsDownloading() {
+        val status = ModelCatalog.statusOf(split, setOf(shards[0].fileName), setOf(shards[1].fileName))
+        assertEquals(Status.DOWNLOADING, status)
+    }
+
+    @Test
+    fun everyShardPresentIsOnDevice() {
+        assertEquals(Status.ON_DEVICE, ModelCatalog.statusOf(split, shards.map { it.fileName }.toSet(), emptySet()))
+    }
+
+    @Test
+    fun legacyMergedFileIsOnDevice() {
+        assertEquals(Status.ON_DEVICE, ModelCatalog.statusOf(legacy, setOf("m.gguf"), emptySet()))
+    }
+
+    @Test
+    fun legacyEntryWithOnlyTheFirstShardIsNotOnDevice() {
+        assertEquals(Status.AVAILABLE, ModelCatalog.statusOf(legacy, setOf(shards[0].fileName), emptySet()))
+    }
+}


### PR DESCRIPTION
## What

`ModelCatalog.statusOf` marked a sharded entry as on-device as soon as its **first** shard was present. The rule exists for a legacy single-file gpt-oss (merged on a PC by an earlier release), but it also fired for every entry whose `fileName` is its own first shard, which is the shape DeepSeek V4 Flash and Qwen3.8-Flash-Next have.

That shard is the smallest of the set (5-10 MB) and lands seconds into a multi-hour download, so:

- the row lost its progress bar for the rest of the download;
- a Run on the incomplete set failed at load (the engine opens the first shard and looks for its siblings);
- if the download chain died, there was no Download button left to resume it: the only way out was Delete and re-download tens of GB.

## Fix

The legacy-merged-file branch now applies only when the entry's `fileName` is not one of its shards. Two lines in `statusOf`.

## Test

The app module gets its first JVM unit test (`ModelCatalogStatusTest`, JUnit 4), five cases over the rule: first shard alone is not on-device, first shard with the rest in flight is downloading, all shards present is on-device, the legacy merged file is on-device, and a legacy entry with only the first shard is not. Two of the five fail on the old rule. CI runs `testDevDebugUnitTest` after the debug APK build.

## Docs

`CHANGELOG.md` (0.24.0, Fixed), `examples/android/README.md` (the test command).
