### PR TITLE
feat(app): Qwen3.8-Flash-Next Q2_K in the catalog, the low-dense build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ Semantic Versioning.
 - **"Prefer cached experts" in the app**, under Speed / quality → Experimental, as a percentage of
   the score range (10 to 30, default off, disabled with the cache off), with a warning from 20 % up.
   Listed under the app's Experimental group.
+- **Qwen3.8-Flash-Next Q2_K in the app catalog**, next to the UD-IQ3_XXS. Its dense side is at
+  2-4 bit: 2.4 GB pinned instead of 4.3, on a phone where that set is walked every token and is what
+  caps the expert cache. A plain `llama-quantize` build without an importance matrix, so the experts
+  are coarser than the UD file's; the row says so. Six shards, ~80 GB, downloaded and resumed like
+  the other sharded entries. Every published dynamic quant of this model keeps the dense side at
+  5-8 bit whatever its overall size; this is the one file that does not.
 
 ### Changed
 - The CSV summary trailer gains `row_table_MiB`, `row_resident_MiB`, `row_rows`, `row_reads`,

--- a/docs/community-benchmarks.md
+++ b/docs/community-benchmarks.md
@@ -119,6 +119,7 @@ the table is for. What the app catalog ships:
 | gpt-oss-120b | Q4_K_M | 62.8 GB | [unsloth/gpt-oss-120b-GGUF](https://huggingface.co/unsloth/gpt-oss-120b-GGUF) | add `--no-think`; pass the first shard |
 | DeepSeek V4 Flash 0731 | UD-IQ2_M | 90.9 GB | [unsloth/DeepSeek-V4-Flash-0731-GGUF](https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF) | pass the first shard |
 | Qwen3.8-Flash-Next | UD-IQ3_XXS | 82.0 GB | [unsloth/Qwen3.8-Flash-Next-GGUF](https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF) | needs engine 0.22.0+; pass the first shard |
+| Qwen3.8-Flash-Next | Q2_K | 80.4 GB | [DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF](https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF) | dense side at 2-4 bit (2.4 GB pinned); no imatrix; pass the first shard |
 
 ### What makes a row comparable
 

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -111,13 +111,21 @@ the first one:
 adb push DeepSeek-V4-Flash-0731-UD-IQ2_M-0000*-of-00003.gguf /data/local/tmp/bmoe/
 ```
 
-Mind the space: DeepSeek V4 Flash UD-IQ2_M is ~91 GB on disk, Qwen3.8-Flash-Next UD-IQ3_XXS ~82 GB.
+Mind the space: DeepSeek V4 Flash UD-IQ2_M is ~91 GB on disk, Qwen3.8-Flash-Next UD-IQ3_XXS ~82 GB
+and its Q2_K build ~80 GB.
 
 Qwen3.8-Flash-Next needs **Dense weights = Pinned (dma-buf)** in Settings. Its dense side is 4.3 GB
 and every token walks it: with Anon the kernel swaps it to zram and single tokens stall for 10-20 s,
 with Mmap it is refaulted from flash every token. Its 51B n-gram table is held back automatically and
 stays mmap'd whatever the setting; the engine says so on stderr at load. Keep the expert cache at
 1000-1500 MiB on a 12 GB phone: the pinned dense set leaves no room for more.
+
+The catalog also offers a **Q2_K build of Qwen3.8-Flash-Next** (DevQuasar) whose dense side is at
+2-4 bit: 2.4 GB pinned instead of 4.3, which is ~2 GB the expert cache can have back. It is a plain
+`llama-quantize` build without an importance matrix, so its experts are coarser than the UD-IQ3_XXS
+ones; pick it when the cache, not expert precision, is what limits the phone. Every published dynamic
+quant of this model keeps the dense side at 5-8 bit whatever its overall size, which is why the two
+builds sit side by side.
 
 **Stream row-gathered tables** takes ~500 MiB more off that pinned set on this model, and 515 MiB
 on Qwen3.6: the token embedding table is read one row per token, so it does not need to be in

--- a/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
+++ b/examples/android/app/src/main/java/io/bigmoeonedge/example/ModelCatalog.kt
@@ -184,6 +184,57 @@ object ModelCatalog {
                 ),
             ),
         ),
+        Entry(
+            title = "Qwen3.8-Flash-Next",
+            quant = "Q2_K",
+            fileName = "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00001-of-00006.gguf",
+            approxBytes = 80_447_449_856L,
+            url = null,
+            // The same model with the DENSE side at 2-4 bit: 2.4 GB pinned instead of the UD file's
+            // 4.3 GB, on a phone where that set is walked every token and is what caps the expert
+            // cache. A plain llama-quantize build (no importance matrix), so its experts are coarser
+            // than the UD-IQ3_XXS ones; the trade is RAM for the cache against expert quality. The
+            // published dynamic quants all keep the dense side at 5-8 bit, whatever their size.
+            blurb = "Same model, dense side at 2-4 bit: 2.4 GB pinned instead of 4.3. ~80 GB on disk.",
+            shards = listOf(
+                Shard(
+                    "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00001-of-00006.gguf",
+                    "https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF/resolve/main/Q2_K/" +
+                        "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00001-of-00006.gguf?download=true",
+                    535_376_896L,
+                ),
+                Shard(
+                    "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00002-of-00006.gguf",
+                    "https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF/resolve/main/Q2_K/" +
+                        "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00002-of-00006.gguf?download=true",
+                    28_800_138_432L,
+                ),
+                Shard(
+                    "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00003-of-00006.gguf",
+                    "https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF/resolve/main/Q2_K/" +
+                        "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00003-of-00006.gguf?download=true",
+                    13_998_686_336L,
+                ),
+                Shard(
+                    "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00004-of-00006.gguf",
+                    "https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF/resolve/main/Q2_K/" +
+                        "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00004-of-00006.gguf?download=true",
+                    13_809_369_312L,
+                ),
+                Shard(
+                    "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00005-of-00006.gguf",
+                    "https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF/resolve/main/Q2_K/" +
+                        "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00005-of-00006.gguf?download=true",
+                    13_782_644_992L,
+                ),
+                Shard(
+                    "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00006-of-00006.gguf",
+                    "https://huggingface.co/DevQuasar/Qwen.Qwen3.8-Flash-Next-GGUF/resolve/main/Q2_K/" +
+                        "Qwen.Qwen3.8-Flash-Next.f16.gguf.Q2_K.gguf-00006-of-00006.gguf?download=true",
+                    9_521_233_888L,
+                ),
+            ),
+        ),
     )
 
     /**


### PR DESCRIPTION
## What

A second Qwen3.8-Flash-Next entry in the app catalog: DevQuasar's plain **Q2_K** (6 shards, 80.4 GB), next to the UD-IQ3_XXS.

## Why

On a 12 GB phone this model is capped by its dense side, not by flash: 4.3 GB pinned and walked every token in the UD-IQ3_XXS, which leaves the expert cache 1000-1500 MiB. Reading the tensor headers of every published quant (Unsloth UD-IQ1_S through UD-Q6_K_XL, AtomicChat, Baekpica, DevQuasar): the dynamic quants keep the dense side at Q5_K/Q6_K/Q8_0 with an F32 router whatever their overall size (UD-IQ1_S still carries 3.6 GB of dense), and the imatrix builds put it at Q8_0. DevQuasar's plain `llama-quantize` Q2_K is the one file with the dense side at 2-4 bit: 2.4 GB pinned (attn_qkv Q4_K, attention gates and SSM output Q2_K, router F32, output Q6_K), at the price of coarser experts with no importance matrix.

Lowering the resident dense precision was first measured on Qwen3.6-35B-A3B on the desktop host: requantizing the dense tensors from Q6_K/Q8_0 to Q4_K with the experts copied untouched took 386 MiB off the resident set for +0.6 % teacher-forced perplexity across five texts (two of them improved), i.e. noise. This entry lets a phone run the same trade on the model where the dense side is 2.5x larger. It downloaded and loaded in-app on the 12 GB test phone.

## Docs

`CHANGELOG.md` (0.24.0, Added), `examples/android/README.md` (sharded models section), `docs/community-benchmarks.md` (catalog table).

## Notes

Built on top of the catalog's existing shard support; no engine change. Independent of #188, but that fix is what makes a sharded download resumable if it stops, so both belong in the same release.
