### PR TITLE
fix(scripts): bench-report model size and storage probe (du on the raw path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,14 @@ Semantic Versioning.
   chain died there was no Download button left to resume it. The legacy-merged-file rule, meant for
   a single-file gpt-oss from an earlier release, now applies only when the entry's file name is not
   one of its shards. The app module gains its first JVM unit test for the rule, run in CI.
+- `bench-report.sh` measured the model with `du` on the path as given, so a Hugging Face cache
+  symlink reported 0.0 GiB and a split model counted only the shard on the command line; sizes now
+  dereference (`stat -L`) and sum every sibling shard. The same raw-path size fed the storage
+  probe's offset, and the probe trusted `dd`'s exit code while assuming a full 1 GiB was read: on
+  a short read, or a filesystem that takes `iflag=direct` without honouring it, that printed rates
+  no drive can do (110 GiB/s in the first community report, #192). The rate now comes from the
+  byte count in `dd`'s own summary, and a physically impossible result prints `n/a` with a note
+  instead of a number. (#193)
 
 ## [0.23.0] - 2026-08-29
 

--- a/docs/community-benchmarks.md
+++ b/docs/community-benchmarks.md
@@ -150,6 +150,9 @@ On a phone, the app's telemetry panel and the CSV from `scripts/bench-run.sh` ca
 - If the storage probe reads far below the drive's rating, say so. That is a result in itself.
 - The first run after a download has the file's head in the page cache. The probe skips a quarter
   into the file for exactly that reason; the engine run uses O_DIRECT and is unaffected.
+- A storage column reading `n/a` means the probe refused its own number: the filesystem accepted
+  `iflag=direct` but served the page cache anyway (network and overlay filesystems do this), so
+  the measured rate was not a physical read. The engine columns are still valid.
 
 ## Results
 

--- a/scripts/bench-report.sh
+++ b/scripts/bench-report.sh
@@ -69,19 +69,49 @@ else
     [ -n "$DRIVE_MODEL" ] || DRIVE_MODEL="$BLOCK"
     DD_FLAGS="iflag=direct"
 fi
-MODEL_GIB="$(du -k "$MODEL" | awk '{printf "%.1f", $1/1024/1024}')"
+# Sizes must dereference: a Hugging Face cache path is a symlink into blobs/, and `du` on the
+# link itself measures the link (0), not the file. `stat -L` follows it on both GNU and BSD.
+fsize() { stat -Lc %s "$1" 2>/dev/null || stat -Lf %z "$1" 2>/dev/null || echo 0; }
+MODEL_BYTES="$(fsize "$MODEL")"
+
+# A split model is one model: report the sum of every sibling shard, not just the shard that was
+# passed on the command line (llama.cpp finds the others from it the same way).
+TOTAL_BYTES="$MODEL_BYTES"
+BASE="$(basename "$MODEL")"
+if echo "$BASE" | grep -qE -- '-[0-9]+-of-[0-9]+\.gguf$'; then
+    SHARD_GLOB="$(echo "$BASE" | sed -E 's/-[0-9]+-of-([0-9]+)\.gguf$/-*-of-\1.gguf/')"
+    TOTAL_BYTES=0
+    for SHARD in "$(dirname "$MODEL")/"$SHARD_GLOB; do
+        TOTAL_BYTES=$(( TOTAL_BYTES + $(fsize "$SHARD") ))
+    done
+fi
+MODEL_GIB="$(awk -v b="$TOTAL_BYTES" 'BEGIN { printf "%.1f", b/1024/1024/1024 }')"
 
 # Read 1 GiB of the model itself at 512 KiB, bypassing the page cache, from a random-ish offset
 # (one quarter in) so a freshly downloaded file's cached head does not flatter the number.
+# The rate comes from the byte count in dd's own summary, never the nominal 1 GiB: dd exits 0
+# on a short read (EOF before count), and a filesystem can accept iflag=direct yet serve the
+# page cache anyway — that case shows up as a rate no single drive can do, and prints n/a.
 probe_read_rate() {
-    local skip=$(( $(du -k "$MODEL" | cut -f1) / 4 / 512 ))
-    local t0 t1
+    local skip=$(( MODEL_BYTES / 4 / 524288 ))
+    local t0 t1 bytes
     t0="$(date +%s.%N)"
-    dd if="$MODEL" of=/dev/null bs=512k count=2048 skip="$skip" $DD_FLAGS 2>/dev/null || return 1
+    bytes="$(dd if="$MODEL" of=/dev/null bs=512k count=2048 skip="$skip" $DD_FLAGS 2>&1 |
+        sed -n 's/^\([0-9][0-9]*\) bytes.*/\1/p' | head -1 || true)"
     t1="$(date +%s.%N)"
-    awk -v a="$t0" -v b="$t1" 'BEGIN { d=b-a; if (d>0) printf "%.0f", 1024/d; else print "n/a" }'
+    awk -v a="$t0" -v b="$t1" -v n="${bytes:-0}" 'BEGIN {
+        d = b - a
+        if (d <= 0 || n <= 0) { print "n/a"; exit }
+        r = n / 1048576 / d
+        if (r > 30720) {
+            print "storage probe: " int(r) " MiB/s is not a physical read rate; O_DIRECT was likely ignored, reporting n/a" > "/dev/stderr"
+            print "n/a"; exit
+        }
+        printf "%.0f", r
+    }'
 }
-READ_MIBS="$(probe_read_rate || echo n/a)"
+READ_MIBS="$(probe_read_rate || true)"
+[ -n "$READ_MIBS" ] || READ_MIBS="n/a"
 
 # --- 3. run ---------------------------------------------------------------------------------
 mkdir -p "$BENCH_OUT"


### PR DESCRIPTION
Fixes the two `du`-based bugs in `scripts/bench-report.sh` surfaced by the first community report (#192).

**Model size.** `du` on the path as given measured a Hugging Face cache symlink as the link (0.0 GiB) and a split model as only the shard on the command line. Sizes now come from `stat -L` (dereferenced, GNU and BSD forms) and sum every sibling `-of-` shard.

**Storage probe.** The probe took its quarter-in offset from the same raw-path size (so a symlink meant `skip=0`, reading the freshly cached head), and computed the rate from wall time assuming a full 1 GiB was read. `dd` exits 0 on a short read, and a filesystem can accept `iflag=direct` without honouring it, which is how #192 printed 110 GiB/s from a single NVMe drive. The rate is now computed from the byte count in `dd`'s own summary (both GNU and BSD formats), and a result above any physical single-drive rate prints `n/a` with a note on stderr instead of a number. `dd` failures no longer kill the script under `set -euo pipefail`.

Tested against the extracted block with GNU coreutils: an HF-style symlink, a 3-shard set (sum exact), a short read (rate from actual bytes), and #192's own numbers through the sanity bound (prints the note and `n/a`).

Changelog entry under 0.24.0 and a line in `docs/community-benchmarks.md` explaining what an `n/a` storage column means.

Closes #193
